### PR TITLE
Features/48 maintenance activities

### DIFF
--- a/Database/LookupTables/dbo.FieldDefinition.sql
+++ b/Database/LookupTables/dbo.FieldDefinition.sql
@@ -42,4 +42,6 @@ VALUES
 (37, N'DefaultBenchmarkValue', N'Default Benchmark Value', '', 1),
 (38, N'AssessmentFailsIfObservationFails', N'Assessment Fails if Observation Fails', '', 1),
 (39, N'TreatmentBMPAttributeType', N'Treatment BMP Attribute Type', '', 1),
-(40, N'TreatmentBMPAttributeDataType', N'Data Type', '', 1)
+(40, N'TreatmentBMPAttributeDataType', N'Data Type', '', 1),
+(41, N'MaintenanceActivityType', N'Maintenance Activity Type', 'Whether the maintenance performed was Preventative or Corrective maintenance', 1),
+(42, N'MaintenanceActivity', N'Maintenance Activity', 'A maintenance activity performed on a Treatment BMP', 1)

--- a/Database/LookupTables/dbo.MaintenanceActivityType.sql
+++ b/Database/LookupTables/dbo.MaintenanceActivityType.sql
@@ -1,0 +1,6 @@
+delete from dbo.MaintenanceActivityType
+
+insert into dbo.MaintenanceActivityType(MaintenanceActivityTypeID, MaintenanceActivityTypeName, MaintenanceActivityTypeDisplayName)
+values
+(1, 'Preventative','Preventative'),
+(2, 'Corrective','Corrective')

--- a/Database/ReleaseScript/017 - Added MaintenanceActivity and MaintenanceActivityType.sql
+++ b/Database/ReleaseScript/017 - Added MaintenanceActivity and MaintenanceActivityType.sql
@@ -1,0 +1,19 @@
+create table dbo.MaintenanceActivityType(
+MaintenanceActivityTypeID int not null constraint PK_MaintenanceActivityType_MaintenanceActivityTypeID primary key,
+MaintenanceActivityTypeName varchar(30) not null constraint AK_MaintenanceActivityType_MaintenanceActivityTypeName unique,
+MaintenanceActivityTypeDisplayName varchar(30) not null constraint AK_MaintenanceActivityType_MaintenanceActivityTypeDisplayName unique
+)
+go
+
+create table dbo.MaintenanceActivity(
+MaintenanceActivityID int not null identity(1,1) constraint PK_MaintenanceActivity_MaintenanceActivityID primary key,
+TenantID int not null constraint FK_MaintenanceActivity_Tenant_TenantID foreign key references dbo.Tenant(TenantID),
+TreatmentBMPID int not null constraint FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID foreign key references dbo.TreatmentBMP(TreatmentBMPID),
+MaintenanceActivityDate date not null,
+PerformedByPersonID int not null constraint FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID foreign key references dbo.Person(PersonID),
+MaintenanceActivityDescription varchar(500) null,
+MaintenanceActivityTypeID int not null constraint FK_MaintenanceActivity_MaintenanceActivityType_MaintenanceActivityTypeID foreign key references dbo.MaintenanceActivityType(MaintenanceActivityTypeID),
+constraint AK_MaintenanceActivity_MaintenanceActivityID_TenantID unique nonclustered (MaintenanceActivityID, TenantID),
+constraint FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID_TenantID foreign key (TreatmentBMPID, TenantID) references dbo.TreatmentBMP(TreatmentBMPID, TenantID)
+)
+go

--- a/Database/ReleaseScript/017 - Added MaintenanceActivity and MaintenanceActivityType.sql
+++ b/Database/ReleaseScript/017 - Added MaintenanceActivity and MaintenanceActivityType.sql
@@ -17,3 +17,7 @@ constraint AK_MaintenanceActivity_MaintenanceActivityID_TenantID unique nonclust
 constraint FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID_TenantID foreign key (TreatmentBMPID, TenantID) references dbo.TreatmentBMP(TreatmentBMPID, TenantID)
 )
 go
+
+insert into dbo.FieldDefinition(FieldDefinitionID, FieldDefinitionName, FieldDefinitionDisplayName, DefaultDefinition, CanCustomizeLabel)
+values (41, N'MaintenanceActivityType', N'Maintenance Activity Type', 'Whether the maintenance performed was Preventative or Corrective maintenance', 1),
+(42, N'MaintenanceActivity', N'Maintenance Activity', 'A maintenance activity performed on a Treatment BMP', 1)

