### PR TITLE
Bug/598

### DIFF
--- a/Database/Objects/Views/dbo.vGeoServerAssessmentAreaExport.sql
+++ b/Database/Objects/Views/dbo.vGeoServerAssessmentAreaExport.sql
@@ -10,7 +10,7 @@ create view dbo.vGeoServerAssessmentAreaExport as
 		area.OnlandVisualTrashAssessmentAreaGeometry,
 		score.OnlandVisualTrashAssessmentScoreDisplayName as Score,
 		ovta.OnlandVisualTrashAssessmentID as AssessmentID,
-		ovta.CompletedDate,
+		CONVERT(VARCHAR(12), ovta.CompletedDate, 107) CompletedDate,
 		ovta.IsProgressAssessment,
 		area.AssessmentAreaDescription as [Description]
 	from dbo.OnlandVisualTrashAssessmentArea area

--- a/Database/Objects/Views/dbo.vGeoServerAssessmentAreaExport.sql
+++ b/Database/Objects/Views/dbo.vGeoServerAssessmentAreaExport.sql
@@ -10,6 +10,9 @@ create view dbo.vGeoServerAssessmentAreaExport as
 		area.OnlandVisualTrashAssessmentAreaGeometry,
 		score.OnlandVisualTrashAssessmentScoreDisplayName as Score,
 		ovta.OnlandVisualTrashAssessmentID as AssessmentID,
+		--The third argument in CONVERT defines the style for the date
+		--107 produces the date in the format Mon dd, yyyy
+		--Consult https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15 if a new format is desired
 		CONVERT(VARCHAR(12), ovta.CompletedDate, 107) CompletedDate,
 		ovta.IsProgressAssessment,
 		area.AssessmentAreaDescription as [Description]

--- a/Database/Objects/Views/dbo.vGeoServerObservationPointExport.sql
+++ b/Database/Objects/Views/dbo.vGeoServerObservationPointExport.sql
@@ -8,7 +8,7 @@ Select
 	a.OnlandVisualTrashAssessmentID as AssessmentID,
 	o.LocationPoint,
 	o.Note,
-	a.CompletedDate,
+	CONVERT(VARCHAR(12), a.CompletedDate, 107) CompletedDate,
 	Score.OnlandVisualTrashAssessmentScoreDisplayName as Score,
 	area.StormwaterJurisdictionID as JurisID,
 	org.OrganizationName as JurisName,

--- a/Database/Objects/Views/dbo.vGeoServerObservationPointExport.sql
+++ b/Database/Objects/Views/dbo.vGeoServerObservationPointExport.sql
@@ -8,6 +8,9 @@ Select
 	a.OnlandVisualTrashAssessmentID as AssessmentID,
 	o.LocationPoint,
 	o.Note,
+	--The third argument in CONVERT defines the style for the date
+	--107 produces the date in the format Mon dd, yyyy
+	--Consult https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15 if a new format is desired
 	CONVERT(VARCHAR(12), a.CompletedDate, 107) CompletedDate,
 	Score.OnlandVisualTrashAssessmentScoreDisplayName as Score,
 	area.StormwaterJurisdictionID as JurisID,


### PR DESCRIPTION
-Converting datetimes to strings so that, when  exported, the GeoServer timestamp format doesn't cause GIS editors to become upset because the date is in a format they  don't recognize (ARCMap refuses to open .shp files with  the format producing the error that was reported, and QGis tries but ultimately can't handle it producing a weird string of characters that don't resemble a  date at all)