### PR TITLE
Features/182 bmp inventory export

### DIFF
--- a/Source/Neptune.Web/Controllers/TreatmentBMPController.cs
+++ b/Source/Neptune.Web/Controllers/TreatmentBMPController.cs
@@ -21,6 +21,7 @@ Source code is available upon request via <support@sitkatech.com>.
 
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -466,7 +467,9 @@ namespace Neptune.Web.Controllers
             var ogr2OgrCommandLineRunner = new Ogr2OgrCommandLineRunner(NeptuneWebConfiguration.Ogr2OgrExecutable,
                 Ogr2OgrCommandLineRunner.DefaultCoordinateSystemId,
                 NeptuneWebConfiguration.HttpRuntimeExecutionTimeout.TotalMilliseconds);
-            var treatmentBmps = HttpRequestStorage.DatabaseEntities.TreatmentBMPs.ToList().Where(x => x.CanView(CurrentPerson)).ToList();
+            var treatmentBmps = HttpRequestStorage.DatabaseEntities.TreatmentBMPs
+                .Include(x=>x.TreatmentBMPType).Include(x=>x.TreatmentBMPType.TreatmentBMPTypeCustomAttributeTypes).Include(x=>x.TreatmentBMPAssessments).Include(x=>x.WaterQualityManagementPlan).Include(x=>x.CustomAttributes)
+                .ToList().Where(x => x.CanView(CurrentPerson)).ToList();
             
             using (var workingDirectory = new DisposableTempDirectory())
             {

--- a/Source/Neptune.Web/Models/Generated/AuditLog.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/AuditLog.Binding.cs
@@ -107,7 +107,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllAuditLogs.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllAuditLogs.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/County.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/County.Binding.cs
@@ -91,7 +91,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllCounties.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllCounties.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/CustomAttribute.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/CustomAttribute.Binding.cs
@@ -102,12 +102,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in CustomAttributeValues.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllCustomAttributes.Remove(this);                
+            dbContext.AllCustomAttributes.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/CustomAttributeType.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/CustomAttributeType.Binding.cs
@@ -99,22 +99,30 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in CustomAttributes.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in MaintenanceRecordObservations.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPTypeCustomAttributeTypes.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllCustomAttributeTypes.Remove(this);                
+            dbContext.AllCustomAttributeTypes.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/CustomAttributeValue.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/CustomAttributeValue.Binding.cs
@@ -90,7 +90,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllCustomAttributeValues.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllCustomAttributeValues.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/FieldDefinitionData.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/FieldDefinitionData.Binding.cs
@@ -87,12 +87,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in FieldDefinitionDataImages.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllFieldDefinitionDatas.Remove(this);                
+            dbContext.AllFieldDefinitionDatas.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/FieldDefinitionDataImage.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/FieldDefinitionDataImage.Binding.cs
@@ -92,7 +92,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllFieldDefinitionDataImages.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllFieldDefinitionDataImages.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/FieldVisit.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/FieldVisit.Binding.cs
@@ -108,17 +108,25 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in MaintenanceRecords.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPAssessments.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllFieldVisits.Remove(this);                
+            dbContext.AllFieldVisits.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/FileResource.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/FileResource.Binding.cs
@@ -117,72 +117,80 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in FieldDefinitionDataImages.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in NeptuneHomePageImages.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in NeptunePageImages.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in OrganizationsWhereYouAreTheLogoFileResource.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TenantAttributesWhereYouAreTheTenantBannerLogoFileResource.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TenantAttributesWhereYouAreTheTenantSquareLogoFileResource.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TenantAttributesWhereYouAreTheTenantStyleSheetFileResource.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPAssessmentPhotos.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPDocuments.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPImages.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanDocuments.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanPhotos.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanVerifies.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllFileResources.Remove(this);                
+            dbContext.AllFileResources.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/FundingEvent.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/FundingEvent.Binding.cs
@@ -94,12 +94,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in FundingEventFundingSources.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllFundingEvents.Remove(this);                
+            dbContext.AllFundingEvents.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/FundingEventFundingSource.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/FundingEventFundingSource.Binding.cs
@@ -93,7 +93,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllFundingEventFundingSources.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllFundingEventFundingSources.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/FundingSource.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/FundingSource.Binding.cs
@@ -94,12 +94,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in FundingEventFundingSources.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllFundingSources.Remove(this);                
+            dbContext.AllFundingSources.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/HydrologicSubarea.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/HydrologicSubarea.Binding.cs
@@ -76,12 +76,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in WaterQualityManagementPlans.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllHydrologicSubareas.Remove(this);                
+            dbContext.AllHydrologicSubareas.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/MaintenanceRecord.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/MaintenanceRecord.Binding.cs
@@ -97,12 +97,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in MaintenanceRecordObservations.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllMaintenanceRecords.Remove(this);                
+            dbContext.AllMaintenanceRecords.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/MaintenanceRecordObservation.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/MaintenanceRecordObservation.Binding.cs
@@ -102,12 +102,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in MaintenanceRecordObservationValues.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllMaintenanceRecordObservations.Remove(this);                
+            dbContext.AllMaintenanceRecordObservations.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/MaintenanceRecordObservationValue.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/MaintenanceRecordObservationValue.Binding.cs
@@ -90,7 +90,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllMaintenanceRecordObservationValues.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllMaintenanceRecordObservationValues.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/ModeledCatchment.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/ModeledCatchment.Binding.cs
@@ -92,12 +92,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in TreatmentBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllModeledCatchments.Remove(this);                
+            dbContext.AllModeledCatchments.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/ModeledCatchmentGeometryStaging.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/ModeledCatchmentGeometryStaging.Binding.cs
@@ -97,7 +97,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllModeledCatchmentGeometryStagings.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllModeledCatchmentGeometryStagings.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/NeptuneHomePageImage.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/NeptuneHomePageImage.Binding.cs
@@ -93,7 +93,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllNeptuneHomePageImages.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllNeptuneHomePageImages.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/NeptunePage.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/NeptunePage.Binding.cs
@@ -86,12 +86,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in NeptunePageImages.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllNeptunePages.Remove(this);                
+            dbContext.AllNeptunePages.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/NeptunePageImage.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/NeptunePageImage.Binding.cs
@@ -92,7 +92,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllNeptunePageImages.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllNeptunePageImages.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/Notification.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/Notification.Binding.cs
@@ -93,7 +93,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllNotifications.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllNotifications.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/Organization.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/Organization.Binding.cs
@@ -101,27 +101,35 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in FundingSources.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in People.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in StormwaterJurisdictions.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPsWhereYouAreTheOwnerOrganization.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllOrganizations.Remove(this);                
+            dbContext.AllOrganizations.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/OrganizationType.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/OrganizationType.Binding.cs
@@ -82,12 +82,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in Organizations.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllOrganizationTypes.Remove(this);                
+            dbContext.AllOrganizationTypes.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/Parcel.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/Parcel.Binding.cs
@@ -87,12 +87,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in WaterQualityManagementPlanParcels.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllParcels.Remove(this);                
+            dbContext.AllParcels.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/Person.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/Person.Binding.cs
@@ -127,62 +127,70 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in AuditLogs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in FieldVisitsWhereYouAreThePerformedByPerson.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in FileResourcesWhereYouAreTheCreatePerson.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in ModeledCatchmentGeometryStagings.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in Notifications.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in OrganizationsWhereYouAreThePrimaryContactPerson.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in StormwaterJurisdictionPeople.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in SupportRequestLogsWhereYouAreTheRequestPerson.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TenantAttributesWhereYouAreThePrimaryContactPerson.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPsWhereYouAreTheInventoryVerifiedByPerson.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanVerifiesWhereYouAreTheLastEditedByPerson.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllPeople.Remove(this);                
+            dbContext.AllPeople.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/QuickBMP.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/QuickBMP.Binding.cs
@@ -96,12 +96,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in WaterQualityManagementPlanVerifyQuickBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllQuickBMPs.Remove(this);                
+            dbContext.AllQuickBMPs.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/SourceControlBMP.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/SourceControlBMP.Binding.cs
@@ -94,12 +94,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in WaterQualityManagementPlanVerifySourceControlBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllSourceControlBMPs.Remove(this);                
+            dbContext.AllSourceControlBMPs.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/SourceControlBMPAttribute.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/SourceControlBMPAttribute.Binding.cs
@@ -90,12 +90,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in SourceControlBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllSourceControlBMPAttributes.Remove(this);                
+            dbContext.AllSourceControlBMPAttributes.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/SourceControlBMPAttributeCategory.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/SourceControlBMPAttributeCategory.Binding.cs
@@ -78,12 +78,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in SourceControlBMPAttributes.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllSourceControlBMPAttributeCategories.Remove(this);                
+            dbContext.AllSourceControlBMPAttributeCategories.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/StateProvince.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/StateProvince.Binding.cs
@@ -82,17 +82,25 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in Counties.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in StormwaterJurisdictions.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllStateProvinces.Remove(this);                
+            dbContext.AllStateProvinces.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/StormwaterJurisdiction.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/StormwaterJurisdiction.Binding.cs
@@ -98,27 +98,35 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in ModeledCatchments.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in StormwaterJurisdictionPeople.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlans.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllStormwaterJurisdictions.Remove(this);                
+            dbContext.AllStormwaterJurisdictions.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/StormwaterJurisdictionPerson.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/StormwaterJurisdictionPerson.Binding.cs
@@ -92,7 +92,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllStormwaterJurisdictionPeople.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllStormwaterJurisdictionPeople.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/SupportRequestLog.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/SupportRequestLog.Binding.cs
@@ -100,7 +100,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllSupportRequestLogs.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllSupportRequestLogs.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TenantAttribute.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TenantAttribute.Binding.cs
@@ -90,7 +90,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllTenantAttributes.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllTenantAttributes.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TrainingVideo.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TrainingVideo.Binding.cs
@@ -79,7 +79,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllTrainingVideos.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllTrainingVideos.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMP.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMP.Binding.cs
@@ -124,52 +124,60 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in CustomAttributes.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in FieldVisits.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in FundingEvents.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in MaintenanceRecords.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPAssessments.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPBenchmarkAndThresholds.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPDocuments.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPImages.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanVerifyTreatmentBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPs.Remove(this);                
+            dbContext.AllTreatmentBMPs.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMPAssessment.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMPAssessment.Binding.cs
@@ -102,17 +102,25 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in TreatmentBMPAssessmentPhotos.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPObservations.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPAssessments.Remove(this);                
+            dbContext.AllTreatmentBMPAssessments.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMPAssessmentObservationType.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMPAssessmentObservationType.Binding.cs
@@ -93,22 +93,30 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in TreatmentBMPBenchmarkAndThresholds.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPObservations.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPTypeAssessmentObservationTypes.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPAssessmentObservationTypes.Remove(this);                
+            dbContext.AllTreatmentBMPAssessmentObservationTypes.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMPAssessmentPhoto.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMPAssessmentPhoto.Binding.cs
@@ -93,7 +93,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPAssessmentPhotos.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllTreatmentBMPAssessmentPhotos.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMPBenchmarkAndThreshold.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMPBenchmarkAndThreshold.Binding.cs
@@ -108,7 +108,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPBenchmarkAndThresholds.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllTreatmentBMPBenchmarkAndThresholds.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMPDocument.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMPDocument.Binding.cs
@@ -99,7 +99,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPDocuments.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllTreatmentBMPDocuments.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMPImage.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMPImage.Binding.cs
@@ -96,7 +96,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPImages.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllTreatmentBMPImages.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMPObservation.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMPObservation.Binding.cs
@@ -105,7 +105,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPObservations.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllTreatmentBMPObservations.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMPType.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMPType.Binding.cs
@@ -86,52 +86,60 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in CustomAttributes.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in MaintenanceRecordObservations.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in QuickBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPAssessments.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPBenchmarkAndThresholds.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPObservations.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPTypeAssessmentObservationTypes.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPTypeCustomAttributeTypes.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPTypes.Remove(this);                
+            dbContext.AllTreatmentBMPTypes.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMPTypeAssessmentObservationType.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMPTypeAssessmentObservationType.Binding.cs
@@ -100,17 +100,25 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in TreatmentBMPBenchmarkAndThresholds.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPObservations.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPTypeAssessmentObservationTypes.Remove(this);                
+            dbContext.AllTreatmentBMPTypeAssessmentObservationTypes.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/TreatmentBMPTypeCustomAttributeType.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/TreatmentBMPTypeCustomAttributeType.Binding.cs
@@ -94,17 +94,25 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in CustomAttributes.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in MaintenanceRecordObservations.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllTreatmentBMPTypeCustomAttributeTypes.Remove(this);                
+            dbContext.AllTreatmentBMPTypeCustomAttributeTypes.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlan.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlan.Binding.cs
@@ -122,37 +122,45 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in QuickBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in SourceControlBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in TreatmentBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanDocuments.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanParcels.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanVerifies.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlans.Remove(this);                
+            dbContext.AllWaterQualityManagementPlans.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanDocument.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanDocument.Binding.cs
@@ -102,7 +102,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanDocuments.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllWaterQualityManagementPlanDocuments.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanParcel.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanParcel.Binding.cs
@@ -92,7 +92,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanParcels.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllWaterQualityManagementPlanParcels.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanPhoto.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanPhoto.Binding.cs
@@ -91,12 +91,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in WaterQualityManagementPlanVerifyPhotos.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanPhotos.Remove(this);                
+            dbContext.AllWaterQualityManagementPlanPhotos.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerify.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerify.Binding.cs
@@ -115,27 +115,35 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in WaterQualityManagementPlanVerifyPhotos.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanVerifyQuickBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanVerifySourceControlBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
 
             foreach(var x in WaterQualityManagementPlanVerifyTreatmentBMPs.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanVerifies.Remove(this);                
+            dbContext.AllWaterQualityManagementPlanVerifies.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifyPhoto.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifyPhoto.Binding.cs
@@ -92,7 +92,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanVerifyPhotos.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllWaterQualityManagementPlanVerifyPhotos.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifyQuickBMP.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifyQuickBMP.Binding.cs
@@ -94,7 +94,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanVerifyQuickBMPs.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllWaterQualityManagementPlanVerifyQuickBMPs.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifySourceControlBMP.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifySourceControlBMP.Binding.cs
@@ -93,7 +93,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanVerifySourceControlBMPs.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllWaterQualityManagementPlanVerifySourceControlBMPs.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifyStatus.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifyStatus.Binding.cs
@@ -76,12 +76,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in WaterQualityManagementPlanVerifies.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanVerifyStatuses.Remove(this);                
+            dbContext.AllWaterQualityManagementPlanVerifyStatuses.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifyTreatmentBMP.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifyTreatmentBMP.Binding.cs
@@ -94,7 +94,15 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanVerifyTreatmentBMPs.Remove(this);                
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            dbContext.AllWaterQualityManagementPlanVerifyTreatmentBMPs.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifyType.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVerifyType.Binding.cs
@@ -76,12 +76,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in WaterQualityManagementPlanVerifies.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanVerifyTypes.Remove(this);                
+            dbContext.AllWaterQualityManagementPlanVerifyTypes.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVisitStatus.Binding.cs
+++ b/Source/Neptune.Web/Models/Generated/WaterQualityManagementPlanVisitStatus.Binding.cs
@@ -76,12 +76,20 @@ namespace Neptune.Web.Models
         /// </summary>
         public void DeleteFull()
         {
+            DeleteFull(HttpRequestStorage.DatabaseEntities);
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
 
             foreach(var x in WaterQualityManagementPlanVerifies.ToList())
             {
-                x.DeleteFull();
+                x.DeleteFull(dbContext);
             }
-            HttpRequestStorage.DatabaseEntities.AllWaterQualityManagementPlanVisitStatuses.Remove(this);                
+            dbContext.AllWaterQualityManagementPlanVisitStatuses.Remove(this);
         }
 
         [Key]

--- a/Source/Neptune.Web/Models/TreatmentBMPModelExtensions.cs
+++ b/Source/Neptune.Web/Models/TreatmentBMPModelExtensions.cs
@@ -22,6 +22,7 @@ Source code is available upon request via <support@sitkatech.com>.
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using GeoJSON.Net.Feature;
 using LtInfo.Common;
 using LtInfo.Common.GeoJson;
 using Neptune.Web.Common;
@@ -74,9 +75,9 @@ namespace Neptune.Web.Models
             return treatmentBMP == null ? new HtmlString(string.Empty) : UrlTemplate.MakeHrefString(DetailUrlTemplate.ParameterReplace(treatmentBMP.TreatmentBMPID), treatmentBMP.TreatmentBMPName);
         }
 
-        public static GeoJSON.Net.Feature.FeatureCollection ToGeoJsonFeatureCollection(this IEnumerable<TreatmentBMP> treatmentBMPs)
+        public static FeatureCollection ToGeoJsonFeatureCollection(this IEnumerable<TreatmentBMP> treatmentBMPs)
         {
-            var featureCollection = new GeoJSON.Net.Feature.FeatureCollection();
+            var featureCollection = new FeatureCollection();
             featureCollection.Features.AddRange(treatmentBMPs.Select(x =>
             {
                 var feature = DbGeometryToGeoJsonHelper.FromDbGeometry(x.LocationPoint);
@@ -92,9 +93,9 @@ namespace Neptune.Web.Models
             return featureCollection;
         }
 
-        public static GeoJSON.Net.Feature.FeatureCollection ToGeoJsonFeatureCollectionGeneric(this IEnumerable<TreatmentBMP> treatmentBMPs)
+        public static FeatureCollection ToGeoJsonFeatureCollectionGeneric(this IEnumerable<TreatmentBMP> treatmentBMPs)
         {
-            var featureCollection = new GeoJSON.Net.Feature.FeatureCollection();
+            var featureCollection = new FeatureCollection();
             featureCollection.Features.AddRange(treatmentBMPs.Select(x =>
             {
                 var feature = DbGeometryToGeoJsonHelper.FromDbGeometry(x.LocationPoint);
@@ -108,5 +109,35 @@ namespace Neptune.Web.Models
             return featureCollection;
         }
 
+        public static FeatureCollection ToExportGeoJsonFeatureCollection(
+            this IEnumerable<TreatmentBMP> treatmentBMPs)
+        {
+            var featureCollection = new FeatureCollection();
+            featureCollection.Features.AddRange(treatmentBMPs.Select(x =>
+            {
+                var feature = DbGeometryToGeoJsonHelper.FromDbGeometry(x.LocationPoint);
+                // TODO: plop the props
+                return feature;
+            }));
+            return featureCollection;
+        }
+
+        /// <summary>
+        /// Overload taking a TreatmentBMPType so it can access the Custom Attributes
+        /// </summary>
+        /// <param name="treatmentBMPs"></param>
+        /// <param name="treatmentBMPType"></param>
+        /// <returns></returns>
+        public static FeatureCollection ToExportGeoJsonFeatureCollection(this IEnumerable<TreatmentBMP> treatmentBMPs, TreatmentBMPType treatmentBMPType)
+        {
+            var featureCollection = new FeatureCollection();
+            featureCollection.Features.AddRange(treatmentBMPs.Select(x =>
+            {
+                var feature = DbGeometryToGeoJsonHelper.FromDbGeometry(x.LocationPoint);
+                // TODO: plop the props
+                return feature;
+            }));
+            return featureCollection;
+        }
     }
 }

--- a/Source/Neptune.Web/Models/TreatmentBMPModelExtensions.cs
+++ b/Source/Neptune.Web/Models/TreatmentBMPModelExtensions.cs
@@ -116,7 +116,7 @@ namespace Neptune.Web.Models
             featureCollection.Features.AddRange(treatmentBMPs.Select(x =>
             {
                 var feature = DbGeometryToGeoJsonHelper.FromDbGeometry(x.LocationPoint);
-                // TODO: plop the props
+                AddAllCommonPropertiesToTreatmentBMPFeature(feature, x);
                 return feature;
             }));
             return featureCollection;
@@ -134,10 +134,38 @@ namespace Neptune.Web.Models
             featureCollection.Features.AddRange(treatmentBMPs.Select(x =>
             {
                 var feature = DbGeometryToGeoJsonHelper.FromDbGeometry(x.LocationPoint);
-                // TODO: plop the props
+                AddAllCommonPropertiesToTreatmentBMPFeature(feature, x);
+                foreach (var ca in treatmentBMPType.TreatmentBMPTypeCustomAttributeTypes)
+                {
+                    feature.Properties.Add(ca.CustomAttributeType.CustomAttributeTypeName, x.GetCustomAttributeValueWithUnits(ca));
+                }
                 return feature;
             }));
             return featureCollection;
+        }
+
+        private static void AddAllCommonPropertiesToTreatmentBMPFeature(Feature feature, TreatmentBMP x)
+        {
+            feature.Properties.Add("Name", x.TreatmentBMPName);
+            feature.Properties.Add("Jurisdiction", x.StormwaterJurisdiction.GetOrganizationDisplayName());
+            feature.Properties.Add("Type", x.TreatmentBMPType.TreatmentBMPTypeName);
+            feature.Properties.Add("Owner", x.OwnerOrganization.GetDisplayName());
+            feature.Properties.Add("Year Built", x.YearBuilt);
+            feature.Properties.Add("ID in System of Record", x.SystemOfRecordID);
+            feature.Properties.Add("Water Quality Management Plan", x.WaterQualityManagementPlan?.WaterQualityManagementPlanName);
+            feature.Properties.Add("Notes", x.Notes);
+            feature.Properties.Add("Last Assessment Date", x.GetMostRecentAssessment()?.GetAssessmentDate());
+            feature.Properties.Add("Last Assessed Score", x.GetMostRecentScoreAsString());
+            feature.Properties.Add("Number of Assessments", x.TreatmentBMPAssessments.Count);
+            feature.Properties.Add("Benchmark and Threshold Set?", x.IsBenchmarkAndThresholdsComplete().ToYesNo());
+            feature.Properties.Add("Required Lifespan of Installation",
+                x.TreatmentBMPLifespanType?.TreatmentBMPLifespanTypeDisplayName ?? "Unknown");
+            feature.Properties.Add("Lifespan End Date (if Fixed End Date)", x.TreatmentBMPLifespanEndDate);
+            feature.Properties.Add(FieldDefinition.RequiredFieldVisitsPerYear.GetFieldDefinitionLabel(),
+                x.RequiredFieldVisitsPerYear);
+            feature.Properties.Add(
+                FieldDefinition.RequiredPostStormFieldVisitsPerYear.GetFieldDefinitionLabel(),
+                x.RequiredPostStormFieldVisitsPerYear);
         }
     }
 }

--- a/Source/Neptune.Web/Views/TreatmentBMP/Index.cshtml
+++ b/Source/Neptune.Web/Views/TreatmentBMP/Index.cshtml
@@ -24,6 +24,7 @@
 @using LtInfo.Common.BootstrapWrappers
 @using LtInfo.Common.DhtmlWrappers
 @using LtInfo.Common.HtmlHelperExtensions
+@using LtInfo.Common.ModalDialog
 @using Newtonsoft.Json
 @using Newtonsoft.Json.Linq
 @inherits Neptune.Web.Views.TreatmentBMP.Index
@@ -39,6 +40,7 @@
     {
         <a class="btn btn-neptune headerButtonText treatmentBMPButton" href="@ViewDataTyped.NewUrl">@BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-plus") Add Treatment BMP</a>
     }
+    <button class="btn btn-neptune" onclick="createDownloadConfirmDialog()"><span class="glyphicon glyphicon-map-marker"></span>Export Inventory to GIS</button>
 }
 
 @{ ViewPageContent.RenderPartialView(Html, ViewDataTyped.ViewPageContentViewData); }
@@ -55,3 +57,29 @@
         </div>
     </div>
 </div>
+
+<script>
+    function createDownloadConfirmDialog()
+    {         
+        var alertHtml =
+            "<div class='modal neptune-modal' style='width: 500px; margin:auto;'>" +
+                "<div class='modal-dialog neptune-modal-dialog'>" +
+                "<div class='modal-content'>" +
+                "<div class='modal-header'>" +
+                "<button type='button' class='btn btn-xs btn-neptune modal-close-button' data-dismiss='modal'><span>&times</span></button>" +
+                "<span class='modal-title'>Export Inventory to GIS</span>" +
+                "</div>" +
+                "<div class='modal-body'>This will download the BMP Inventory to your computer as a collection of shapefiles. " +
+                "The download process may take several minutes. Please do not close your browser or navigate to a different page until the download is complete.</div>" +
+            "<div class='modal-footer'>" +
+            "<button type='button' class='btn btn-neptune pull-right' data-dismiss='modal'>Cancel</button>" +
+                "<a class='btn btn-neptune pull-right' style='margin-right:5px;' href='@ViewDataTyped.DownloadBMPInventoryUrl'>Continue</a>" +
+                "</div>" +
+                "</div>" +
+                "</div>" +
+                "</div>";
+        var alertDiv = jQuery(alertHtml);
+        alertDiv.modal({ keyboard: true });
+        alertDiv.draggable({ handle: ".modal-header" });
+    }
+</script>

--- a/Source/Neptune.Web/Views/TreatmentBMP/Index.cshtml
+++ b/Source/Neptune.Web/Views/TreatmentBMP/Index.cshtml
@@ -70,10 +70,10 @@
                 "<span class='modal-title'>Export Inventory to GIS</span>" +
                 "</div>" +
                 "<div class='modal-body'>This will download the BMP Inventory to your computer as a collection of shapefiles. " +
-                "The download process may take several minutes. Please do not close your browser or navigate to a different page until the download is complete.</div>" +
+                "This will open a new tab and may take several minutes. Please do not close your browser or the new tab until the download is complete.</div>" +
             "<div class='modal-footer'>" +
             "<button type='button' class='btn btn-neptune pull-right' data-dismiss='modal'>Cancel</button>" +
-                "<a class='btn btn-neptune pull-right' style='margin-right:5px;' href='@ViewDataTyped.DownloadBMPInventoryUrl'>Continue</a>" +
+                "<a class='btn btn-neptune pull-right' style='margin-right:5px;' href='@ViewDataTyped.DownloadBMPInventoryUrl' target='_blank' data-dismiss='modal'>Continue</a>" +
                 "</div>" +
                 "</div>" +
                 "</div>" +

--- a/Source/Neptune.Web/Views/TreatmentBMP/IndexViewData.cs
+++ b/Source/Neptune.Web/Views/TreatmentBMP/IndexViewData.cs
@@ -13,6 +13,7 @@ namespace Neptune.Web.Views.TreatmentBMP
         public string GridDataUrl { get; }
         public string NewUrl { get; }
         public bool HasManagePermissions { get; }
+        public string DownloadBMPInventoryUrl { get; }
 
         public IndexViewData(Person currentPerson, Models.NeptunePage neptunePage)
             : base(currentPerson, StormwaterBreadCrumbEntity.TreatmentBMP, neptunePage)
@@ -26,6 +27,8 @@ namespace Neptune.Web.Views.TreatmentBMP
             GridDataUrl = SitkaRoute<TreatmentBMPController>.BuildUrlFromExpression(j => j.TreatmentBMPGridJsonData());
             NewUrl = SitkaRoute<TreatmentBMPController>.BuildUrlFromExpression(x => x.New());
             HasManagePermissions = new JurisdictionManageFeature().HasPermissionByPerson(currentPerson);
+            DownloadBMPInventoryUrl =
+                SitkaRoute<TreatmentBMPController>.BuildUrlFromExpression(x => x.BMPInventoryExport());
         }
     }
 }

--- a/Source/Neptune.Web/Views/TreatmentBMP/TreatmentBMPMapController.js
+++ b/Source/Neptune.Web/Views/TreatmentBMP/TreatmentBMPMapController.js
@@ -15,6 +15,7 @@
         var summaryUrl = $scope.AngularViewData.FindTreatmentBMPByNameUrl;
 
         $scope.neptuneMap = new NeptuneMaps.Map($scope.AngularViewData.MapInitJson);
+        console.log($scope.AngularViewData.MapInitJson.SearchableLayerGeoJson.GeoJsonFeatureCollection);
 
         $scope.typeaheadSearch = function (typeaheadSelector, typeaheadSelectorButton, summaryUrl) {
             $scope.typeaheadSelector = typeaheadSelector;


### PR DESCRIPTION
-Enables downloading a collection of shapefiles containing all the treatment bmp records that are visible to the user.
-Produces a separate shapefile for each treatment bmp type so that custom attributes can be carried down. -Makes this feature available via a button on the treatment bmp index page that pops a confirm dialog reminding the user not to close the download tab.