--- a/Database/Tables/dbo.MaintenanceActivity.sql
+++ b/Database/Tables/dbo.MaintenanceActivity.sql
@@ -1,0 +1,48 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[MaintenanceActivity](
+	[MaintenanceActivityID] [int] IDENTITY(1,1) NOT NULL,
+	[TenantID] [int] NOT NULL,
+	[TreatmentBMPID] [int] NOT NULL,
+	[MaintenanceActivityDate] [date] NOT NULL,
+	[PerformedByPersonID] [int] NOT NULL,
+	[MaintenanceActivityDescription] [varchar](500) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[MaintenanceActivityTypeID] [int] NOT NULL,
+ CONSTRAINT [PK_MaintenanceActivity_MaintenanceActivityID] PRIMARY KEY CLUSTERED 
+(
+	[MaintenanceActivityID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [AK_MaintenanceActivity_MaintenanceActivityID_TenantID] UNIQUE NONCLUSTERED 
+(
+	[MaintenanceActivityID] ASC,
+	[TenantID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+
+GO
+ALTER TABLE [dbo].[MaintenanceActivity]  WITH CHECK ADD  CONSTRAINT [FK_MaintenanceActivity_MaintenanceActivityType_MaintenanceActivityTypeID] FOREIGN KEY([MaintenanceActivityTypeID])
+REFERENCES [dbo].[MaintenanceActivityType] ([MaintenanceActivityTypeID])
+GO
+ALTER TABLE [dbo].[MaintenanceActivity] CHECK CONSTRAINT [FK_MaintenanceActivity_MaintenanceActivityType_MaintenanceActivityTypeID]
+GO
+ALTER TABLE [dbo].[MaintenanceActivity]  WITH CHECK ADD  CONSTRAINT [FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID] FOREIGN KEY([PerformedByPersonID])
+REFERENCES [dbo].[Person] ([PersonID])
+GO
+ALTER TABLE [dbo].[MaintenanceActivity] CHECK CONSTRAINT [FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID]
+GO
+ALTER TABLE [dbo].[MaintenanceActivity]  WITH CHECK ADD  CONSTRAINT [FK_MaintenanceActivity_Tenant_TenantID] FOREIGN KEY([TenantID])
+REFERENCES [dbo].[Tenant] ([TenantID])
+GO
+ALTER TABLE [dbo].[MaintenanceActivity] CHECK CONSTRAINT [FK_MaintenanceActivity_Tenant_TenantID]
+GO
+ALTER TABLE [dbo].[MaintenanceActivity]  WITH CHECK ADD  CONSTRAINT [FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID] FOREIGN KEY([TreatmentBMPID])
+REFERENCES [dbo].[TreatmentBMP] ([TreatmentBMPID])
+GO
+ALTER TABLE [dbo].[MaintenanceActivity] CHECK CONSTRAINT [FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID]
+GO
+ALTER TABLE [dbo].[MaintenanceActivity]  WITH CHECK ADD  CONSTRAINT [FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID_TenantID] FOREIGN KEY([TreatmentBMPID], [TenantID])
+REFERENCES [dbo].[TreatmentBMP] ([TreatmentBMPID], [TenantID])
+GO
+ALTER TABLE [dbo].[MaintenanceActivity] CHECK CONSTRAINT [FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID_TenantID]

--- a/Database/Tables/dbo.MaintenanceActivityType.sql
+++ b/Database/Tables/dbo.MaintenanceActivityType.sql
@@ -1,0 +1,21 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[MaintenanceActivityType](
+	[MaintenanceActivityTypeID] [int] NOT NULL,
+	[MaintenanceActivityTypeName] [varchar](30) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
+	[MaintenanceActivityTypeDisplayName] [varchar](30) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
+ CONSTRAINT [PK_MaintenanceActivityType_MaintenanceActivityTypeID] PRIMARY KEY CLUSTERED 
+(
+	[MaintenanceActivityTypeID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [AK_MaintenanceActivityType_MaintenanceActivityTypeDisplayName] UNIQUE NONCLUSTERED 
+(
+	[MaintenanceActivityTypeDisplayName] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY],
+ CONSTRAINT [AK_MaintenanceActivityType_MaintenanceActivityTypeName] UNIQUE NONCLUSTERED 
+(
+	[MaintenanceActivityTypeName] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]

--- a/Source/Neptune.Web/Controllers/EditMaintenanceActivity.cs
+++ b/Source/Neptune.Web/Controllers/EditMaintenanceActivity.cs
@@ -1,0 +1,9 @@
+using LtInfo.Common.Mvc;
+
+namespace Neptune.Web.Views.MaintenanceActivity
+{
+    public abstract class EditMaintenanceActivity : TypedWebPartialViewPage<EditMaintenanceActivityViewData,
+        EditMaintenanceActivityViewModel>
+    {
+    }
+}

--- a/Source/Neptune.Web/Controllers/MaintenanceActivityController.cs
+++ b/Source/Neptune.Web/Controllers/MaintenanceActivityController.cs
@@ -1,24 +1,68 @@
 using System.Linq;
 using System.Web.Mvc;
 using LtInfo.Common.MvcResults;
-using Neptune.Web.Common;
 using Neptune.Web.Models;
 using Neptune.Web.Security;
-using MaintenanceActivityGridSpec = Neptune.Web.Views.MaintenanceActivity.MaintenanceActivityGridSpec;
+using Neptune.Web.Views.MaintenanceActivity;
 
 namespace Neptune.Web.Controllers
 {
     public class MaintenanceActivityController : NeptuneBaseController
     {
-        
-        [NeptuneViewFeature]
-        public GridJsonNetJObjectResult<MaintenanceActivity> MaintenanceActivitysGridJsonData()
+        [TreatmentBMPManageFeature]
+        public GridJsonNetJObjectResult<MaintenanceActivity> MaintenanceActivitysGridJsonData(
+            TreatmentBMPPrimaryKey treatmentBmpPrimaryKey)
         {
-            var gridSpec = new MaintenanceActivityGridSpec(CurrentPerson);
-            var bmpMaintenanceActivitys = HttpRequestStorage.DatabaseEntities.MaintenanceActivitys.ToList().Where(x => x.IsPublicRegularMaintenanceActivity()).OrderByDescending(x => x.MaintenanceActivityDate).ToList();
-            var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<MaintenanceActivity>(bmpMaintenanceActivitys, gridSpec);
+            var treatmentBmp = treatmentBmpPrimaryKey.EntityObject;
+            var gridSpec = new MaintenanceActivityGridSpec(CurrentPerson, treatmentBmp);
+            var bmpMaintenanceActivitys = treatmentBmp.MaintenanceActivities.ToList()
+                .OrderByDescending(x => x.MaintenanceActivityDate).ToList();
+            var gridJsonNetJObjectResult =
+                new GridJsonNetJObjectResult<MaintenanceActivity>(bmpMaintenanceActivitys, gridSpec);
             return gridJsonNetJObjectResult;
         }
-        
+
+        [HttpGet]
+        [TreatmentBMPManageFeature]
+        public PartialViewResult New(TreatmentBMPPrimaryKey treatmentBmpPrimaryKey)
+        {
+            return ViewNew(new EditMaintenanceActivityViewModel());
+        }
+
+        //todo : possibly an unnecessary abstraction
+        private PartialViewResult ViewNew(EditMaintenanceActivityViewModel viewModel)
+        {
+            return ViewEdit(viewModel);
+        }
+
+        [HttpGet]
+        [TreatmentBMPManageFeature]
+        public PartialViewResult Edit(MaintenanceActivityPrimaryKey maintenanceActivityPrimaryKey)
+        {
+            var maintenanceActivity = maintenanceActivityPrimaryKey.EntityObject;
+            var viewModel = new EditMaintenanceActivityViewModel(maintenanceActivity);
+            return ViewEdit(viewModel);
+        }
+
+        [HttpPost]
+        [TreatmentBMPManageFeature]
+        public ActionResult Edit(MaintenanceActivityPrimaryKey maintenanceActivityPrimaryKey,
+            EditMaintenanceActivityViewModel viewModel)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        private PartialViewResult ViewEdit(EditMaintenanceActivityViewModel viewModel)
+        {
+            var viewData = new EditMaintenanceActivityViewData();
+            return RazorPartialView<EditMaintenanceActivity, EditMaintenanceActivityViewData,
+                EditMaintenanceActivityViewModel>(viewData, viewModel);
+        }
+
+        [TreatmentBMPManageFeature]
+        public ActionResult Delete(MaintenanceActivityPrimaryKey maintenanceActivityPrimaryKey)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/Source/Neptune.Web/Controllers/MaintenanceActivityController.cs
+++ b/Source/Neptune.Web/Controllers/MaintenanceActivityController.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using System.Web.Mvc;
+using LtInfo.Common.MvcResults;
+using Neptune.Web.Common;
+using Neptune.Web.Models;
+using Neptune.Web.Security;
+using MaintenanceActivityGridSpec = Neptune.Web.Views.MaintenanceActivity.MaintenanceActivityGridSpec;
+
+namespace Neptune.Web.Controllers
+{
+    public class MaintenanceActivityController : NeptuneBaseController
+    {
+        
+        [NeptuneViewFeature]
+        public GridJsonNetJObjectResult<MaintenanceActivity> MaintenanceActivitysGridJsonData()
+        {
+            var gridSpec = new MaintenanceActivityGridSpec(CurrentPerson);
+            var bmpMaintenanceActivitys = HttpRequestStorage.DatabaseEntities.MaintenanceActivitys.ToList().Where(x => x.IsPublicRegularMaintenanceActivity()).OrderByDescending(x => x.MaintenanceActivityDate).ToList();
+            var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<MaintenanceActivity>(bmpMaintenanceActivitys, gridSpec);
+            return gridJsonNetJObjectResult;
+        }
+        
+    }
+}

--- a/Source/Neptune.Web/DatabaseEntities.csdl
+++ b/Source/Neptune.Web/DatabaseEntities.csdl
@@ -6,6 +6,7 @@
     <EntitySet Name="FieldDefinitionData" EntityType="Neptune.Web.Models.FieldDefinitionData" />
     <EntitySet Name="FieldDefinitionDataImage" EntityType="Neptune.Web.Models.FieldDefinitionDataImage" />
     <EntitySet Name="FileResource" EntityType="Neptune.Web.Models.FileResource" />
+    <EntitySet Name="MaintenanceActivity" EntityType="Neptune.Web.Models.MaintenanceActivity" />
     <EntitySet Name="ModeledCatchment" EntityType="Neptune.Web.Models.ModeledCatchment" />
     <EntitySet Name="ModeledCatchmentGeometryStaging" EntityType="Neptune.Web.Models.ModeledCatchmentGeometryStaging" />
     <EntitySet Name="NeptuneHomePageImage" EntityType="Neptune.Web.Models.NeptuneHomePageImage" />
@@ -83,6 +84,14 @@
     <AssociationSet Name="FK_TreatmentBMPImage_FileResource_FileResourceID" Association="Neptune.Web.Models.FK_TreatmentBMPImage_FileResource_FileResourceID">
       <End Role="FileResource" EntitySet="FileResource" />
       <End Role="TreatmentBMPImages" EntitySet="TreatmentBMPImage" />
+    </AssociationSet>
+    <AssociationSet Name="FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID" Association="Neptune.Web.Models.FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID">
+      <End Role="PerformedByPerson" EntitySet="Person" />
+      <End Role="MaintenanceActivitiesWhereYouAreThePerformedByPerson" EntitySet="MaintenanceActivity" />
+    </AssociationSet>
+    <AssociationSet Name="FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID" Association="Neptune.Web.Models.FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID">
+      <End Role="TreatmentBMP" EntitySet="TreatmentBMP" />
+      <End Role="MaintenanceActivities" EntitySet="MaintenanceActivity" />
     </AssociationSet>
     <AssociationSet Name="FK_ModeledCatchment_StormwaterJurisdiction_StormwaterJurisdictionID" Association="Neptune.Web.Models.FK_ModeledCatchment_StormwaterJurisdiction_StormwaterJurisdictionID">
       <End Role="StormwaterJurisdiction" EntitySet="StormwaterJurisdiction" />
@@ -311,6 +320,20 @@
     <NavigationProperty Name="TreatmentBMPDocuments" Relationship="Neptune.Web.Models.FK_TreatmentBMPDocument_FileResource_FileResourceID" FromRole="FileResource" ToRole="TreatmentBMPDocuments" />
     <NavigationProperty Name="TreatmentBMPImages" Relationship="Neptune.Web.Models.FK_TreatmentBMPImage_FileResource_FileResourceID" FromRole="FileResource" ToRole="TreatmentBMPImages" />
   </EntityType>
+  <EntityType Name="MaintenanceActivity">
+    <Key>
+      <PropertyRef Name="MaintenanceActivityID" />
+    </Key>
+    <Property Name="MaintenanceActivityID" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
+    <Property Name="TenantID" Type="Int32" Nullable="false" />
+    <Property Name="TreatmentBMPID" Type="Int32" Nullable="false" />
+    <Property Name="MaintenanceActivityDate" Type="DateTime" Nullable="false" />
+    <Property Name="PerformedByPersonID" Type="Int32" Nullable="false" />
+    <Property Name="MaintenanceActivityDescription" Type="String" MaxLength="500" Unicode="false" FixedLength="false" />
+    <Property Name="MaintenanceActivityTypeID" Type="Int32" Nullable="false" />
+    <NavigationProperty Name="PerformedByPerson" Relationship="Neptune.Web.Models.FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID" FromRole="MaintenanceActivitiesWhereYouAreThePerformedByPerson" ToRole="PerformedByPerson" />
+    <NavigationProperty Name="TreatmentBMP" Relationship="Neptune.Web.Models.FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID" FromRole="MaintenanceActivities" ToRole="TreatmentBMP" />
+  </EntityType>
   <EntityType Name="ModeledCatchment">
     <Key>
       <PropertyRef Name="ModeledCatchmentID" />
@@ -447,6 +470,7 @@
     <Property Name="LoginName" Type="String" Nullable="false" MaxLength="128" Unicode="false" FixedLength="false" />
     <NavigationProperty Name="AuditLogs" Relationship="Neptune.Web.Models.FK_AuditLog_Person_PersonID" FromRole="Person" ToRole="AuditLogs" />
     <NavigationProperty Name="FileResourcesWhereYouAreTheCreatePerson" Relationship="Neptune.Web.Models.FK_FileResource_Person_CreatePersonID_PersonID" FromRole="CreatePerson" ToRole="FileResourcesWhereYouAreTheCreatePerson" />
+    <NavigationProperty Name="MaintenanceActivitiesWhereYouAreThePerformedByPerson" Relationship="Neptune.Web.Models.FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID" FromRole="PerformedByPerson" ToRole="MaintenanceActivitiesWhereYouAreThePerformedByPerson" />
     <NavigationProperty Name="ModeledCatchmentGeometryStagings" Relationship="Neptune.Web.Models.FK_ModeledCatchmentGeometryStaging_Person_PersonID" FromRole="Person" ToRole="ModeledCatchmentGeometryStagings" />
     <NavigationProperty Name="Notifications" Relationship="Neptune.Web.Models.FK_Notification_Person_PersonID" FromRole="Person" ToRole="Notifications" />
     <NavigationProperty Name="OrganizationsWhereYouAreThePrimaryContactPerson" Relationship="Neptune.Web.Models.FK_Organization_Person_PrimaryContactPersonID_PersonID" FromRole="PrimaryContactPerson" ToRole="OrganizationsWhereYouAreThePrimaryContactPerson" />
@@ -548,6 +572,7 @@
     <Property Name="SystemOfRecordID" Type="String" MaxLength="100" Unicode="false" FixedLength="false" />
     <Property Name="YearBuilt" Type="Int32" />
     <Property Name="OwnerOrganizationID" Type="Int32" Nullable="false" />
+    <NavigationProperty Name="MaintenanceActivities" Relationship="Neptune.Web.Models.FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID" FromRole="TreatmentBMP" ToRole="MaintenanceActivities" />
     <NavigationProperty Name="ModeledCatchment" Relationship="Neptune.Web.Models.FK_TreatmentBMP_ModeledCatchment_ModeledCatchmentID" FromRole="TreatmentBMPs" ToRole="ModeledCatchment" />
     <NavigationProperty Name="OwnerOrganization" Relationship="Neptune.Web.Models.FK_TreatmentBMP_Organization_OwnerOrganizationID_OrganizationID" FromRole="TreatmentBMPsWhereYouAreTheOwnerOrganization" ToRole="OwnerOrganization" />
     <NavigationProperty Name="StormwaterJurisdiction" Relationship="Neptune.Web.Models.FK_TreatmentBMP_StormwaterJurisdiction_StormwaterJurisdictionID" FromRole="TreatmentBMPs" ToRole="StormwaterJurisdiction" />
@@ -866,6 +891,30 @@
       </Principal>
       <Dependent Role="TreatmentBMPImages">
         <PropertyRef Name="FileResourceID" />
+      </Dependent>
+    </ReferentialConstraint>
+  </Association>
+  <Association Name="FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID">
+    <End Role="PerformedByPerson" Type="Neptune.Web.Models.Person" Multiplicity="1" />
+    <End Role="MaintenanceActivitiesWhereYouAreThePerformedByPerson" Type="Neptune.Web.Models.MaintenanceActivity" Multiplicity="*" />
+    <ReferentialConstraint>
+      <Principal Role="PerformedByPerson">
+        <PropertyRef Name="PersonID" />
+      </Principal>
+      <Dependent Role="MaintenanceActivitiesWhereYouAreThePerformedByPerson">
+        <PropertyRef Name="PerformedByPersonID" />
+      </Dependent>
+    </ReferentialConstraint>
+  </Association>
+  <Association Name="FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID">
+    <End Role="TreatmentBMP" Type="Neptune.Web.Models.TreatmentBMP" Multiplicity="1" />
+    <End Role="MaintenanceActivities" Type="Neptune.Web.Models.MaintenanceActivity" Multiplicity="*" />
+    <ReferentialConstraint>
+      <Principal Role="TreatmentBMP">
+        <PropertyRef Name="TreatmentBMPID" />
+      </Principal>
+      <Dependent Role="MaintenanceActivities">
+        <PropertyRef Name="TreatmentBMPID" />
       </Dependent>
     </ReferentialConstraint>
   </Association>

--- a/Source/Neptune.Web/DatabaseEntities.msl
+++ b/Source/Neptune.Web/DatabaseEntities.msl
@@ -65,6 +65,19 @@
         </MappingFragment>
       </EntityTypeMapping>
     </EntitySetMapping>
+    <EntitySetMapping Name="MaintenanceActivity">
+      <EntityTypeMapping TypeName="Neptune.Web.Models.MaintenanceActivity">
+        <MappingFragment StoreEntitySet="MaintenanceActivity">
+          <ScalarProperty Name="MaintenanceActivityID" ColumnName="MaintenanceActivityID" />
+          <ScalarProperty Name="TenantID" ColumnName="TenantID" />
+          <ScalarProperty Name="TreatmentBMPID" ColumnName="TreatmentBMPID" />
+          <ScalarProperty Name="MaintenanceActivityDate" ColumnName="MaintenanceActivityDate" />
+          <ScalarProperty Name="PerformedByPersonID" ColumnName="PerformedByPersonID" />
+          <ScalarProperty Name="MaintenanceActivityDescription" ColumnName="MaintenanceActivityDescription" />
+          <ScalarProperty Name="MaintenanceActivityTypeID" ColumnName="MaintenanceActivityTypeID" />
+        </MappingFragment>
+      </EntityTypeMapping>
+    </EntitySetMapping>
     <EntitySetMapping Name="ModeledCatchment">
       <EntityTypeMapping TypeName="Neptune.Web.Models.ModeledCatchment">
         <MappingFragment StoreEntitySet="ModeledCatchment">

--- a/Source/Neptune.Web/DatabaseEntities.ssdl
+++ b/Source/Neptune.Web/DatabaseEntities.ssdl
@@ -6,6 +6,7 @@
     <EntitySet Name="FieldDefinitionData" EntityType="Neptune.Web.Models.Store.FieldDefinitionData" store:Type="Tables" Schema="dbo" />
     <EntitySet Name="FieldDefinitionDataImage" EntityType="Neptune.Web.Models.Store.FieldDefinitionDataImage" store:Type="Tables" Schema="dbo" />
     <EntitySet Name="FileResource" EntityType="Neptune.Web.Models.Store.FileResource" store:Type="Tables" Schema="dbo" />
+    <EntitySet Name="MaintenanceActivity" EntityType="Neptune.Web.Models.Store.MaintenanceActivity" store:Type="Tables" Schema="dbo" />
     <EntitySet Name="ModeledCatchment" EntityType="Neptune.Web.Models.Store.ModeledCatchment" store:Type="Tables" Schema="dbo" />
     <EntitySet Name="ModeledCatchmentGeometryStaging" EntityType="Neptune.Web.Models.Store.ModeledCatchmentGeometryStaging" store:Type="Tables" Schema="dbo" />
     <EntitySet Name="NeptuneHomePageImage" EntityType="Neptune.Web.Models.Store.NeptuneHomePageImage" store:Type="Tables" Schema="dbo" />
@@ -51,6 +52,14 @@
     <AssociationSet Name="FK_FileResource_Person_CreatePersonID_PersonID" Association="Neptune.Web.Models.Store.FK_FileResource_Person_CreatePersonID_PersonID">
       <End Role="CreatePerson" EntitySet="Person" />
       <End Role="FileResourcesWhereYouAreTheCreatePerson" EntitySet="FileResource" />
+    </AssociationSet>
+    <AssociationSet Name="FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID" Association="Neptune.Web.Models.Store.FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID">
+      <End Role="PerformedByPerson" EntitySet="Person" />
+      <End Role="MaintenanceActivitiesWhereYouAreThePerformedByPerson" EntitySet="MaintenanceActivity" />
+    </AssociationSet>
+    <AssociationSet Name="FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID" Association="Neptune.Web.Models.Store.FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID">
+      <End Role="TreatmentBMP" EntitySet="TreatmentBMP" />
+      <End Role="MaintenanceActivities" EntitySet="MaintenanceActivity" />
     </AssociationSet>
     <AssociationSet Name="FK_ModeledCatchment_StormwaterJurisdiction_StormwaterJurisdictionID" Association="Neptune.Web.Models.Store.FK_ModeledCatchment_StormwaterJurisdiction_StormwaterJurisdictionID">
       <End Role="StormwaterJurisdiction" EntitySet="StormwaterJurisdiction" />
@@ -310,6 +319,18 @@ warning 6035: The relationship 'FK_TreatmentBMPImage_FileResource_FileResourceID
     <Property Name="CreatePersonID" Type="int" Nullable="false" />
     <Property Name="CreateDate" Type="datetime" Nullable="false" />
   </EntityType>
+  <EntityType Name="MaintenanceActivity">
+    <Key>
+      <PropertyRef Name="MaintenanceActivityID" />
+    </Key>
+    <Property Name="MaintenanceActivityID" Type="int" Nullable="false" StoreGeneratedPattern="Identity" />
+    <Property Name="TenantID" Type="int" Nullable="false" />
+    <Property Name="TreatmentBMPID" Type="int" Nullable="false" />
+    <Property Name="MaintenanceActivityDate" Type="date" Nullable="false" />
+    <Property Name="PerformedByPersonID" Type="int" Nullable="false" />
+    <Property Name="MaintenanceActivityDescription" Type="varchar" MaxLength="500" />
+    <Property Name="MaintenanceActivityTypeID" Type="int" Nullable="false" />
+  </EntityType>
   <!--Errors Found During Generation:
 warning 6035: The relationship 'FK_TreatmentBMP_ModeledCatchment_ModeledCatchmentID_TenantID' has columns that are not part of the key of the table on the primary side of the relationship. The relationship was excluded.
 -->
@@ -526,6 +547,7 @@ warning 6035: The relationship 'FK_TreatmentBMP_StormwaterJurisdiction_Stormwate
     <Property Name="RecaptchaPrivateKey" Type="varchar" MaxLength="100" />
   </EntityType>
   <!--Errors Found During Generation:
+warning 6035: The relationship 'FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID_TenantID' has columns that are not part of the key of the table on the primary side of the relationship. The relationship was excluded.
 warning 6035: The relationship 'FK_TreatmentBMPAssessment_TreatmentBMP_TreatmentBMPID_TenantID' has columns that are not part of the key of the table on the primary side of the relationship. The relationship was excluded.
 warning 6035: The relationship 'FK_TreatmentBMPAssessment_TreatmentBMP_TreatmentBMPID_TreatmentBMPTypeID' has columns that are not part of the key of the table on the primary side of the relationship. The relationship was excluded.
 warning 6035: The relationship 'FK_TreatmentBMPAttribute_TreatmentBMP_TreatmentBMPID_TenantID' has columns that are not part of the key of the table on the primary side of the relationship. The relationship was excluded.
@@ -747,6 +769,30 @@ warning 6035: The relationship 'FK_TreatmentBMPObservation_TreatmentBMPTypeObser
       </Principal>
       <Dependent Role="FileResourcesWhereYouAreTheCreatePerson">
         <PropertyRef Name="CreatePersonID" />
+      </Dependent>
+    </ReferentialConstraint>
+  </Association>
+  <Association Name="FK_MaintenanceActivity_Person_PerformedByPersonID_PersonID">
+    <End Role="PerformedByPerson" Type="Neptune.Web.Models.Store.Person" Multiplicity="1" />
+    <End Role="MaintenanceActivitiesWhereYouAreThePerformedByPerson" Type="Neptune.Web.Models.Store.MaintenanceActivity" Multiplicity="*" />
+    <ReferentialConstraint>
+      <Principal Role="PerformedByPerson">
+        <PropertyRef Name="PersonID" />
+      </Principal>
+      <Dependent Role="MaintenanceActivitiesWhereYouAreThePerformedByPerson">
+        <PropertyRef Name="PerformedByPersonID" />
+      </Dependent>
+    </ReferentialConstraint>
+  </Association>
+  <Association Name="FK_MaintenanceActivity_TreatmentBMP_TreatmentBMPID">
+    <End Role="TreatmentBMP" Type="Neptune.Web.Models.Store.TreatmentBMP" Multiplicity="1" />
+    <End Role="MaintenanceActivities" Type="Neptune.Web.Models.Store.MaintenanceActivity" Multiplicity="*" />
+    <ReferentialConstraint>
+      <Principal Role="TreatmentBMP">
+        <PropertyRef Name="TreatmentBMPID" />
+      </Principal>
+      <Dependent Role="MaintenanceActivities">
+        <PropertyRef Name="TreatmentBMPID" />
       </Dependent>
     </ReferentialConstraint>
   </Association>

--- a/Source/Neptune.Web/Models/AuditLog.cs
+++ b/Source/Neptune.Web/Models/AuditLog.cs
@@ -47,7 +47,8 @@ namespace Neptune.Web.Models
             "NeptunePageImage",
             "FileResource",
             "Notification",
-            "SupportRequestLog"
+            "SupportRequestLog",
+            "MaintenanceActivity"
         };
 
         public string AuditDescriptionDisplay

--- a/Source/Neptune.Web/Models/Generated/DatabaseEntities.Context.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/DatabaseEntities.Context.Binding.cs
@@ -38,6 +38,8 @@ namespace Neptune.Web.Models
         public virtual IQueryable<FieldDefinitionData> FieldDefinitionDatas { get { return AllFieldDefinitionDatas.Where(x => x.TenantID == HttpRequestStorage.Tenant.TenantID); } }
         public virtual DbSet<FileResource> AllFileResources { get; set; }
         public virtual IQueryable<FileResource> FileResources { get { return AllFileResources.Where(x => x.TenantID == HttpRequestStorage.Tenant.TenantID); } }
+        public virtual DbSet<MaintenanceActivity> AllMaintenanceActivities { get; set; }
+        public virtual IQueryable<MaintenanceActivity> MaintenanceActivities { get { return AllMaintenanceActivities.Where(x => x.TenantID == HttpRequestStorage.Tenant.TenantID); } }
         public virtual DbSet<ModeledCatchmentGeometryStaging> AllModeledCatchmentGeometryStagings { get; set; }
         public virtual IQueryable<ModeledCatchmentGeometryStaging> ModeledCatchmentGeometryStagings { get { return AllModeledCatchmentGeometryStagings.Where(x => x.TenantID == HttpRequestStorage.Tenant.TenantID); } }
         public virtual DbSet<ModeledCatchment> AllModeledCatchments { get; set; }
@@ -129,6 +131,14 @@ namespace Neptune.Web.Models
                     var googleChartType = GoogleChartType.All.SingleOrDefault(x => x.PrimaryKey == primaryKey);
                     Check.RequireNotNullThrowNotFound(googleChartType, "GoogleChartType", primaryKey);
                     return googleChartType;
+
+                case "MaintenanceActivity":
+                    return MaintenanceActivities.GetMaintenanceActivity(primaryKey);
+
+                case "MaintenanceActivityType":
+                    var maintenanceActivityType = MaintenanceActivityType.All.SingleOrDefault(x => x.PrimaryKey == primaryKey);
+                    Check.RequireNotNullThrowNotFound(maintenanceActivityType, "MaintenanceActivityType", primaryKey);
+                    return maintenanceActivityType;
 
                 case "MeasurementUnitType":
                     var measurementUnitType = MeasurementUnitType.All.SingleOrDefault(x => x.PrimaryKey == primaryKey);

--- a/Source/Neptune.Web/Models/Generated/FieldDefinition.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/FieldDefinition.Binding.cs
@@ -58,6 +58,8 @@ namespace Neptune.Web.Models
         public static readonly FieldDefinitionAssessmentFailsIfObservationFails AssessmentFailsIfObservationFails = FieldDefinitionAssessmentFailsIfObservationFails.Instance;
         public static readonly FieldDefinitionTreatmentBMPAttributeType TreatmentBMPAttributeType = FieldDefinitionTreatmentBMPAttributeType.Instance;
         public static readonly FieldDefinitionTreatmentBMPAttributeDataType TreatmentBMPAttributeDataType = FieldDefinitionTreatmentBMPAttributeDataType.Instance;
+        public static readonly FieldDefinitionMaintenanceActivityType MaintenanceActivityType = FieldDefinitionMaintenanceActivityType.Instance;
+        public static readonly FieldDefinitionMaintenanceActivity MaintenanceActivity = FieldDefinitionMaintenanceActivity.Instance;
 
         public static readonly List<FieldDefinition> All;
         public static readonly ReadOnlyDictionary<int, FieldDefinition> AllLookupDictionary;
@@ -67,7 +69,7 @@ namespace Neptune.Web.Models
         /// </summary>
         static FieldDefinition()
         {
-            All = new List<FieldDefinition> { IsPrimaryContactOrganization, Organization, Password, MeasurementUnit, PhotoCaption, PhotoCredit, PhotoTiming, PrimaryContact, OrganizationType, Username, ExternalLinks, RoleName, ChartLastUpdatedDate, TreatmentBMPType, TypeOfAssessment, ConveyanceFunctionsAsIntended, AssessmentScoreWeight, ObservationScore, AlternativeScore, AssessmentForInternalUseOnly, TreatmentBMPDesignDepth, ReceivesSystemCommunications, Jurisdiction, ModeledCatchment, TreatmentBMP, ObservationType, ObservationCollectionMethod, ObservationThresholdType, ObservationTargetType, MeasurementUnitLabel, PropertiesToObserve, MinimumNumberOfObservations, MaximumNumberOfObservations, MinimumValueOfEachObservation, MaximumValueOfEachObservation, DefaultThresholdValue, DefaultBenchmarkValue, AssessmentFailsIfObservationFails, TreatmentBMPAttributeType, TreatmentBMPAttributeDataType };
+            All = new List<FieldDefinition> { IsPrimaryContactOrganization, Organization, Password, MeasurementUnit, PhotoCaption, PhotoCredit, PhotoTiming, PrimaryContact, OrganizationType, Username, ExternalLinks, RoleName, ChartLastUpdatedDate, TreatmentBMPType, TypeOfAssessment, ConveyanceFunctionsAsIntended, AssessmentScoreWeight, ObservationScore, AlternativeScore, AssessmentForInternalUseOnly, TreatmentBMPDesignDepth, ReceivesSystemCommunications, Jurisdiction, ModeledCatchment, TreatmentBMP, ObservationType, ObservationCollectionMethod, ObservationThresholdType, ObservationTargetType, MeasurementUnitLabel, PropertiesToObserve, MinimumNumberOfObservations, MaximumNumberOfObservations, MinimumValueOfEachObservation, MaximumValueOfEachObservation, DefaultThresholdValue, DefaultBenchmarkValue, AssessmentFailsIfObservationFails, TreatmentBMPAttributeType, TreatmentBMPAttributeDataType, MaintenanceActivityType, MaintenanceActivity };
             AllLookupDictionary = new ReadOnlyDictionary<int, FieldDefinition>(All.ToDictionary(x => x.FieldDefinitionID));
         }
 
@@ -169,6 +171,10 @@ namespace Neptune.Web.Models
                     return IsPrimaryContactOrganization;
                 case FieldDefinitionEnum.Jurisdiction:
                     return Jurisdiction;
+                case FieldDefinitionEnum.MaintenanceActivity:
+                    return MaintenanceActivity;
+                case FieldDefinitionEnum.MaintenanceActivityType:
+                    return MaintenanceActivityType;
                 case FieldDefinitionEnum.MaximumNumberOfObservations:
                     return MaximumNumberOfObservations;
                 case FieldDefinitionEnum.MaximumValueOfEachObservation:
@@ -274,7 +280,9 @@ namespace Neptune.Web.Models
         DefaultBenchmarkValue = 37,
         AssessmentFailsIfObservationFails = 38,
         TreatmentBMPAttributeType = 39,
-        TreatmentBMPAttributeDataType = 40
+        TreatmentBMPAttributeDataType = 40,
+        MaintenanceActivityType = 41,
+        MaintenanceActivity = 42
     }
 
     public partial class FieldDefinitionIsPrimaryContactOrganization : FieldDefinition
@@ -515,5 +523,17 @@ namespace Neptune.Web.Models
     {
         private FieldDefinitionTreatmentBMPAttributeDataType(int fieldDefinitionID, string fieldDefinitionName, string fieldDefinitionDisplayName, string defaultDefinition, bool canCustomizeLabel) : base(fieldDefinitionID, fieldDefinitionName, fieldDefinitionDisplayName, defaultDefinition, canCustomizeLabel) {}
         public static readonly FieldDefinitionTreatmentBMPAttributeDataType Instance = new FieldDefinitionTreatmentBMPAttributeDataType(40, @"TreatmentBMPAttributeDataType", @"Data Type", @"", true);
+    }
+
+    public partial class FieldDefinitionMaintenanceActivityType : FieldDefinition
+    {
+        private FieldDefinitionMaintenanceActivityType(int fieldDefinitionID, string fieldDefinitionName, string fieldDefinitionDisplayName, string defaultDefinition, bool canCustomizeLabel) : base(fieldDefinitionID, fieldDefinitionName, fieldDefinitionDisplayName, defaultDefinition, canCustomizeLabel) {}
+        public static readonly FieldDefinitionMaintenanceActivityType Instance = new FieldDefinitionMaintenanceActivityType(41, @"MaintenanceActivityType", @"Maintenance Activity Type", @"Whether the maintenance performed was Preventative or Corrective maintenance", true);
+    }
+
+    public partial class FieldDefinitionMaintenanceActivity : FieldDefinition
+    {
+        private FieldDefinitionMaintenanceActivity(int fieldDefinitionID, string fieldDefinitionName, string fieldDefinitionDisplayName, string defaultDefinition, bool canCustomizeLabel) : base(fieldDefinitionID, fieldDefinitionName, fieldDefinitionDisplayName, defaultDefinition, canCustomizeLabel) {}
+        public static readonly FieldDefinitionMaintenanceActivity Instance = new FieldDefinitionMaintenanceActivity(42, @"MaintenanceActivity", @"Maintenance Activity", @"A maintenance activity performed on a Treatment BMP", true);
     }
 }

--- a/Source/Neptune.Web/Models/Generated/MaintenanceActivity.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/MaintenanceActivity.Binding.cs
@@ -1,0 +1,117 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[MaintenanceActivity]
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+using System.Data.Entity.Spatial;
+using System.Linq;
+using System.Web;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+using Neptune.Web.Common;
+
+namespace Neptune.Web.Models
+{
+    [Table("[dbo].[MaintenanceActivity]")]
+    public partial class MaintenanceActivity : IHavePrimaryKey, IHaveATenantID
+    {
+        /// <summary>
+        /// Default Constructor; only used by EF
+        /// </summary>
+        protected MaintenanceActivity()
+        {
+
+            this.TenantID = HttpRequestStorage.Tenant.TenantID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public MaintenanceActivity(int maintenanceActivityID, int treatmentBMPID, DateTime maintenanceActivityDate, int performedByPersonID, string maintenanceActivityDescription, int maintenanceActivityTypeID) : this()
+        {
+            this.MaintenanceActivityID = maintenanceActivityID;
+            this.TreatmentBMPID = treatmentBMPID;
+            this.MaintenanceActivityDate = maintenanceActivityDate;
+            this.PerformedByPersonID = performedByPersonID;
+            this.MaintenanceActivityDescription = maintenanceActivityDescription;
+            this.MaintenanceActivityTypeID = maintenanceActivityTypeID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public MaintenanceActivity(int treatmentBMPID, DateTime maintenanceActivityDate, int performedByPersonID, int maintenanceActivityTypeID) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.MaintenanceActivityID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            
+            this.TreatmentBMPID = treatmentBMPID;
+            this.MaintenanceActivityDate = maintenanceActivityDate;
+            this.PerformedByPersonID = performedByPersonID;
+            this.MaintenanceActivityTypeID = maintenanceActivityTypeID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields, using objects whenever possible
+        /// </summary>
+        public MaintenanceActivity(TreatmentBMP treatmentBMP, DateTime maintenanceActivityDate, Person performedByPerson, MaintenanceActivityType maintenanceActivityType) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.MaintenanceActivityID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            this.TreatmentBMPID = treatmentBMP.TreatmentBMPID;
+            this.TreatmentBMP = treatmentBMP;
+            treatmentBMP.MaintenanceActivities.Add(this);
+            this.MaintenanceActivityDate = maintenanceActivityDate;
+            this.PerformedByPersonID = performedByPerson.PersonID;
+            this.PerformedByPerson = performedByPerson;
+            performedByPerson.MaintenanceActivitiesWhereYouAreThePerformedByPerson.Add(this);
+            this.MaintenanceActivityTypeID = maintenanceActivityType.MaintenanceActivityTypeID;
+        }
+
+        /// <summary>
+        /// Creates a "blank" object of this type and populates primitives with defaults
+        /// </summary>
+        public static MaintenanceActivity CreateNewBlank(TreatmentBMP treatmentBMP, Person performedByPerson, MaintenanceActivityType maintenanceActivityType)
+        {
+            return new MaintenanceActivity(treatmentBMP, default(DateTime), performedByPerson, maintenanceActivityType);
+        }
+
+        /// <summary>
+        /// Does this object have any dependent objects? (If it does have dependent objects, these would need to be deleted before this object could be deleted.)
+        /// </summary>
+        /// <returns></returns>
+        public bool HasDependentObjects()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(MaintenanceActivity).Name};
+
+        [Key]
+        public int MaintenanceActivityID { get; set; }
+        public int TenantID { get; private set; }
+        public int TreatmentBMPID { get; set; }
+        public DateTime MaintenanceActivityDate { get; set; }
+        public int PerformedByPersonID { get; set; }
+        public string MaintenanceActivityDescription { get; set; }
+        public int MaintenanceActivityTypeID { get; set; }
+        [NotMapped]
+        public int PrimaryKey { get { return MaintenanceActivityID; } set { MaintenanceActivityID = value; } }
+
+        public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
+        public virtual TreatmentBMP TreatmentBMP { get; set; }
+        public virtual Person PerformedByPerson { get; set; }
+        public MaintenanceActivityType MaintenanceActivityType { get { return MaintenanceActivityType.AllLookupDictionary[MaintenanceActivityTypeID]; } }
+
+        public static class FieldLengths
+        {
+            public const int MaintenanceActivityDescription = 500;
+        }
+    }
+}

--- a/Source/Neptune.Web/Models/Generated/MaintenanceActivity.DatabaseContextExtensions.cs
+++ b/Source/Neptune.Web/Models/Generated/MaintenanceActivity.DatabaseContextExtensions.cs
@@ -1,0 +1,48 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[MaintenanceActivity]
+using System.Collections.Generic;
+using System.Linq;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+using Neptune.Web.Common;
+
+namespace Neptune.Web.Models
+{
+    public static partial class DatabaseContextExtensions
+    {
+        public static MaintenanceActivity GetMaintenanceActivity(this IQueryable<MaintenanceActivity> maintenanceActivities, int maintenanceActivityID)
+        {
+            var maintenanceActivity = maintenanceActivities.SingleOrDefault(x => x.MaintenanceActivityID == maintenanceActivityID);
+            Check.RequireNotNullThrowNotFound(maintenanceActivity, "MaintenanceActivity", maintenanceActivityID);
+            return maintenanceActivity;
+        }
+
+        public static void DeleteMaintenanceActivity(this List<int> maintenanceActivityIDList)
+        {
+            if(maintenanceActivityIDList.Any())
+            {
+                HttpRequestStorage.DatabaseEntities.AllMaintenanceActivities.RemoveRange(HttpRequestStorage.DatabaseEntities.MaintenanceActivities.Where(x => maintenanceActivityIDList.Contains(x.MaintenanceActivityID)));
+            }
+        }
+
+        public static void DeleteMaintenanceActivity(this ICollection<MaintenanceActivity> maintenanceActivitiesToDelete)
+        {
+            if(maintenanceActivitiesToDelete.Any())
+            {
+                HttpRequestStorage.DatabaseEntities.AllMaintenanceActivities.RemoveRange(maintenanceActivitiesToDelete);
+            }
+        }
+
+        public static void DeleteMaintenanceActivity(this int maintenanceActivityID)
+        {
+            DeleteMaintenanceActivity(new List<int> { maintenanceActivityID });
+        }
+
+        public static void DeleteMaintenanceActivity(this MaintenanceActivity maintenanceActivityToDelete)
+        {
+            DeleteMaintenanceActivity(new List<MaintenanceActivity> { maintenanceActivityToDelete });
+        }
+    }
+}

--- a/Source/Neptune.Web/Models/Generated/MaintenanceActivityPrimaryKey.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/MaintenanceActivityPrimaryKey.Binding.cs
@@ -1,0 +1,26 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: dbo.MaintenanceActivity
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+using Neptune.Web.Common;
+
+namespace Neptune.Web.Models
+{
+    public class MaintenanceActivityPrimaryKey : LtInfo.Common.EntityModelBinding.LtInfoEntityPrimaryKey<MaintenanceActivity>
+    {
+        public MaintenanceActivityPrimaryKey(int primaryKeyValue) : base(primaryKeyValue){}
+        public MaintenanceActivityPrimaryKey(MaintenanceActivity maintenanceActivity) : base(maintenanceActivity){}
+
+        public static implicit operator MaintenanceActivityPrimaryKey(int primaryKeyValue)
+        {
+            return new MaintenanceActivityPrimaryKey(primaryKeyValue);
+        }
+
+        public static implicit operator MaintenanceActivityPrimaryKey(MaintenanceActivity maintenanceActivity)
+        {
+            return new MaintenanceActivityPrimaryKey(maintenanceActivity);
+        }
+    }
+}

--- a/Source/Neptune.Web/Models/Generated/MaintenanceActivityType.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/MaintenanceActivityType.Binding.cs
@@ -1,0 +1,129 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[MaintenanceActivityType]
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data;
+using System.Linq;
+using System.Web;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+using Neptune.Web.Common;
+
+namespace Neptune.Web.Models
+{
+    public abstract partial class MaintenanceActivityType : IHavePrimaryKey
+    {
+        public static readonly MaintenanceActivityTypePreventative Preventative = MaintenanceActivityTypePreventative.Instance;
+        public static readonly MaintenanceActivityTypeCorrective Corrective = MaintenanceActivityTypeCorrective.Instance;
+
+        public static readonly List<MaintenanceActivityType> All;
+        public static readonly ReadOnlyDictionary<int, MaintenanceActivityType> AllLookupDictionary;
+
+        /// <summary>
+        /// Static type constructor to coordinate static initialization order
+        /// </summary>
+        static MaintenanceActivityType()
+        {
+            All = new List<MaintenanceActivityType> { Preventative, Corrective };
+            AllLookupDictionary = new ReadOnlyDictionary<int, MaintenanceActivityType>(All.ToDictionary(x => x.MaintenanceActivityTypeID));
+        }
+
+        /// <summary>
+        /// Protected constructor only for use in instantiating the set of static lookup values that match database
+        /// </summary>
+        protected MaintenanceActivityType(int maintenanceActivityTypeID, string maintenanceActivityTypeName, string maintenanceActivityTypeDisplayName)
+        {
+            MaintenanceActivityTypeID = maintenanceActivityTypeID;
+            MaintenanceActivityTypeName = maintenanceActivityTypeName;
+            MaintenanceActivityTypeDisplayName = maintenanceActivityTypeDisplayName;
+        }
+
+        [Key]
+        public int MaintenanceActivityTypeID { get; private set; }
+        public string MaintenanceActivityTypeName { get; private set; }
+        public string MaintenanceActivityTypeDisplayName { get; private set; }
+        [NotMapped]
+        public int PrimaryKey { get { return MaintenanceActivityTypeID; } }
+
+        /// <summary>
+        /// Enum types are equal by primary key
+        /// </summary>
+        public bool Equals(MaintenanceActivityType other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+            return other.MaintenanceActivityTypeID == MaintenanceActivityTypeID;
+        }
+
+        /// <summary>
+        /// Enum types are equal by primary key
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as MaintenanceActivityType);
+        }
+
+        /// <summary>
+        /// Enum types are equal by primary key
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return MaintenanceActivityTypeID;
+        }
+
+        public static bool operator ==(MaintenanceActivityType left, MaintenanceActivityType right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(MaintenanceActivityType left, MaintenanceActivityType right)
+        {
+            return !Equals(left, right);
+        }
+
+        public MaintenanceActivityTypeEnum ToEnum { get { return (MaintenanceActivityTypeEnum)GetHashCode(); } }
+
+        public static MaintenanceActivityType ToType(int enumValue)
+        {
+            return ToType((MaintenanceActivityTypeEnum)enumValue);
+        }
+
+        public static MaintenanceActivityType ToType(MaintenanceActivityTypeEnum enumValue)
+        {
+            switch (enumValue)
+            {
+                case MaintenanceActivityTypeEnum.Corrective:
+                    return Corrective;
+                case MaintenanceActivityTypeEnum.Preventative:
+                    return Preventative;
+                default:
+                    throw new ArgumentException(string.Format("Unable to map Enum: {0}", enumValue));
+            }
+        }
+    }
+
+    public enum MaintenanceActivityTypeEnum
+    {
+        Preventative = 1,
+        Corrective = 2
+    }
+
+    public partial class MaintenanceActivityTypePreventative : MaintenanceActivityType
+    {
+        private MaintenanceActivityTypePreventative(int maintenanceActivityTypeID, string maintenanceActivityTypeName, string maintenanceActivityTypeDisplayName) : base(maintenanceActivityTypeID, maintenanceActivityTypeName, maintenanceActivityTypeDisplayName) {}
+        public static readonly MaintenanceActivityTypePreventative Instance = new MaintenanceActivityTypePreventative(1, @"Preventative", @"Preventative");
+    }
+
+    public partial class MaintenanceActivityTypeCorrective : MaintenanceActivityType
+    {
+        private MaintenanceActivityTypeCorrective(int maintenanceActivityTypeID, string maintenanceActivityTypeName, string maintenanceActivityTypeDisplayName) : base(maintenanceActivityTypeID, maintenanceActivityTypeName, maintenanceActivityTypeDisplayName) {}
+        public static readonly MaintenanceActivityTypeCorrective Instance = new MaintenanceActivityTypeCorrective(2, @"Corrective", @"Corrective");
+    }
+}

--- a/Source/Neptune.Web/Models/Generated/MaintenanceActivityTypePrimaryKey.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/MaintenanceActivityTypePrimaryKey.Binding.cs
@@ -1,0 +1,26 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: dbo.MaintenanceActivityType
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+using Neptune.Web.Common;
+
+namespace Neptune.Web.Models
+{
+    public class MaintenanceActivityTypePrimaryKey : LtInfo.Common.EntityModelBinding.LtInfoEntityPrimaryKey<MaintenanceActivityType>
+    {
+        public MaintenanceActivityTypePrimaryKey(int primaryKeyValue) : base(primaryKeyValue){}
+        public MaintenanceActivityTypePrimaryKey(MaintenanceActivityType maintenanceActivityType) : base(maintenanceActivityType){}
+
+        public static implicit operator MaintenanceActivityTypePrimaryKey(int primaryKeyValue)
+        {
+            return new MaintenanceActivityTypePrimaryKey(primaryKeyValue);
+        }
+
+        public static implicit operator MaintenanceActivityTypePrimaryKey(MaintenanceActivityType maintenanceActivityType)
+        {
+            return new MaintenanceActivityTypePrimaryKey(maintenanceActivityType);
+        }
+    }
+}

--- a/Source/Neptune.Web/Models/Generated/Person.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/Person.Binding.cs
@@ -25,6 +25,7 @@ namespace Neptune.Web.Models
         {
             this.AuditLogs = new HashSet<AuditLog>();
             this.FileResourcesWhereYouAreTheCreatePerson = new HashSet<FileResource>();
+            this.MaintenanceActivitiesWhereYouAreThePerformedByPerson = new HashSet<MaintenanceActivity>();
             this.ModeledCatchmentGeometryStagings = new HashSet<ModeledCatchmentGeometryStaging>();
             this.Notifications = new HashSet<Notification>();
             this.OrganizationsWhereYouAreThePrimaryContactPerson = new HashSet<Organization>();
@@ -111,13 +112,13 @@ namespace Neptune.Web.Models
         /// <returns></returns>
         public bool HasDependentObjects()
         {
-            return AuditLogs.Any() || FileResourcesWhereYouAreTheCreatePerson.Any() || ModeledCatchmentGeometryStagings.Any() || Notifications.Any() || OrganizationsWhereYouAreThePrimaryContactPerson.Any() || StormwaterJurisdictionPeople.Any() || SupportRequestLogsWhereYouAreTheRequestPerson.Any() || TenantAttributesWhereYouAreThePrimaryContactPerson.Any() || TreatmentBMPAssessments.Any();
+            return AuditLogs.Any() || FileResourcesWhereYouAreTheCreatePerson.Any() || MaintenanceActivitiesWhereYouAreThePerformedByPerson.Any() || ModeledCatchmentGeometryStagings.Any() || Notifications.Any() || OrganizationsWhereYouAreThePrimaryContactPerson.Any() || StormwaterJurisdictionPeople.Any() || SupportRequestLogsWhereYouAreTheRequestPerson.Any() || TenantAttributesWhereYouAreThePrimaryContactPerson.Any() || TreatmentBMPAssessments.Any();
         }
 
         /// <summary>
         /// Dependent type names of this entity
         /// </summary>
-        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(Person).Name, typeof(AuditLog).Name, typeof(FileResource).Name, typeof(ModeledCatchmentGeometryStaging).Name, typeof(Notification).Name, typeof(Organization).Name, typeof(StormwaterJurisdictionPerson).Name, typeof(SupportRequestLog).Name, typeof(TenantAttribute).Name, typeof(TreatmentBMPAssessment).Name};
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(Person).Name, typeof(AuditLog).Name, typeof(FileResource).Name, typeof(MaintenanceActivity).Name, typeof(ModeledCatchmentGeometryStaging).Name, typeof(Notification).Name, typeof(Organization).Name, typeof(StormwaterJurisdictionPerson).Name, typeof(SupportRequestLog).Name, typeof(TenantAttribute).Name, typeof(TreatmentBMPAssessment).Name};
 
         [Key]
         public int PersonID { get; set; }
@@ -140,6 +141,7 @@ namespace Neptune.Web.Models
 
         public virtual ICollection<AuditLog> AuditLogs { get; set; }
         public virtual ICollection<FileResource> FileResourcesWhereYouAreTheCreatePerson { get; set; }
+        public virtual ICollection<MaintenanceActivity> MaintenanceActivitiesWhereYouAreThePerformedByPerson { get; set; }
         public virtual ICollection<ModeledCatchmentGeometryStaging> ModeledCatchmentGeometryStagings { get; set; }
         public virtual ICollection<Notification> Notifications { get; set; }
         public virtual ICollection<Organization> OrganizationsWhereYouAreThePrimaryContactPerson { get; set; }

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMP.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMP.Binding.cs
@@ -23,6 +23,7 @@ namespace Neptune.Web.Models
         /// </summary>
         protected TreatmentBMP()
         {
+            this.MaintenanceActivities = new HashSet<MaintenanceActivity>();
             this.TreatmentBMPAssessments = new HashSet<TreatmentBMPAssessment>();
             this.TreatmentBMPAttributes = new HashSet<TreatmentBMPAttribute>();
             this.TreatmentBMPBenchmarkAndThresholds = new HashSet<TreatmentBMPBenchmarkAndThreshold>();
@@ -95,13 +96,13 @@ namespace Neptune.Web.Models
         /// <returns></returns>
         public bool HasDependentObjects()
         {
-            return TreatmentBMPAssessments.Any() || TreatmentBMPAttributes.Any() || TreatmentBMPBenchmarkAndThresholds.Any() || TreatmentBMPDocuments.Any() || TreatmentBMPImages.Any();
+            return MaintenanceActivities.Any() || TreatmentBMPAssessments.Any() || TreatmentBMPAttributes.Any() || TreatmentBMPBenchmarkAndThresholds.Any() || TreatmentBMPDocuments.Any() || TreatmentBMPImages.Any();
         }
 
         /// <summary>
         /// Dependent type names of this entity
         /// </summary>
-        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(TreatmentBMP).Name, typeof(TreatmentBMPAssessment).Name, typeof(TreatmentBMPAttribute).Name, typeof(TreatmentBMPBenchmarkAndThreshold).Name, typeof(TreatmentBMPDocument).Name, typeof(TreatmentBMPImage).Name};
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(TreatmentBMP).Name, typeof(MaintenanceActivity).Name, typeof(TreatmentBMPAssessment).Name, typeof(TreatmentBMPAttribute).Name, typeof(TreatmentBMPBenchmarkAndThreshold).Name, typeof(TreatmentBMPDocument).Name, typeof(TreatmentBMPImage).Name};
 
         [Key]
         public int TreatmentBMPID { get; set; }
@@ -118,6 +119,7 @@ namespace Neptune.Web.Models
         [NotMapped]
         public int PrimaryKey { get { return TreatmentBMPID; } set { TreatmentBMPID = value; } }
 
+        public virtual ICollection<MaintenanceActivity> MaintenanceActivities { get; set; }
         public virtual ICollection<TreatmentBMPAssessment> TreatmentBMPAssessments { get; set; }
         public virtual ICollection<TreatmentBMPAttribute> TreatmentBMPAttributes { get; set; }
         public virtual ICollection<TreatmentBMPBenchmarkAndThreshold> TreatmentBMPBenchmarkAndThresholds { get; set; }

--- a/Source/Neptune.Web/Models/MaintenanceActivityModelExtensions.cs
+++ b/Source/Neptune.Web/Models/MaintenanceActivityModelExtensions.cs
@@ -1,0 +1,21 @@
+﻿using LtInfo.Common;
+using Neptune.Web.Common;
+using Neptune.Web.Controllers;
+
+namespace Neptune.Web.Models
+{
+    public static class MaintenanceActivityModelExtensions
+    {
+        public static readonly UrlTemplate<int> EditUrlTemplate = new UrlTemplate<int>(SitkaRoute<MaintenanceActivityController>.BuildUrlFromExpression(t => t.Edit(UrlTemplate.Parameter1Int)));
+        public static string GetEditUrl(this MaintenanceActivity maintenanceActivity)
+        {
+            return EditUrlTemplate.ParameterReplace(maintenanceActivity.MaintenanceActivityID);
+        }
+
+        public static readonly UrlTemplate<int> DeleteUrlTemplate = new UrlTemplate<int>(SitkaRoute<MaintenanceActivityController>.BuildUrlFromExpression(t => t.Delete(UrlTemplate.Parameter1Int)));
+        public static string GetDeleteUrl(this MaintenanceActivity maintenanceActivity)
+        {
+            return DeleteUrlTemplate.ParameterReplace(maintenanceActivity.MaintenanceActivityID);
+        }
+    }
+}

--- a/Source/Neptune.Web/Neptune.Web.csproj
+++ b/Source/Neptune.Web/Neptune.Web.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -70,6 +70,11 @@
     <Compile Include="Models\Generated\FileResourcePrimaryKey.Binding.cs" />
     <Compile Include="Models\Generated\GoogleChartType.Binding.cs" />
     <Compile Include="Models\Generated\GoogleChartTypePrimaryKey.Binding.cs" />
+    <Compile Include="Models\Generated\MaintenanceActivity.Binding.cs" />
+    <Compile Include="Models\Generated\MaintenanceActivity.DatabaseContextExtensions.cs" />
+    <Compile Include="Models\Generated\MaintenanceActivityPrimaryKey.Binding.cs" />
+    <Compile Include="Models\Generated\MaintenanceActivityType.Binding.cs" />
+    <Compile Include="Models\Generated\MaintenanceActivityTypePrimaryKey.Binding.cs" />
     <Compile Include="Models\Generated\MeasurementUnitType.Binding.cs" />
     <Compile Include="Models\Generated\MeasurementUnitTypePrimaryKey.Binding.cs" />
     <Compile Include="Models\Generated\ModeledCatchment.Binding.cs" />
@@ -176,6 +181,7 @@
     <Compile Include="Models\Generated\TreatmentBMPTypeObservationType.DatabaseContextExtensions.cs" />
     <Compile Include="Models\Generated\TreatmentBMPTypeObservationTypePrimaryKey.Binding.cs" />
     <Compile Include="Models\Generated\TreatmentBMPTypePrimaryKey.Binding.cs" />
+    <Compile Include="Controllers\AssessmentController - Copy.cs" />
     <Compile Include="Controllers\TreatmentBMPAttributeTypeController.cs" />
     <Compile Include="Controllers\TreatmentBMPImageController.cs" />
     <Compile Include="Controllers\TreatmentBMPDocumentController.cs" />
@@ -269,6 +275,7 @@
     <Compile Include="Views\Jurisdiction\IndexGridSpec.cs" />
     <Compile Include="Views\Jurisdiction\IndexViewData.cs" />
     <Compile Include="Views\Jurisdiction\JurisdictionUrbanCatchmentsGridSpec.cs" />
+    <Compile Include="Views\MaintenanceActivity\MaintenanceActivityGridSpec.cs" />
     <Compile Include="Views\Map\JurisdictionsMapInitJson.cs" />
     <Compile Include="Views\ModeledCatchment\ApproveModeledCatchmentGisUpload.cs" />
     <Compile Include="Views\ModeledCatchment\ApproveModeledCatchmentGisUploadViewData.cs" />

--- a/Source/Neptune.Web/Neptune.Web.csproj
+++ b/Source/Neptune.Web/Neptune.Web.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -46,6 +46,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Controllers\EditMaintenanceActivity.cs" />
     <Compile Include="Models\Generated\AuditLog.Binding.cs" />
     <Compile Include="Models\Generated\AuditLog.DatabaseContextExtensions.cs" />
     <Compile Include="Models\Generated\AuditLogEventType.Binding.cs" />
@@ -181,7 +182,9 @@
     <Compile Include="Models\Generated\TreatmentBMPTypeObservationType.DatabaseContextExtensions.cs" />
     <Compile Include="Models\Generated\TreatmentBMPTypeObservationTypePrimaryKey.Binding.cs" />
     <Compile Include="Models\Generated\TreatmentBMPTypePrimaryKey.Binding.cs" />
-    <Compile Include="Controllers\AssessmentController - Copy.cs" />
+    <Compile Include="Views\MaintenanceActivity\EditMaintenanceActivityViewData.cs" />
+    <Compile Include="Views\MaintenanceActivity\EditMaintenanceActivityViewModel.cs" />
+    <Compile Include="Controllers\MaintenanceActivityController.cs" />
     <Compile Include="Controllers\TreatmentBMPAttributeTypeController.cs" />
     <Compile Include="Controllers\TreatmentBMPImageController.cs" />
     <Compile Include="Controllers\TreatmentBMPDocumentController.cs" />
@@ -203,6 +206,7 @@
     <Compile Include="Common\SitkaRouteTableEntry.cs" />
     <Compile Include="Controllers\GoogleChartController.cs" />
     <Compile Include="Models\HslColor.cs" />
+    <Compile Include="Models\MaintenanceActivityModelExtensions.cs" />
     <Compile Include="Models\TreatmentBMPAttribute.cs" />
     <Compile Include="Models\TreatmentBMPAttributeDataType.cs" />
     <Compile Include="Models\TreatmentBMPAttributeTypeSimple.cs" />
@@ -913,6 +917,7 @@
     <Content Include="Views\TreatmentBMPAttributeType\Edit.cshtml" />
     <Content Include="Views\TreatmentBMPAttributeType\Manage.cshtml" />
     <Content Include="Views\TreatmentBMP\EditAttributes.cshtml" />
+    <Content Include="Views\MaintenanceActivity\EditMaintenanceActivity.cshtml" />
     <Reference Include="Antlr3.Runtime">
       <HintPath>..\NuGetPackages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>

--- a/Source/Neptune.Web/Security/TreatmentBMPManageFeature.cs
+++ b/Source/Neptune.Web/Security/TreatmentBMPManageFeature.cs
@@ -52,4 +52,26 @@ namespace Neptune.Web.Security
             return new PermissionCheckResult();
         }
     }
+    [SecurityFeatureDescription("Allows editing a Maintenance Activity if you are can edit the BMP it belonds to")]
+    public class MaintenanceActivityManageFeature : NeptuneFeatureWithContext, INeptuneBaseFeatureWithContext<MaintenanceActivity>
+    {
+        private readonly NeptuneFeatureWithContextImpl<MaintenanceActivity> _lakeTahoeInfoFeatureWithContextImpl;
+
+        public MaintenanceActivityManageFeature()
+            : base(new List<Role> { Role.SitkaAdmin, Role.Admin, Role.Normal })
+        {
+            _lakeTahoeInfoFeatureWithContextImpl = new NeptuneFeatureWithContextImpl<MaintenanceActivity>(this);
+            ActionFilter = _lakeTahoeInfoFeatureWithContextImpl;
+        }
+
+        public void DemandPermission(Person person, MaintenanceActivity contextModelObject)
+        {
+            _lakeTahoeInfoFeatureWithContextImpl.DemandPermission(person, contextModelObject);
+        }
+
+        public PermissionCheckResult HasPermission(Person person, MaintenanceActivity contextModelObject)
+        {
+            return new TreatmentBMPManageFeature().HasPermission(person, contextModelObject.TreatmentBMP);
+        }
+    }
 }

