### PR TITLE
Bug/624

### DIFF
--- a/Source/Neptune.Web/Models/TreatmentBMPModelExtensions.cs
+++ b/Source/Neptune.Web/Models/TreatmentBMPModelExtensions.cs
@@ -345,11 +345,11 @@ namespace Neptune.Web.Models
             }
         }
 
-        public static bool UpdatedCentralizedBMPDelineationIfPresent(this TreatmentBMP treatmentBMP)
+        public static void UpdatedCentralizedBMPDelineationIfPresent(this TreatmentBMP treatmentBMP)
         {
             if (treatmentBMP.Delineation == null || treatmentBMP.Delineation.DelineationTypeID != (int) DelineationTypeEnum.Centralized)
             {
-                return false;
+                return;
             }
 
             var updated4326Geometry =
@@ -375,11 +375,7 @@ namespace Neptune.Web.Models
                 {
                     ModelingEngineUtilities.QueueLGURefreshForArea(oldShape, newShape);
                 }
-
-                return true;
             }
-
-            return false;
         }
 
         public static bool IsFullyParameterized(this TreatmentBMP treatmentBMP)

--- a/Source/Neptune.Web/Models/TreatmentBMPModelExtensions.cs
+++ b/Source/Neptune.Web/Models/TreatmentBMPModelExtensions.cs
@@ -370,11 +370,6 @@ namespace Neptune.Web.Models
                 {
                     treatmentBMP.Delineation.DeleteDelineation(HttpRequestStorage.DatabaseEntities);
                 }
-
-                if (!(newShape == null & oldShape == null) && treatmentBMP.TreatmentBMPType.TreatmentBMPModelingType != null)
-                {
-                    ModelingEngineUtilities.QueueLGURefreshForArea(oldShape, newShape);
-                }
             }
         }
 

--- a/Source/Neptune.Web/Views/Delineation/DelineationMap.cshtml
+++ b/Source/Neptune.Web/Views/Delineation/DelineationMap.cshtml
@@ -88,8 +88,8 @@
                         <input id="verifyDelineationButton" type="checkbox" data-toggle="toggle" data-on="Verified" data-off="Provisional" data-width="100" />
                     </div>
                     
-                    <div style="margin-top: 10px;" id="editOrDeleteDelineationButtonsWrapper" ng-hide="delineationMapState.isInEditLocationMode">
-                        <button class="btn btn-sm btn-neptune" id="delineationButton" type="button" ng-click="beginDelineation(); $event.stopPropagation();" ng-hide="delineationMapState.isInDelineationMode">Edit</button>
+                    <div style="margin-top: 10px;" id="editOrDeleteDelineationButtonsWrapper" ng-hide="delineationMapState.isInEditLocationMode || delineationMapState.isInDelineationMode">
+                        <button class="btn btn-sm btn-neptune" id="delineationButton" type="button" ng-click="beginDelineation(); $event.stopPropagation();">Edit</button>
                         <button class="btn btn-sm btn-neptune" id="deleteDelineationButton" style="display: none;" ng-show="showDeleteButton()" ng-click="deleteDelineation(); $event.stopPropagation()"><span class="glyphicon glyphicon-trash"></span></button>
                         <a id="requestRevisionButton" ng-href="/RegionalSubbasinRevisionRequest/New/{{treatmentBMPID()}}" ng-show="showRequestRevisionButton()" style="margin-bottom: 5px;"><button class="btn btn-sm btn-neptune">Request Revision</button></a>
                     </div>
@@ -113,7 +113,7 @@
                     <button class="btn btn-sm btn-neptune" id="cancelLocationButton" type="button" ng-click="cancelLocationEdit()">Cancel</button>
                 </div>
 
-                <div id="saveCancelAndThinButtonsWrapper" ng-show="delineationMapState.isInDelineationMode && delineationMapState.isEditedDelineationPresent">
+                <div style="margin-top: 10px;" id="saveCancelAndThinButtonsWrapper" ng-show="delineationMapState.isInDelineationMode && delineationMapState.isEditedDelineationPresent">
                     <button class="btn btn-sm btn-neptune" id="saveDelineationButton" type="button" ng-click="saveDelineation()">Save</button>
                     <button class="btn btn-sm btn-neptune" id="cancelDelineationButton" type="button" ng-click="cancelDelineation()">Cancel</button>
                     <a id="requestRevisionDuringEditButton" ng-href="/RegionalSubbasinRevisionRequest/New/{{treatmentBMPID()}}" ng-show="delineationMapState.isEditingCentralizedDelineation" style="margin-bottom: 5px;"><button class="btn btn-sm btn-neptune">Request Revision</button></a>

--- a/Source/Neptune.Web/Views/Delineation/DelineationMap.cshtml
+++ b/Source/Neptune.Web/Views/Delineation/DelineationMap.cshtml
@@ -108,6 +108,7 @@
                 <div id="editLocationModeButtonsWrapper" ng-hide="!delineationMapState.isInEditLocationMode">
                     <hr />
                     <p>Click the map to set a new location for this BMP.</p>
+                    <p>For centralized BMPs, any existing delineation will automatically be re-calculated based the new saved location.</p>
                     <button class="btn btn-sm btn-neptune" id="saveLocationButton" type="button" ng-click="saveLocationEdit()">Save Location</button>
                     <button class="btn btn-sm btn-neptune" id="cancelLocationButton" type="button" ng-click="cancelLocationEdit()">Cancel</button>
                 </div>

