### PR TITLE
[neptune/#160] Pre-populate post maintenance assessment from initial …

### DIFF
--- a/Source/Neptune.Web/Views/FieldVisit/Observations.cshtml
+++ b/Source/Neptune.Web/Views/FieldVisit/Observations.cshtml
@@ -19,6 +19,7 @@
     </license>
     -----------------------------------------------------------------------*@
 @using LtInfo.Common.BootstrapWrappers
+@using Neptune.Web.Controllers
 @using Neptune.Web.Views.FieldVisit
 @using Newtonsoft.Json
 @using Newtonsoft.Json.Linq
@@ -54,15 +55,18 @@
 
 <form method="POST" action="@ViewDataTyped.SubmitUrl" ng-app="NeptuneApp" id="ObservationsControllerApp" ng-controller="ObservationsController" ng-init="initializeData(AngularModel.Observations)" name="observationForm" class="field-visit-form">
     <div class="row observation-panel" ng-repeat="observationTypeSchema in AngularViewData.ObservationTypeSchemas">
-        <div ng-show="$first" style="background-color: #f9f9f9; text-align: right; padding-bottom: 16px;">
-            <button type="button" class="btn btn-neptune" ng-if="observationTypeSchema.InitialAssessmentObservations != null" ng-click="openCopyDataFromInitialAssessmentModal(observationTypeSchema.InitialAssessmentObservations)">
-                Copy Data from Initial Assessment
-            </button>
-            <button type="button" class="btn btn-neptune" ng-if="observationTypeSchema.InitialAssessmentObservations == null"
-                    title="No Pre-Maintenance Assessment data entered" disabled="disabled">
-                Copy Data from Initial Assessment
-            </button>
-        </div>
+        @if (ViewDataTyped.FieldVisitAssessmentType == FieldVisitAssessmentType.PostMaintenance)
+        {
+            <div ng-show="$first" style="background-color: #f9f9f9; text-align: right; padding-bottom: 16px;">
+                <button type="button" class="btn btn-neptune" ng-if="observationTypeSchema.InitialAssessmentObservations == null || observationTypeSchema.InitialAssessmentObservations.length == 0"
+                        title="No Pre-Maintenance Assessment data entered" disabled="disabled">
+                    Copy Data from Initial Assessment
+                </button>
+                <button type="button" class="btn btn-neptune" ng-if="observationTypeSchema.InitialAssessmentObservations != null && observationTypeSchema.InitialAssessmentObservations.length > 0" ng-click="openCopyDataFromInitialAssessmentModal(observationTypeSchema.InitialAssessmentObservations)">
+                    Copy Data from Initial Assessment
+                </button>
+            </div>
+        }
         <div class="col-xs-12">
             <h4 ng-bind="observationTypeSchema.TreatmentBMPAssessmentObservationTypeName"></h4>
         </div>

--- a/Source/Neptune.Web/Views/FieldVisit/ObservationsViewData.cs
+++ b/Source/Neptune.Web/Views/FieldVisit/ObservationsViewData.cs
@@ -33,13 +33,17 @@ namespace Neptune.Web.Views.FieldVisit
     public class ObservationsViewData : FieldVisitSectionViewData
     {
         public ObservationsViewDataForAngular ViewDataForAngular { get; }
-        public string SubmitUrl { get; }        
+        public string SubmitUrl { get; }    
+        public FieldVisitAssessmentType FieldVisitAssessmentType { get; set; }
 
         public ObservationsViewData(Models.FieldVisit fieldVisit, FieldVisitAssessmentType fieldVisitAssessmentType, Person currentPerson)
             : base(currentPerson, fieldVisit, fieldVisitAssessmentType == FieldVisitAssessmentType.Initial ? (Models.FieldVisitSection) Models.FieldVisitSection.Assessment : Models.FieldVisitSection.PostMaintenanceAssessment)
         {
             var initialAssessmentObservations = fieldVisit.InitialAssessment?.TreatmentBMPObservations.Select(x =>
                 new CollectionMethodSectionViewModel(x, x.TreatmentBMPAssessmentObservationType)).ToList();
+            SubsectionName = "Observations";
+            SectionHeader = "Observations";
+            FieldVisitAssessmentType = fieldVisitAssessmentType;
             ViewDataForAngular = new ObservationsViewDataForAngular(fieldVisit.TreatmentBMP.TreatmentBMPType, initialAssessmentObservations);
             SubmitUrl = SitkaRoute<FieldVisitController>.BuildUrlFromExpression(x => x.Observations(fieldVisit, (int)fieldVisitAssessmentType));
         }


### PR DESCRIPTION
[neptune/#160] Pre-populate post maintenance assessment from initial assessment

* Fixed Navigation menu on the side of the Field Visit Observations page show it highlights the page it is on
* Only show the "Copy Data from Initial Assessment" button on the post-assessment page
* If there are zero observations to move over from the initial assessments page, disabled the button on the post-assessment page