--- a/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivity.cshtml
+++ b/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivity.cshtml
@@ -1,0 +1,15 @@
+﻿@using LtInfo.Common.HtmlHelperExtensions
+@using Neptune.Web.Common
+@inherits Neptune.Web.Views.MaintenanceActivity.EditMaintenanceActivity
+
+@using (Html.BeginForm())
+{
+    <div class="form-horizontal">
+        <div class="form-group">
+            <div class="col-xs-4 control-label">Hello, World!</div>
+            <div class="col-xs-8">
+                <p>Goodbye, World!</p>
+            </div>
+        </div>
+    </div>
+}

--- a/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivity.cshtml
+++ b/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivity.cshtml
@@ -1,14 +1,40 @@
-﻿@using LtInfo.Common.HtmlHelperExtensions
+﻿@using LtInfo.Common
+@using LtInfo.Common.HtmlHelperExtensions
 @using Neptune.Web.Common
 @inherits Neptune.Web.Views.MaintenanceActivity.EditMaintenanceActivity
 
 @using (Html.BeginForm())
 {
+    @Html.ValidationSummary()
     <div class="form-horizontal">
         <div class="form-group">
-            <div class="col-xs-4 control-label">Hello, World!</div>
+            <div class="col-xs-4 control-label">@Html.LabelFor(m => m.MaintenanceActivityDate)</div>
             <div class="col-xs-8">
-                <p>Goodbye, World!</p>
+                <div class="input-group date" data-date-format="m/d/yyyy" data-provide="datepicker" data-date-autoclose="true" data-date-clear-btn="true" style="width: 150px">
+                    <input type="text" name="@Html.NameFor(m => m.MaintenanceActivityDate)" class="form-control assessmentDate" value="@Model.MaintenanceActivityDate.ToStringDate()" />
+                    <div class="input-group-addon">
+                        <span class="glyphicon glyphicon-th"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="form-group">
+            <div class="col-xs-4 control-label">@Html.LabelFor(m => m.MaintenanceActivityTypeID)</div>
+            <div class="col-xs-8">
+                @Html.DropDownListFor(m => m.MaintenanceActivityTypeID, ViewDataTyped.AllMaintenanceActivityTypes, new { @class = "form-control" })
+                
+            </div>
+        </div>
+        <div class="form-group">
+            <div class="col-xs-4 control-label">@Html.LabelFor(m => m.PerformedByPersonID)</div>
+            <div class="col-xs-8">
+                @Html.SearchableDropDownListFor(m=>m.PerformedByPersonID, ViewDataTyped.AllPersons, new{title=""})
+                </div>
+        </div>
+        <div class="form-group">
+            <div class="col-xs-4 control-label">@Html.LabelFor(m => m.MaintenanceActivityDescription)</div>
+            <div class="col-xs-8">
+                @Html.TextAreaFor(m => m.MaintenanceActivityDescription, new { @class = "form-control" })
             </div>
         </div>
     </div>

--- a/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivityViewData.cs
+++ b/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivityViewData.cs
@@ -1,0 +1,6 @@
+namespace Neptune.Web.Views.MaintenanceActivity
+{
+    public class EditMaintenanceActivityViewData : NeptuneUserControlViewData
+    {
+    }
+}

--- a/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivityViewData.cs
+++ b/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivityViewData.cs
@@ -1,6 +1,23 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Web.Mvc;
+using LtInfo.Common.Mvc;
+using Neptune.Web.Models;
+
 namespace Neptune.Web.Views.MaintenanceActivity
 {
     public class EditMaintenanceActivityViewData : NeptuneUserControlViewData
     {
+        public EditMaintenanceActivityViewData(List<Person> persons)
+        {
+            AllPersons = persons.ToSelectListWithEmptyFirstRow(x => x.PersonID.ToString(CultureInfo.InvariantCulture),
+                x => x.FullNameLastFirst,"");
+
+            AllMaintenanceActivityTypes = MaintenanceActivityType.All.ToSelectListWithEmptyFirstRow(x=>x.MaintenanceActivityTypeID.ToString(CultureInfo.InvariantCulture), x=>x.MaintenanceActivityTypeDisplayName,"");
+        }
+
+        public IEnumerable<SelectListItem> AllMaintenanceActivityTypes { get; }
+
+        public IEnumerable<SelectListItem> AllPersons { get; }
     }
 }

--- a/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivityViewModel.cs
+++ b/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivityViewModel.cs
@@ -1,4 +1,8 @@
+using System;
+using System.ComponentModel.DataAnnotations;
 using LtInfo.Common.Models;
+using Neptune.Web.Common;
+using Neptune.Web.Models;
 
 namespace Neptune.Web.Views.MaintenanceActivity
 {
@@ -9,12 +13,39 @@ namespace Neptune.Web.Views.MaintenanceActivity
         /// </summary>
         public EditMaintenanceActivityViewModel()
         {
-
         }
 
         public EditMaintenanceActivityViewModel(Models.MaintenanceActivity maintenanceActivity)
         {
-            throw new System.NotImplementedException();
+            MaintenanceActivityDate = maintenanceActivity.MaintenanceActivityDate;
+            PerformedByPersonID = maintenanceActivity.PerformedByPersonID;
+            MaintenanceActivityTypeID = maintenanceActivity.MaintenanceActivityTypeID;
+            MaintenanceActivityDescription = maintenanceActivity.MaintenanceActivityDescription;
+        }
+
+        [Required]
+        [MaxLength(Models.MaintenanceActivity.FieldLengths.MaintenanceActivityDescription)]
+        [Display(Name = "Description")]
+        public string MaintenanceActivityDescription { get; set; }
+
+        [Required]
+        [FieldDefinitionDisplay(FieldDefinitionEnum.MaintenanceActivityType)]
+        public int? MaintenanceActivityTypeID { get; set; }
+
+        [Required]
+        [Display(Name = "Performed By")]
+        public int? PerformedByPersonID { get; set; }
+
+        [Display(Name = "Date")]
+        [Required]
+        public DateTime? MaintenanceActivityDate { get; set; }
+
+        public void UpdateModel(Models.MaintenanceActivity maintenanceActivity)
+        {
+            maintenanceActivity.MaintenanceActivityDate = MaintenanceActivityDate.Value;
+            maintenanceActivity.PerformedByPersonID = PerformedByPersonID.Value;
+            maintenanceActivity.MaintenanceActivityTypeID = MaintenanceActivityTypeID.Value;
+            maintenanceActivity.MaintenanceActivityDescription = MaintenanceActivityDescription;
         }
     }
 }

