### PR TITLE
Features/330 flag delineations as verified or provisional

### DIFF
--- a/Source/Neptune.Web/Controllers/DelineationController.cs
+++ b/Source/Neptune.Web/Controllers/DelineationController.cs
@@ -179,13 +179,13 @@ namespace Neptune.Web.Controllers
                 return ViewDeleteDelineation(delineation, viewModel);
             }
             delineation.DeleteFull(HttpRequestStorage.DatabaseEntities);
-            SetMessageForDisplay("Successfully deleted the field visit.");
+            SetMessageForDisplay("Successfully deleted the delineation.");
             return new ModalDialogFormJsonResult(SitkaRoute<ManagerDashboardController>.BuildUrlFromExpression(c => c.Index()));
         }
 
         private PartialViewResult ViewDeleteDelineation(Delineation delineation, ConfirmDialogFormViewModel viewModel)
         {
-            var confirmMessage = $"Are you sure you want to delete the delineation '{delineation.DelineationID}' from '{delineation.TreatmentBMP.TreatmentBMPName}'?";
+            var confirmMessage = $"Are you sure you want to delete the delineation for '{delineation.TreatmentBMP.TreatmentBMPName}'?";
 
             var viewData = new ConfirmDialogFormViewData(confirmMessage, true);
             return RazorPartialView<ConfirmDialogForm, ConfirmDialogFormViewData, ConfirmDialogFormViewModel>(viewData, viewModel);

--- a/Source/Neptune.Web/Views/Delineation/DelineationMap.js
+++ b/Source/Neptune.Web/Views/Delineation/DelineationMap.js
@@ -231,6 +231,7 @@ NeptuneMaps.DelineationMap.prototype.exitDrawCatchmentMode = function (save) {
         
         // this is where to set the UI back to showing "Provisional" instead of "Verified"
         this.selectedAssetControl.flipVerifyButton(false);
+        this.selectedAssetControl.showVerifyButton();
         // returns a promise but there's no need to actually do anything with it
         this.persistDrawnCatchment();
     }

--- a/Source/Neptune.Web/Views/Delineation/DelineationMapControls.js
+++ b/Source/Neptune.Web/Views/Delineation/DelineationMapControls.js
@@ -69,6 +69,7 @@ L.Control.DelineationMapSelectedAsset = L.Control.TemplatedControl.extend({
 
         if (treatmentBMPFeature.properties.DelineationURL) {
             this.getTrackedElement("delineationType").innerHTML = treatmentBMPFeature.properties.DelineationType;
+            this.getTrackedElement("delineationStatus").style.display = "initial";
         } else {
             this.getTrackedElement("delineationType").innerHTML = "No delineation provided";
             this.getTrackedElement("delineationStatus").style.display = "none";
@@ -78,6 +79,7 @@ L.Control.DelineationMapSelectedAsset = L.Control.TemplatedControl.extend({
         this._noAssetSelected.classList.add("hiddenControlElement");
 
         $('#verifyDelineationButton').bootstrapToggle({
+            onstyle: 'btn btn-neptune'
         });
 
         var self = this;
@@ -141,6 +143,10 @@ L.Control.DelineationMapSelectedAsset = L.Control.TemplatedControl.extend({
         } else {
             jQuery(this.getTrackedElement("verifyDelineationButton")).data('bs.toggle').on(true);
         }
+    },
+
+    showVerifyButton() {
+        this.getTrackedElement("delineationStatus").style.display = "initial";
     }
 });
 

--- a/Source/Neptune.Web/Views/ManagerDashboard/ProvisionalBMPDelineationsGridSpec.cs
+++ b/Source/Neptune.Web/Views/ManagerDashboard/ProvisionalBMPDelineationsGridSpec.cs
@@ -52,7 +52,7 @@ namespace Neptune.Web.Views.ManagerDashboard
             Add("BMP Name", x => x.TreatmentBMP.GetDisplayNameAsUrl(), 120, DhtmlxGridColumnFilterType.Html);
             Add("BMP Type", x => x.TreatmentBMP.TreatmentBMPType.TreatmentBMPTypeName, 125, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add("Delineation Type", x => x.TreatmentBMP.Delineation.DelineationType.DelineationTypeDisplayName,80, DhtmlxGridColumnFilterType.SelectFilterStrict);
-            Add("Delineation Area (to 1/100th acre)", x => x.TreatmentBMP.Delineation?.GetDelineationAreaString(), 50,
+            Add("Delineation Area", x => x.TreatmentBMP.Delineation?.GetDelineationAreaString(), 50,
                 DhtmlxGridColumnFilterType.Text);
             Add("Date of Last Delineation Verification", x => x.TreatmentBMP.Delineation?.DateLastVerified, 120,
                 DhtmlxGridColumnFormatType.Date);

--- a/Source/Neptune.Web/Views/TreatmentBMP/Detail.cshtml
+++ b/Source/Neptune.Web/Views/TreatmentBMP/Detail.cshtml
@@ -356,7 +356,7 @@
                             <p style="margin-top: 8px;"><label>Delination Status</label></p>
                         </div>
                         <div class="col-xs-4 text-center">
-                            @ViewDataTyped.DelineationStatus
+                            <p style="margin-top: 8px;">@ViewDataTyped.DelineationStatus</p>
                         </div>
                     </div>
                 }


### PR DESCRIPTION
After failing to make atomic commits, the rest of the work done

Get toggle button to persist, through newly created delineations, selecting assests, and from the map
Had have display of delineation status level with status value in the detail location card 