### PR TITLE
[neptune/#490] Select Upstream BMP field to support co-located BMP delineations

### DIFF
--- a/Source/Neptune.Web/Controllers/TreatmentBMPController.cs
+++ b/Source/Neptune.Web/Controllers/TreatmentBMPController.cs
@@ -166,10 +166,10 @@ namespace Neptune.Web.Controllers
             var mapInitJson = new TreatmentBMPDetailMapInitJson("StormwaterDetailMap", treatmentBMP.LocationPoint);
             mapInitJson.Layers.Add(
                 StormwaterMapInitJson.MakeTreatmentBMPLayerGeoJson(new[] {treatmentBMP}, false, true));
-            if (treatmentBMP.Delineation?.DelineationGeometry != null)
+            if (treatmentBMP.Delineation?.DelineationGeometry != null || treatmentBMP.UpstreamBMP?.Delineation?.DelineationGeometry != null)
             {
                 mapInitJson.DelineationLayer =
-                    StormwaterMapInitJson.MakeTreatmentBMPDelineationLayerGeoJson(treatmentBMP);
+                    StormwaterMapInitJson.MakeTreatmentBMPDelineationLayerGeoJson(treatmentBMP.UpstreamBMP ?? treatmentBMP);
             }
 
             var carouselImages = treatmentBMP.TreatmentBMPImages.OrderBy(x => x.TreatmentBMPImageID).ToList();
@@ -179,7 +179,7 @@ namespace Neptune.Web.Controllers
                     x => x.VerifyInventory(treatmentBMPPrimaryKey));
 
             var viewData = new DetailViewData(CurrentPerson, treatmentBMP, mapInitJson, imageCarouselViewData,
-                verifiedUnverifiedUrl, new HRUCharacteristicsViewData(treatmentBMP), mapServiceUrl);
+                verifiedUnverifiedUrl, new HRUCharacteristicsViewData(treatmentBMP.UpstreamBMP ?? treatmentBMP), mapServiceUrl);
             return RazorView<Detail, DetailViewData>(viewData);
         }
 