--- a/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivityViewModel.cs
+++ b/Source/Neptune.Web/Views/MaintenanceActivity/EditMaintenanceActivityViewModel.cs
@@ -1,0 +1,20 @@
+using LtInfo.Common.Models;
+
+namespace Neptune.Web.Views.MaintenanceActivity
+{
+    public class EditMaintenanceActivityViewModel : FormViewModel
+    {
+        /// <summary>
+        /// Needed by ModelBinder
+        /// </summary>
+        public EditMaintenanceActivityViewModel()
+        {
+
+        }
+
+        public EditMaintenanceActivityViewModel(Models.MaintenanceActivity maintenanceActivity)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Source/Neptune.Web/Views/MaintenanceActivity/MaintenanceActivityGridSpec.cs
+++ b/Source/Neptune.Web/Views/MaintenanceActivity/MaintenanceActivityGridSpec.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LtInfo.Common.DhtmlWrappers;
+using Neptune.Web.Models;
+
+namespace Neptune.Web.Views.MaintenanceActivity
+{
+    public class MaintenanceActivityGridSpec : GridSpec<Models.MaintenanceActivity>
+    {
+        public MaintenanceActivityGridSpec(Person currentPerson)
+        {
+
+        }
+    }
+}

--- a/Source/Neptune.Web/Views/MaintenanceActivity/MaintenanceActivityGridSpec.cs
+++ b/Source/Neptune.Web/Views/MaintenanceActivity/MaintenanceActivityGridSpec.cs
@@ -38,13 +38,13 @@ namespace Neptune.Web.Views.MaintenanceActivity
                 x => DhtmlxGridHtmlHelpers.MakeDeleteIconAndLinkBootstrap(x.GetDeleteUrl(), 
                     currentPersonCanEditOrDelete), 30, DhtmlxGridColumnFilterType.None);
             Add(string.Empty,
-                x => DhtmlxGridHtmlHelpers.MakeEditIconAsModalDialogLinkBootstrap(new ModalDialogForm(x.GetEditUrl())), 30, DhtmlxGridColumnFilterType.None);
+                x => DhtmlxGridHtmlHelpers.MakeEditIconAsModalDialogLinkBootstrap(new ModalDialogForm(x.GetEditUrl(),$"Edit {Models.FieldDefinition.MaintenanceActivity.GetFieldDefinitionLabel()}")), 30, DhtmlxGridColumnFilterType.None);
             Add(Models.FieldDefinition.MaintenanceActivityType.ToGridHeaderString("Type"),
                 x => x.MaintenanceActivityType.MaintenanceActivityTypeDisplayName, 100,
                 DhtmlxGridColumnFilterType.Text);
             Add("Date", x => x.MaintenanceActivityDate.ToShortDateString(), 100);
             Add("Performed By", x => x.PerformedByPerson.FullNameLastFirst, 100, DhtmlxGridColumnFilterType.Text);
