### PR TITLE
[neptune/#77] Remove Copyright info from footer

### DIFF
--- a/Database/LookupTables/dbo.NeptunePageType.sql
+++ b/Database/LookupTables/dbo.NeptunePageType.sql
@@ -21,4 +21,5 @@ values
 (16, 'ManageTreatmentBMPTypeInstructions', 'Manage Treatment BMP Type Instructions', 2),
 (17, 'ManageTreatmentBMPAttributeTypeInstructions', 'Manage Treatment BMP Attribute Type Instructions', 2),
 (18, 'ManageTreatmentBMPAttributeInstructions', 'Manage Treatment BMP Attribute Instructions', 2),
-(19, 'ManageTreatmentBMPAttributeTypesList', 'Manage Treatment BMP Attribute Types List', 2)
+(19, 'ManageTreatmentBMPAttributeTypesList', 'Manage Treatment BMP Attribute Types List', 2),
+(20, 'Legal', 'Legal', 2)

--- a/Database/ReleaseScript/019 - adding legal.sql
+++ b/Database/ReleaseScript/019 - adding legal.sql
@@ -1,0 +1,18 @@
+insert into dbo.NeptunePageType(NeptunePageTypeID, NeptunePageTypeName, NeptunePageTypeDisplayName, NeptunePageRenderTypeID)
+values
+(20, 'Legal', 'Legal', 2)
+
+insert into dbo.NeptunePage(NeptunePageTypeID, NeptunePageContent, TenantID)
+values
+(20, '<p>
+	The Stormwater Tools application is built by <a href="http://www.sitkatech.com/">Sitka Technology Group</a> in partnership with <a href="https://www.geosyntec.com/">Geosyntec Consultants</a> for <a href="http://www.ocpublicworks.com/">Orange County Public Works</a>.
+	The Stormwater Tools application is derived from the <a href="http://www.trpa.org/">Tahoe Regional Planning Agency</a>''s Lake Tahoe Info Stormwater Tools.
+</p>
+<p>
+	This program is free software; you can redistribute it and/or modify it under the terms of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License</a> as published by the Free Software Foundation.
+	Source code is available on <a href="http://github.com/sitkatech/neptune/">GitHub</a>.
+</p>
+<p>
+	Copyright &copy; <a href="http://www.trpa.org/">Tahoe Regional Planning Agency</a> and <a href="http://www.sitkatech.com/">Sitka Technology Group</a>
+</p>
+', 2)

--- a/Source/Neptune.Web/Controllers/HomeController.cs
+++ b/Source/Neptune.Web/Controllers/HomeController.cs
@@ -106,6 +106,15 @@ namespace Neptune.Web.Controllers
         }
 
         [HttpGet]
+        [Route("Legal")]
+        [AnonymousUnclassifiedFeature]
+        public ViewResult Legal()
+        {
+            var con = new HomeController {ControllerContext = ControllerContext};
+            return con.ViewPageContent(NeptunePageTypeEnum.Legal);
+        }
+
+        [HttpGet]
         [NeptuneAdminFeature]
         public ViewResult ManageHomePageImages()
         {

--- a/Source/Neptune.Web/Models/Generated/NeptunePageType.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/NeptunePageType.Binding.cs
@@ -37,6 +37,7 @@ namespace Neptune.Web.Models
         public static readonly NeptunePageTypeManageTreatmentBMPAttributeTypeInstructions ManageTreatmentBMPAttributeTypeInstructions = NeptunePageTypeManageTreatmentBMPAttributeTypeInstructions.Instance;
         public static readonly NeptunePageTypeManageTreatmentBMPAttributeInstructions ManageTreatmentBMPAttributeInstructions = NeptunePageTypeManageTreatmentBMPAttributeInstructions.Instance;
         public static readonly NeptunePageTypeManageTreatmentBMPAttributeTypesList ManageTreatmentBMPAttributeTypesList = NeptunePageTypeManageTreatmentBMPAttributeTypesList.Instance;
+        public static readonly NeptunePageTypeLegal Legal = NeptunePageTypeLegal.Instance;
 
         public static readonly List<NeptunePageType> All;
         public static readonly ReadOnlyDictionary<int, NeptunePageType> AllLookupDictionary;
@@ -46,7 +47,7 @@ namespace Neptune.Web.Models
         /// </summary>
         static NeptunePageType()
         {
-            All = new List<NeptunePageType> { HomePage, About, OrganizationsList, HomeMapInfo, HomeAdditionalInfo, TreatmentBMP, TreatmentBMPType, ModeledCatchment, Jurisdiction, Assessment, ManageObservationTypesList, ManageTreatmentBMPTypesList, ManageObservationTypeInstructions, ManageObservationTypeObservationInstructions, ManageObservationTypeLabelsAndUnitsInstructions, ManageTreatmentBMPTypeInstructions, ManageTreatmentBMPAttributeTypeInstructions, ManageTreatmentBMPAttributeInstructions, ManageTreatmentBMPAttributeTypesList };
+            All = new List<NeptunePageType> { HomePage, About, OrganizationsList, HomeMapInfo, HomeAdditionalInfo, TreatmentBMP, TreatmentBMPType, ModeledCatchment, Jurisdiction, Assessment, ManageObservationTypesList, ManageTreatmentBMPTypesList, ManageObservationTypeInstructions, ManageObservationTypeObservationInstructions, ManageObservationTypeLabelsAndUnitsInstructions, ManageTreatmentBMPTypeInstructions, ManageTreatmentBMPAttributeTypeInstructions, ManageTreatmentBMPAttributeInstructions, ManageTreatmentBMPAttributeTypesList, Legal };
             AllLookupDictionary = new ReadOnlyDictionary<int, NeptunePageType>(All.ToDictionary(x => x.NeptunePageTypeID));
         }
 
@@ -130,6 +131,8 @@ namespace Neptune.Web.Models
                     return HomePage;
                 case NeptunePageTypeEnum.Jurisdiction:
                     return Jurisdiction;
+                case NeptunePageTypeEnum.Legal:
+                    return Legal;
                 case NeptunePageTypeEnum.ManageObservationTypeInstructions:
                     return ManageObservationTypeInstructions;
                 case NeptunePageTypeEnum.ManageObservationTypeLabelsAndUnitsInstructions:
@@ -182,7 +185,8 @@ namespace Neptune.Web.Models
         ManageTreatmentBMPTypeInstructions = 16,
         ManageTreatmentBMPAttributeTypeInstructions = 17,
         ManageTreatmentBMPAttributeInstructions = 18,
-        ManageTreatmentBMPAttributeTypesList = 19
+        ManageTreatmentBMPAttributeTypesList = 19,
+        Legal = 20
     }
 
     public partial class NeptunePageTypeHomePage : NeptunePageType
@@ -297,5 +301,11 @@ namespace Neptune.Web.Models
     {
         private NeptunePageTypeManageTreatmentBMPAttributeTypesList(int neptunePageTypeID, string neptunePageTypeName, string neptunePageTypeDisplayName, int neptunePageRenderTypeID) : base(neptunePageTypeID, neptunePageTypeName, neptunePageTypeDisplayName, neptunePageRenderTypeID) {}
         public static readonly NeptunePageTypeManageTreatmentBMPAttributeTypesList Instance = new NeptunePageTypeManageTreatmentBMPAttributeTypesList(19, @"ManageTreatmentBMPAttributeTypesList", @"Manage Treatment BMP Attribute Types List", 2);
+    }
+
+    public partial class NeptunePageTypeLegal : NeptunePageType
+    {
+        private NeptunePageTypeLegal(int neptunePageTypeID, string neptunePageTypeName, string neptunePageTypeDisplayName, int neptunePageRenderTypeID) : base(neptunePageTypeID, neptunePageTypeName, neptunePageTypeDisplayName, neptunePageRenderTypeID) {}
+        public static readonly NeptunePageTypeLegal Instance = new NeptunePageTypeLegal(20, @"Legal", @"Legal", 2);
     }
 }