--- a/Source/Neptune.Web/Views/Delineation/DelineationMap.cshtml
+++ b/Source/Neptune.Web/Views/Delineation/DelineationMap.cshtml
@@ -108,7 +108,7 @@
                 <div id="editLocationModeButtonsWrapper" ng-hide="!delineationMapState.isInEditLocationMode">
                     <hr />
                     <p>Click the map to set a new location for this BMP.</p>
-                    <p>For centralized BMPs, any existing delineation will automatically be re-calculated based the new saved location.</p>
+                    <p>For centralized BMPs, any existing delineation will automatically be re-calculated based on the new saved location.</p>
                     <button class="btn btn-sm btn-neptune" id="saveLocationButton" type="button" ng-click="saveLocationEdit()">Save Location</button>
                     <button class="btn btn-sm btn-neptune" id="cancelLocationButton" type="button" ng-click="cancelLocationEdit()">Cancel</button>
                 </div>

--- a/Source/Neptune.Web/Views/Delineation/DelineationMap.js
+++ b/Source/Neptune.Web/Views/Delineation/DelineationMap.js
@@ -272,9 +272,23 @@ NeptuneMaps.DelineationMap.prototype.exitEditLocationMode = function (save) {
             self.initializeTreatmentBMPClusteredLayer();
             var movedLayer = self.treatmentBMPLayerLookup.get(treatmentBMPID);
             self.setSelectedFeature(movedLayer.feature);
-            self.removeLoading();
-            self.initializationsOnMapRefresh();
-            toast("Successfully updated Treatment BMP location.", "success");
+            self.retrieveAndShowBMPDelineation(movedLayer.feature).then(function (response) {
+                var delineationStatus;
+                if (self.selectedBMPDelineationLayer) {
+                    delineationStatus = self.selectedBMPDelineationLayer.getLayers()[0].feature.properties
+                        .DelineationStatus;
+                } else {
+                    delineationStatus = "None";
+                }
+                self.selectedAssetControl.treatmentBMP(movedLayer.feature, delineationStatus);
+                self.delineationMapService.broadcastDelineationMapState({
+                    selectedTreatmentBMPFeature: movedLayer.feature
+                });
+            }).always(function () {
+                self.removeLoading();
+                self.initializationsOnMapRefresh();
+                toast("Successfully updated Treatment BMP location.", "success");
+            });
         }).fail(function() {
             self.initializeTreatmentBMPClusteredLayer();
             var movedLayer = self.treatmentBMPLayerLookup.get(treatmentBMPID);

--- a/Source/Neptune.Web/Views/Delineation/DelineationMapController.js
+++ b/Source/Neptune.Web/Views/Delineation/DelineationMapController.js
@@ -74,6 +74,8 @@ angular.module("NeptuneApp")
 
         // UI element handlers
         $scope.beginDelineation = function () {
+            //Make sure we're cleaned up from any other editing requests
+            DelineationMapService.resetDelineationMapEditingState(true);
             $scope.delineationMapState.isInDelineationMode = true;
             $scope.delineationMap.addBeginDelineationControl();
         };

--- a/Source/Neptune.Web/Views/Shared/Location/EditLocation.cshtml
+++ b/Source/Neptune.Web/Views/Shared/Location/EditLocation.cshtml
@@ -34,6 +34,8 @@
                             <li>Click on the location of the BMP on the map <strong>OR</strong></li>
                             <li>Directly type in the latitude and longitude</li>
                         </ul>
+
+                        <p>For centralized BMPs, any existing delineation will automatically be re-calculated based on the new saved location.</p>
                     </div>
                     <div class="col-xs-12 col-sm-6 col-md-12">
                         <div class="row">

--- a/Source/Neptune.Web/Views/Shared/Location/EditLocationViewModel.cs
+++ b/Source/Neptune.Web/Views/Shared/Location/EditLocationViewModel.cs
@@ -42,7 +42,6 @@ namespace Neptune.Web.Views.Shared.Location
         [DisplayName("Latitude")]
         [Range(-90, 90, ErrorMessage = "Latitude must be between -90 and 90")]
         public double? TreatmentBMPPointY { get; set; }
-        public bool? CentralizedBMPDelineationUpdated { get; set; }
 
         /// <summary>
         /// Needed by the ModelBinder

--- a/Source/Neptune.Web/Views/Shared/Location/EditLocationViewModel.cs
+++ b/Source/Neptune.Web/Views/Shared/Location/EditLocationViewModel.cs
@@ -42,6 +42,7 @@ namespace Neptune.Web.Views.Shared.Location
         [DisplayName("Latitude")]
         [Range(-90, 90, ErrorMessage = "Latitude must be between -90 and 90")]
         public double? TreatmentBMPPointY { get; set; }
+        public bool? CentralizedBMPDelineationUpdated { get; set; }
 
         /// <summary>
         /// Needed by the ModelBinder
@@ -64,6 +65,8 @@ namespace Neptune.Web.Views.Shared.Location
 
             // associate watershed, lspc basin, precipitation zone
             treatmentBMP.SetTreatmentBMPPointInPolygonDataByLocationPoint(locationPoint);
+
+            treatmentBMP.UpdatedCentralizedBMPDelineationIfPresent();
         }
     }
 }


### PR DESCRIPTION
-Automatically recalculate centralized bmps on location change if there is a centralized delineation
-Ensure that editing delineation state is cleaned up appropriately between edits