-            Add("Description", x => x.MaintenanceActivityDescription, 100, DhtmlxGridColumnFilterType.Text);
+            Add("Description", x => x.MaintenanceActivityDescription, 300, DhtmlxGridColumnFilterType.Text);
         }
     }
 }

--- a/Source/Neptune.Web/Views/MaintenanceActivity/MaintenanceActivityGridSpec.cs
+++ b/Source/Neptune.Web/Views/MaintenanceActivity/MaintenanceActivityGridSpec.cs
@@ -1,18 +1,50 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*-----------------------------------------------------------------------
+<copyright file="MaintenancyActivityGridSpec.cs" company="Tahoe Regional Planning Agency">
+Copyright (c) Tahoe Regional Planning Agency. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+
 using LtInfo.Common.DhtmlWrappers;
+using LtInfo.Common.HtmlHelperExtensions;
+using LtInfo.Common.ModalDialog;
+using LtInfo.Common.Views;
 using Neptune.Web.Models;
+using Neptune.Web.Security;
 
 namespace Neptune.Web.Views.MaintenanceActivity
 {
     public class MaintenanceActivityGridSpec : GridSpec<Models.MaintenanceActivity>
     {
-        public MaintenanceActivityGridSpec(Person currentPerson)
+        public MaintenanceActivityGridSpec(Person currentPerson, Models.TreatmentBMP treatmentBMP)
         {
+            var currentPersonCanEditOrDelete = new TreatmentBMPManageFeature().HasPermission(currentPerson, treatmentBMP).HasPermission;
 
+            Add(string.Empty,
+                x => DhtmlxGridHtmlHelpers.MakeDeleteIconAndLinkBootstrap(x.GetDeleteUrl(), 
+                    currentPersonCanEditOrDelete), 30, DhtmlxGridColumnFilterType.None);
+            Add(string.Empty,
+                x => DhtmlxGridHtmlHelpers.MakeEditIconAsModalDialogLinkBootstrap(new ModalDialogForm(x.GetEditUrl())), 30, DhtmlxGridColumnFilterType.None);
+            Add(Models.FieldDefinition.MaintenanceActivityType.ToGridHeaderString("Type"),
+                x => x.MaintenanceActivityType.MaintenanceActivityTypeDisplayName, 100,
+                DhtmlxGridColumnFilterType.Text);
+            Add("Date", x => x.MaintenanceActivityDate.ToShortDateString(), 100);
+            Add("Performed By", x => x.PerformedByPerson.FullNameLastFirst, 100, DhtmlxGridColumnFilterType.Text);
+            Add("Description", x => x.MaintenanceActivityDescription, 100, DhtmlxGridColumnFilterType.Text);
         }
     }
 }