--- a/Source/Neptune.Web/Views/NeptuneViewData.cs
+++ b/Source/Neptune.Web/Views/NeptuneViewData.cs
@@ -20,7 +20,6 @@ Source code is available upon request via <support@sitkatech.com>.
 -----------------------------------------------------------------------*/
 using System.Collections.Generic;
 using System.Linq;
-using LtInfo.Common;
 using Neptune.Web.Common;
 using Neptune.Web.Controllers;
 using Neptune.Web.Models;
@@ -45,6 +44,7 @@ namespace Neptune.Web.Views
         public readonly string LogInUrl;
         public readonly string LogOutUrl;
         public readonly string RequestSupportUrl;
+        public readonly string LegalUrl;
         public readonly ViewPageContentViewData ViewPageContentViewData;
 
         /// <summary>
@@ -69,19 +69,20 @@ namespace Neptune.Web.Views
 
             RequestSupportUrl = SitkaRoute<HelpController>.BuildUrlFromExpression(c => c.Support());
 
+            LegalUrl = SitkaRoute<HomeController>.BuildUrlFromExpression(c => c.Legal());
+
             MakeNeptuneMenu(currentPerson);
 
             ViewPageContentViewData = neptunePage != null ? new ViewPageContentViewData(neptunePage, currentPerson) : null;
         }
 
