### PR TITLE
[neptune/#146] Verify BMP Inventory

### DIFF
--- a/Source/Neptune.Web/Controllers/TreatmentBMPController.cs
+++ b/Source/Neptune.Web/Controllers/TreatmentBMPController.cs
@@ -180,6 +180,7 @@ namespace Neptune.Web.Controllers
             }
 
             var treatmentBMP = treatmentBMPPrimaryKey.EntityObject;
+            treatmentBMP.MarkInventoryAsProvisionalIfNonManager(CurrentPerson);
             viewModel.UpdateModel(treatmentBMP, CurrentPerson);
 
             SetMessageForDisplay("Treatment BMP successfully saved.");


### PR DESCRIPTION
[neptune/#146] Verify BMP Inventory

* Fixed so when editor edits the Basics panel on the TreatmentBMP Details page, the BMP changes from verified