### PR TITLE
Features/150 manager dashboard showing bmps and field visits requiring approval

### DIFF
--- a/Source/Neptune.Web/Controllers/HomeController.cs
+++ b/Source/Neptune.Web/Controllers/HomeController.cs
@@ -167,11 +167,11 @@ namespace Neptune.Web.Controllers
             string managerDashboardDescription = null;
             if (provisionalBMPRecordCount > 0)
             {
-                managerDashboardDescription = $"There are {provisionalBMPRecordCount} provisional BMP records";
+                managerDashboardDescription = $"There are <strong>{provisionalBMPRecordCount} provisional BMP records</strong>";
                 if (provisionalFieldVisitCount > 0)
                 {
                     managerDashboardDescription +=
-                        "and " + provisionalFieldVisitCount + " Assessment and Maintenance Records Added during a Field Visit";
+                        $" and <strong>{provisionalFieldVisitCount} Provisional Assessment and Maintenance Records</strong>";
                 }
 
                 managerDashboardDescription += " waiting for your verification.";

--- a/Source/Neptune.Web/Views/Home/LaunchPad.cshtml
+++ b/Source/Neptune.Web/Views/Home/LaunchPad.cshtml
@@ -180,6 +180,16 @@
                     </div>
                 </div>
             </div>
+            <div class="col-xs-12 col-sm-6 launchPadAction">
+                <div class="row">
+                    <div class="col-xs-6 col-md-5 col-lg-4">
+                        <a href="@ViewDataTyped.ManagerDashboardUrl" class="btn btn-neptune launchPadActionButton" style="word-wrap: break-word; white-space: pre-wrap;">View Manager Dashboard</a>
+                    </div>
+                    <div class="col-xs-6 col-md-7 col-lg-8">
+                        View and verify provisional records
+                    </div>
+                </div>
+            </div>
         }
     </div>
     { ViewPageContent.RenderPartialView(Html, ViewDataTyped.LaunchPadViewPageContentViewData); }

--- a/Source/Neptune.Web/Views/Home/LaunchPad.cshtml
+++ b/Source/Neptune.Web/Views/Home/LaunchPad.cshtml
@@ -1,4 +1,5 @@
-﻿@using LtInfo.Common.ModalDialog
+﻿@using LtInfo.Common
+@using LtInfo.Common.ModalDialog
 @using Neptune.Web.Models
 @using Neptune.Web.Views.Home
 @using Neptune.Web.Views.Shared
@@ -75,7 +76,7 @@
                 {
                     <div class="alert alert-info" role="alert">
                         <span class="glyphicon glyphicon-info-sign"></span>
-                        <span>@ViewDataTyped.ManagerDashboardDescription
+                        <span>@ViewDataTyped.ManagerDashboardDescription.ToHTMLFormattedString()
                             <a href="@ViewDataTyped.ManagerDashboardUrl" class="alert-link">Go to the Manager Dashboard</a>.</span>
                     </div>
                 }

--- a/Source/Neptune.Web/Views/ManagerDashboard/Index.cshtml
+++ b/Source/Neptune.Web/Views/ManagerDashboard/Index.cshtml
@@ -34,7 +34,7 @@
     <div class="col-xs-12 col-sm-12">
         <div class="panel panelNeptune">
             <div class="panel-heading panelTitle">
-                Assessment and Maintenance Records Added during a Field Visit
+                Provisional Assessment and Maintenance Records
             </div>
             <div class="panel-body">
                 @if (ViewDataTyped.FieldVisitCount > 0)


### PR DESCRIPTION
[neptune/#150] Manager dashboard showing BMPs and Field Visits requiring approval

* Changed the text “Assessment and Maintenance Added during a Field Visit” to be “Provisional Assessment and Maintenance Records” on the Manager Dashboard and on the homepage alert
* On the homepage alert, bold the count and record text
* On the homepage alert, make sure there are spaces between words
* On the homepage, add to the Admin Task list, a button for “View Manager Dashboard”, with description text “View and verify provisional records”