-        protected NeptuneViewData(Person currentPerson, StormwaterBreadCrumbEntity stormwaterBreadCrumbEntity, Models.NeptunePage neptunePage) : this(currentPerson, neptunePage)
+        protected NeptuneViewData(Person currentPerson, StormwaterBreadCrumbEntity stormwaterBreadCrumbEntity,
+            Models.NeptunePage neptunePage) : this(currentPerson, neptunePage)
         {
-            
         }
 
         protected NeptuneViewData(Person currentPerson, StormwaterBreadCrumbEntity stormwaterBreadCrumbEntity) : this(currentPerson)
         {
-
         }
 
         private void MakeNeptuneMenu(Person currentPerson)
@@ -149,14 +150,10 @@ namespace Neptune.Web.Views
             {
                 return $" | {BreadCrumbTitle}";
             }
-            else if (!string.IsNullOrWhiteSpace(PageTitle))
-            {
-                return $" | {PageTitle}";
-            }
-            else
-            {
-                return string.Empty;
-            }
+
+            return !string.IsNullOrWhiteSpace(PageTitle)
+                ? $" | {PageTitle}"
+                : string.Empty;
         }
     }
 }

--- a/Source/Neptune.Web/Views/Shared/NavAndHeaderLayout.cshtml
+++ b/Source/Neptune.Web/Views/Shared/NavAndHeaderLayout.cshtml
@@ -124,7 +124,7 @@ Source code is available upon request via <support@sitkatech.com>.
                 Disclaimers, copyright, and source code are available <a href="@ViewDataTyped.LegalUrl">here</a>.
             </p>
             <p class="text-center">
-                Copyright &copy; <a href="http://trpa.org">Tahoe Regional Planning Agency</a> and <a href="http://www.sitkatech.com">Sitka Technology Group</a> | Version @NeptuneWebConfiguration.WebApplicationVersionInfo.Value.ApplicationVersion | Compiled @NeptuneWebConfiguration.WebApplicationVersionInfo.Value.DateCompiled.ToString("yyyy-MM-dd HH:mm:ss") | PID @Process.GetCurrentProcess().Id
+                Version @NeptuneWebConfiguration.WebApplicationVersionInfo.Value.ApplicationVersion | Compiled @NeptuneWebConfiguration.WebApplicationVersionInfo.Value.DateCompiled.ToString("yyyy-MM-dd HH:mm:ss") | PID @Process.GetCurrentProcess().Id
             </p>
 
         </div>

--- a/Source/Neptune.Web/Views/Shared/NavAndHeaderLayout.cshtml
+++ b/Source/Neptune.Web/Views/Shared/NavAndHeaderLayout.cshtml
@@ -120,12 +120,11 @@ Source code is available upon request via <support@sitkatech.com>.
     <footer id="footer">
         <div class="container">
             <p class="text-center">
-                The @MultiTenantHelpers.GetTenantDisplayName() application is built by <a href="http://sitkatech.com/">Sitka Technology Group</a> for Orange County Public Works. The @MultiTenantHelpers.GetTenantDisplayName() application is derived from the Tahoe Regional Planning Agency's <a href="https://stormwater.laketahoeinfo.org">Lake Tahoe Info Stormwater Tools</a>.
                 This program is free software; you can redistribute it and/or modify it under the terms of the <a href="https://www.gnu.org/licenses/agpl-3.0.html">GNU Affero General Public License</a> as published by the <a href="https://www.fsf.org/">Free Software Foundation</a>.
-                Source code is available on <a href="https://github.com/sitkatech/neptune">GitHub</a>.
+                Disclaimers, copyright, and source code are available <a href="@ViewDataTyped.LegalUrl">here</a>.
             </p>
             <p class="text-center">
-                Copyright (C) <a href="http://trpa.org">Tahoe Regional Planning Agency</a> and <a href="http://www.sitkatech.com">Sitka Technology Group</a> | Version @NeptuneWebConfiguration.WebApplicationVersionInfo.Value.ApplicationVersion | Compiled @NeptuneWebConfiguration.WebApplicationVersionInfo.Value.DateCompiled.ToString("yyyy-MM-dd HH:mm:ss") | PID @Process.GetCurrentProcess().Id
+                Copyright &copy; <a href="http://trpa.org">Tahoe Regional Planning Agency</a> and <a href="http://www.sitkatech.com">Sitka Technology Group</a> | Version @NeptuneWebConfiguration.WebApplicationVersionInfo.Value.ApplicationVersion | Compiled @NeptuneWebConfiguration.WebApplicationVersionInfo.Value.DateCompiled.ToString("yyyy-MM-dd HH:mm:ss") | PID @Process.GetCurrentProcess().Id
             </p>
 
         </div>


### PR DESCRIPTION
Moving legal content to its own page

+ New Neptune Page Type: Legal
+ Made new page for legal content with explicit route
+ Legal page content driven by new Legal Neptune Page Type
+ Updated existing footer to reference Legal page