--- a/Source/Neptune.Web/Views/TreatmentBMP/Detail.cshtml
+++ b/Source/Neptune.Web/Views/TreatmentBMP/Detail.cshtml
@@ -865,10 +865,19 @@
                 }
                 else if (ViewDataTyped.TreatmentBMP.Delineation == null && (ViewDataTyped.TreatmentBMP.UpstreamBMP == null || ViewDataTyped.TreatmentBMP.UpstreamBMP.Delineation == null))
                 {
-                    <p class="systemText">
-                        No delineation is provided for this @FieldDefinition.TreatmentBMP.GetFieldDefinitionLabel(). Land Use Statistics cannot be determined until a 
-                        @(ViewDataTyped.TreatmentBMP.UpstreamBMP == null ? new MvcHtmlString("<a href=" + ViewDataTyped.DelineationMapUrl + ">delineation is provided</a>") : new MvcHtmlString("delineation is provided to the Upstream BMP or the Upstream BMP is removed")).
-                    </p>
+                <p class="systemText">
+                    No delineation is provided for this @FieldDefinition.TreatmentBMP.GetFieldDefinitionLabel(). Land Use Statistics cannot be determined until a
+                    @{
+                        if (ViewDataTyped.TreatmentBMP.UpstreamBMP == null)
+                        {
+                            @:<a href="@ViewDataTyped.DelineationMapUrl">delineation is provided</a>.
+                        }
+                        else
+                        {
+                            @:delineation is provided to the Upstream BMP or the Upstream BMP is removed.
+                        }
+                    }
+                </p>
                 }
                 else
                 {

--- a/Source/Neptune.Web/Views/TreatmentBMP/Detail.cshtml
+++ b/Source/Neptune.Web/Views/TreatmentBMP/Detail.cshtml
@@ -227,23 +227,25 @@
                 </div>
                 <hr />
                 <div class="row">
-                    <label class="col-sm-5 control-label text-right" style="margin-top:8px">Upstream BMP</label>
+                    <label class="col-sm-5 control-label text-right" style="margin-top: 8px">
+                        @Html.LabelWithSugarFor(FieldDefinition.UpstreamBMP)
+                    </label>
                     @if (ViewDataTyped.TreatmentBMP.GetRegionalSubbasin().GetTreatmentBMPs().Any(x => x.TreatmentBMPID != ViewDataTyped.TreatmentBMP.TreatmentBMPID))
                     {
                         <div class="col-sm-4" style="margin-top:8px">@(ViewDataTyped.TreatmentBMP.UpstreamBMP == null ? new HtmlString("Not Provided") : ViewDataTyped.TreatmentBMP.UpstreamBMP.GetDisplayNameAsUrl())</div>
-                        <div class="col-xs-3">
+                        <div class="col-xs-3" style="margin-top:6px">
                             @if (ViewDataTyped.TreatmentBMP.UpstreamBMP != null)
                             {
                                 <form method="post" action="@ViewDataTyped.RemoveUpstreamBMPUrl" style="display:inline">
-                                    <button class="btn btn-sm btn-neptune" id="deleteUpstreamBMPButton" type="submit"><span class="glyphicon glyphicon-trash"></span></button>
+                                    <button class="btn btn-xs btn-neptune" id="deleteUpstreamBMPButton" type="submit"><span class="glyphicon glyphicon-trash"></span></button>
                                 </form>
                             }
-                            @ModalDialogFormHelper.ModalDialogFormLink("Edit", ViewDataTyped.EditUpstreamBMPUrl, "Choose Upstream BMP", new List<string> { "btn btn-neptune" }, ViewDataTyped.CanEditStormwaterJurisdiction)
+                            @ModalDialogFormHelper.ModalDialogFormLink("Edit", ViewDataTyped.EditUpstreamBMPUrl, "Choose Upstream BMP", new List<string> { "btn btn-xs btn-neptune" }, ViewDataTyped.CanEditStormwaterJurisdiction)
                         </div>
                     }
                     else
                     {
-                        <div class="col-sm-4">No BMPs within Regional Subbasin applicable</div>
+                        <div class="col-sm-7 text-muted"><em>No Inventoried BMPs within the same Regional Subbasin</em></div>
                     }
                 </div>
                 <hr/>
@@ -830,7 +832,8 @@
                 {
                     <div class="row" style="margin-top: 10px;">
                         <div class="col-xs-12 text-center">
-                            <em>No delineation may be added because this BMP has an Upstream BMP. <br/> Please remove the Upstream BMP to add a delineation.</em>
+                            <em>No delineation may be added or edited because this BMP has an Upstream BMP. <br/> Please remove the Upstream BMP to add a delineation.</em>
+                            @(ViewDataTyped.MapInitJson.DelineationLayer != null ? new MvcHtmlString("<br/><br/><em>*Note: Currently displayed delineation is a property of the currently assigned Upstream BMP.*</em>") : null)
                         </div>
                     </div>
                 }
@@ -856,13 +859,16 @@
                 Land Use Statistics
             </div>
             <div class="panel-body">
-                @if (ViewDataTyped.TreatmentBMP.HRUCharacteristics.Any() && ViewDataTyped.TreatmentBMP.Delineation != null)
+                @if ((ViewDataTyped.TreatmentBMP.HRUCharacteristics.Any() && ViewDataTyped.TreatmentBMP.Delineation != null) || (ViewDataTyped.TreatmentBMP.UpstreamBMPID != null && ViewDataTyped.TreatmentBMP.UpstreamBMP.HRUCharacteristics.Any() && ViewDataTyped.TreatmentBMP.UpstreamBMP.Delineation != null))
                 {
                     HRUCharacteristics.RenderPartialView(Html, ViewDataTyped.HRUCharacteristicsViewData);
                 }
-                else if (ViewDataTyped.TreatmentBMP.Delineation == null)
+                else if (ViewDataTyped.TreatmentBMP.Delineation == null && (ViewDataTyped.TreatmentBMP.UpstreamBMP == null || ViewDataTyped.TreatmentBMP.UpstreamBMP.Delineation == null))
                 {
-                    <p class="systemText">No delineation is provided for this @FieldDefinition.TreatmentBMP.GetFieldDefinitionLabel(). Land Use Statistics cannot be determined until a <a href="@ViewDataTyped.DelineationMapUrl">delineation is provided</a>.</p>
+                    <p class="systemText">
+                        No delineation is provided for this @FieldDefinition.TreatmentBMP.GetFieldDefinitionLabel(). Land Use Statistics cannot be determined until a 
+                        @(ViewDataTyped.TreatmentBMP.UpstreamBMP == null ? new MvcHtmlString("<a href=" + ViewDataTyped.DelineationMapUrl + ">delineation is provided</a>") : new MvcHtmlString("delineation is provided to the Upstream BMP or the Upstream BMP is removed")).
+                    </p>
                 }
                 else
                 {

--- a/Source/Neptune.Web/Views/TreatmentBMP/EditUpstreamBMP.cshtml
+++ b/Source/Neptune.Web/Views/TreatmentBMP/EditUpstreamBMP.cshtml
@@ -1,4 +1,5 @@
 ﻿@using LtInfo.Common.HtmlHelperExtensions
+@using Neptune.Web.Models
 @inherits Neptune.Web.Views.TreatmentBMP.EditUpstreamBMP
     
 
@@ -8,6 +9,14 @@
 {
     <div class="form-horizontal">
         <div class="row">
+            <div class="col-sm-12">
+                Indicate that the BMP receives flow from an Upstream BMP. After you save, this Treatment BMP will inherit the delineation 
+                area from the Upstream BMP for modeling purposes . If you already added a delineation for this BMP, it will be removed 
+                and replaced with the reference to the Upstream BMP.
+            </div>
+        </div>
+        <hr/>
+        <div class="row" style="margin-top:15px">
             <div class="col-sm-3 control-label">
                 @Html.LabelWithSugarFor(x => x.UpstreamBMPID)
             </div>

--- a/Source/Neptune.Web/Views/TreatmentBMP/EditUpstreamBMPViewModel.cs
+++ b/Source/Neptune.Web/Views/TreatmentBMP/EditUpstreamBMPViewModel.cs
@@ -1,12 +1,14 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using Neptune.Web.Common;
+using Neptune.Web.Models;
 
 namespace Neptune.Web.Views.TreatmentBMP
 {
     public class EditUpstreamBMPViewModel
     {
         [Required]
-        [DisplayName("Upstream BMP")]
+        [FieldDefinitionDisplay(FieldDefinitionEnum.UpstreamBMP)]
         public int? UpstreamBMPID { get; set; }
 
         /// <summary>


### PR DESCRIPTION
-Added field definitions for Upstream BMP references
-Made buttons more consistent
-Edited text when no upstream bmps are available
-Added instructional text to EditUpstreamBMP modal
-Land Usage Statistics are now relevant to Upstream BMP (if set) Land Usage Statistics and the Upstream BMP's delineation can be seen on the detail map (if a delineation is set)