--- a/Source/Neptune.Web/Views/TreatmentBMP/Detail.cshtml
+++ b/Source/Neptune.Web/Views/TreatmentBMP/Detail.cshtml
@@ -203,7 +203,6 @@
                 }
                 @if (ViewDataTyped.TreatmentBMP.TreatmentBMPAssessments.Any())
                 {
-                    <p class="systemText">Assessments for treatment BMP that are included in an active Registration with a credit declaration cannot be deleted or edited.</p>
                     @Html.DhtmlxGrid(ViewDataTyped.AssessmentGridSpec, ViewDataTyped.AssessmentGridName, ViewDataTyped.AssessmentGridDataUrl, null, DhtmlxGridResizeType.VerticalFillHorizontalAutoFit)
                 }
                 @if (!ViewDataTyped.TreatmentBMP.TreatmentBMPAssessments.Any() && ViewDataTyped.TreatmentBMP.IsBenchmarkAndThresholdsComplete())
@@ -211,6 +210,30 @@
                     <p class="systemText">
                         BMP has not been assessed.
                     </p>
+                }
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-12">
+        <div class="panel panelNeptune">
+            <div class="panel-heading panelTitle">
+                Maintenance Activity
+                @if (ViewDataTyped.CurrentPersonCanManage)
+                {
+                <span class="pull-right">
+                    @ModalDialogFormHelper.ModalDialogFormLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-plus").ToString(), ViewDataTyped.NewMaintenanceActivityUrl, "Add Maintenance Activity", new List<string>(), ViewDataTyped.CurrentPersonCanManage)
+                </span>
+                }
+            </div>
+            <div class="panel-body">
+                @if (ViewDataTyped.TreatmentBMP.MaintenanceActivities.Any())
+                {
+                    @Html.DhtmlxGrid(ViewDataTyped.MaintenanceActivityGridSpec, ViewDataTyped.MaintenanceActivityGridName, ViewDataTyped.MaintenanceActivityGridUrl, null, DhtmlxGridResizeType.VerticalFillHorizontalAutoFit)
+                }
+                else
+                {
+                    <p class="systemText">There are no @FieldDefinition.MaintenanceActivity.GetFieldDefinitionLabelPluralized() for this @FieldDefinition.TreatmentBMP.GetFieldDefinitionLabel()</p>
                 }
             </div>
         </div>
