### PR TITLE
[neptune/#148] Allow Jurisdiction Manager to Bulk Verify BMP Inventory

### DIFF
--- a/Source/Neptune.Web/Models/TreatmentBMP.cs
+++ b/Source/Neptune.Web/Models/TreatmentBMP.cs
@@ -153,11 +153,6 @@ namespace Neptune.Web.Models
             InventoryLastChangedDate = DateTime.Now;
         }
 
-        public FieldVisit GetLastFieldVisitWithAnInventoryUpdate()
-        {
-            return FieldVisits.Where(y => y.InventoryUpdated).OrderByDescending(y => y.VisitDate).FirstOrDefault();
-        }
-
         public void MarkAsVerified(Person currentPerson)
         {
             InventoryIsVerified = true;

--- a/Source/Neptune.Web/Views/Shared/ProjectControls/BulkRowTreatmentBMP.cshtml
+++ b/Source/Neptune.Web/Views/Shared/ProjectControls/BulkRowTreatmentBMP.cshtml
@@ -47,7 +47,7 @@ else
                 <tr>
                     <th scope="col">BMP Name</th>
                     <th scope="col">Verified By</th>
-                    <th scope="col">Date Last Modified</th>
+                    <th scope="col">Date of Last Inventory Change</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -66,9 +66,9 @@ else
                             }
                         </td>
                         <td>
-                            @if (treatmentBMP.GetLastFieldVisitWithAnInventoryUpdate() != null)
+                            @if (treatmentBMP.InventoryLastChangedDate != null)
                             {
-                                <span>@treatmentBMP.GetLastFieldVisitWithAnInventoryUpdate().VisitDate</span>
+                                <span>@treatmentBMP.InventoryLastChangedDate</span>
                             }
                             else
                             {


### PR DESCRIPTION
[neptune/#148] Allow Jurisdiction Manager to Bulk Verify BMP Inventory

* Shows last updated date in the confirmation modal
* Changed text to say “Date of Last Inventory Change”
* Removed unneeded method