### PR TITLE
Bug/592

### DIFF
--- a/Source/Neptune.Web/Views/Delineation/DelineationMap.js
+++ b/Source/Neptune.Web/Views/Delineation/DelineationMap.js
@@ -156,6 +156,8 @@ NeptuneMaps.DelineationMap.prototype.preselectTreatmentBMP = function (treatment
             self.delineationMapService.adjustZoom(self.selectedBMPDelineationLayer);
         } else {
             delineationStatus = "None";
+            var coords = layer.feature.geometry.coordinates;
+            self.map.setView([coords[1], coords[0]], 18);
         }
         self.delineationMapService.broadcastDelineationMapState({ selectedTreatmentBMPFeature: layer.feature });
         


### PR DESCRIPTION
When loading the delineation map with a treatmentBMPID that has no delineation, zoom to the point instead of staying zoomed  fully out