@@ -253,7 +276,7 @@
                 }
                 else
                 {
-                    <p class="systemText">No documents have been uploaded for this Treatment BMP.</p>
+                    <p class="systemText">No documents have been uploaded for this @FieldDefinition.TreatmentBMP.GetFieldDefinitionLabel().</p>
                 }
             </div>
         </div>

--- a/Source/Neptune.Web/Views/TreatmentBMP/DetailViewData.cs
+++ b/Source/Neptune.Web/Views/TreatmentBMP/DetailViewData.cs
@@ -75,7 +75,7 @@ namespace Neptune.Web.Views.TreatmentBMP
             AssessmentGridName = "Assessment";
 
             MaintenanceActivityGridSpec = new MaintenanceActivityGridSpec(CurrentPerson, treatmentBMP);
-            MaintenanceActivityGridName = "Maintenance Activity";
+            MaintenanceActivityGridName = "MaintenanceActivity";
 
             AssessmentGridDataUrl = SitkaRoute<TreatmentBMPAssessmentController>.BuildUrlFromExpression(t => t.AssessmentGridJsonData(treatmentBMP));
             MaintenanceActivityGridUrl =

--- a/Source/Neptune.Web/Views/TreatmentBMP/DetailViewData.cs
+++ b/Source/Neptune.Web/Views/TreatmentBMP/DetailViewData.cs
@@ -22,6 +22,7 @@ Source code is available upon request via <support@sitkatech.com>.
 using Neptune.Web.Common;
 using Neptune.Web.Controllers;
 using Neptune.Web.Models;
