### PR TITLE
[neptune/#129] Enable searching by Address on the WQMP Parcel Picker

### DIFF
--- a/Source/Neptune.Web/Views/Parcel/Index.cshtml
+++ b/Source/Neptune.Web/Views/Parcel/Index.cshtml
@@ -113,6 +113,8 @@ Source code is available upon request via <support@sitkatech.com>.
                     }
                 });
 
+                displayName = displayName === 'Parcels' ? 'Parcel Numbers' : 'Addresses';
+
                 return {
                     name: name,
                     source: bloodhound,


### PR DESCRIPTION
* Changed “Parcels” to “Parcel Numbers”