+using Neptune.Web.Views.MaintenanceActivity;
 using Neptune.Web.Views.Shared;
 using Neptune.Web.Views.TreatmentBMPAssessment;
 
@@ -49,6 +50,11 @@ namespace Neptune.Web.Views.TreatmentBMP
         public ImageCarouselViewData ImageCarouselViewData { get; }
         public string EditTreatmentBMPAttributesUrl { get; }
 
+        public string MaintenanceActivityGridName { get; }
+        public MaintenanceActivityGridSpec MaintenanceActivityGridSpec { get; }
+        public string MaintenanceActivityGridUrl { get; }
+        public string NewMaintenanceActivityUrl { get; }
+
         public DetailViewData(Person currentPerson, Models.TreatmentBMP treatmentBMP, MapInitJson mapInitJson, ImageCarouselViewData imageCarouselViewData)
             : base(currentPerson, StormwaterBreadCrumbEntity.TreatmentBMP, null)
         {
@@ -67,7 +73,15 @@ namespace Neptune.Web.Views.TreatmentBMP
 
             AssessmentGridSpec = new TreatmentBMPAssessmentGridSpec(CurrentPerson);
             AssessmentGridName = "Assessment";
+
+            MaintenanceActivityGridSpec = new MaintenanceActivityGridSpec(CurrentPerson, treatmentBMP);
+            MaintenanceActivityGridName = "Maintenance Activity";
+
             AssessmentGridDataUrl = SitkaRoute<TreatmentBMPAssessmentController>.BuildUrlFromExpression(t => t.AssessmentGridJsonData(treatmentBMP));
+            MaintenanceActivityGridUrl =
+                SitkaRoute<MaintenanceActivityController>.BuildUrlFromExpression(c =>
+                    c.MaintenanceActivitysGridJsonData(treatmentBMP));
+            NewMaintenanceActivityUrl = SitkaRoute<MaintenanceActivityController>.BuildUrlFromExpression(c => c.New(treatmentBMP));
             NewTreatmentBMPDocumentUrl = SitkaRoute<TreatmentBMPDocumentController>.BuildUrlFromExpression(t => t.New(treatmentBMP));
             NewTreatmentBMPImageUrl = SitkaRoute<TreatmentBMPImageController>.BuildUrlFromExpression(c => c.New(treatmentBMP));
             EditTreatmentBMPImagesUrl = SitkaRoute<TreatmentBMPImageController>.BuildUrlFromExpression(c => c.Edit(treatmentBMP));


### PR DESCRIPTION
Implements the ability to add short records of maintenance activities to Treatment BMPs and display them in a panel on the Treatment BMP detail page. Having manage permissions for a BMP will let you add, edit, and delete maintenance activity records on that BMP.