### PR TITLE
Add a verify view feature that  looks like the old wqmp  view feature…

### DIFF
--- a/Source/Neptune.Web/Controllers/WaterQualityManagementPlanController.cs
+++ b/Source/Neptune.Web/Controllers/WaterQualityManagementPlanController.cs
@@ -463,7 +463,7 @@ namespace Neptune.Web.Controllers
 
 
         [HttpGet]
-        [WaterQualityManagementPlanViewFeature]
+        [WaterQualityManagementPlanVerifyViewFeature]
         public ViewResult WqmpVerify(WaterQualityManagementPlanVerifyPrimaryKey waterQualityManagementPlanVerifyPrimaryKey)
         {
             var waterQualityManagementPlanVerify = waterQualityManagementPlanVerifyPrimaryKey.EntityObject;
@@ -613,22 +613,7 @@ namespace Neptune.Web.Controllers
                 return ViewDeleteVerify(waterQualityManagementPlanVerify, viewModel);
             }
 
-            var waterQualityManagementPlanQuickBMP = HttpRequestStorage.DatabaseEntities
-                .WaterQualityManagementPlanVerifyQuickBMPs.Where(x =>
-                    x.WaterQualityManagementPlanVerifyID ==
-                    waterQualityManagementPlanVerify.WaterQualityManagementPlanVerifyID).ToList();
-
-            var waterQualityManagementPlanTreatmentBMP = HttpRequestStorage.DatabaseEntities
-                .WaterQualityManagementPlanVerifyTreatmentBMPs.Where(x =>
-                    x.WaterQualityManagementPlanVerifyID ==
-                    waterQualityManagementPlanVerify.WaterQualityManagementPlanVerifyID).ToList();
-
             var lastEditedDate = waterQualityManagementPlanVerify.LastEditedDate.ToShortDateString();
-
-            HttpRequestStorage.DatabaseEntities.WaterQualityManagementPlanVerifyQuickBMPs
-                .DeleteWaterQualityManagementPlanVerifyQuickBMP(waterQualityManagementPlanQuickBMP);
-            HttpRequestStorage.DatabaseEntities.WaterQualityManagementPlanVerifyTreatmentBMPs
-                .DeleteWaterQualityManagementPlanVerifyTreatmentBMP(waterQualityManagementPlanTreatmentBMP);
 
             waterQualityManagementPlanVerify.DeleteFull(HttpRequestStorage.DatabaseEntities);
             SetMessageForDisplay($"Successfully deleted \"{lastEditedDate}\".");

--- a/Source/Neptune.Web/Neptune.Web.csproj
+++ b/Source/Neptune.Web/Neptune.Web.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\NuGetPackages\EntityFramework.6.4.0\build\EntityFramework.props" Condition="Exists('..\NuGetPackages\EntityFramework.6.4.0\build\EntityFramework.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -552,6 +552,7 @@
     <Compile Include="ScheduledJobs\TotalNetworkSolveJob.cs" />
     <Compile Include="Security\OnlandVisualTrashAssessmentAreaEditFeature.cs" />
     <Compile Include="Security\StormwaterJurisdictionViewFeature.cs" />
+    <Compile Include="Security\WaterQualityManagementPlanVerifyViewFeature.cs" />
     <Compile Include="Views\FieldVisit\BulkUploadTrashScreenVisit.cs" />
     <Compile Include="Views\FieldVisit\BulkUploadTrashScreenVisitViewData.cs" />
     <Compile Include="Views\FieldVisit\EditDateAndType.cs" />

--- a/Source/Neptune.Web/Security/WaterQualityManagementPlanVerifyViewFeature.cs
+++ b/Source/Neptune.Web/Security/WaterQualityManagementPlanVerifyViewFeature.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Neptune.Web.Models;
+
+namespace Neptune.Web.Security
+{
+    [SecurityFeatureDescription("Allows viewing a WQMP  Verification if you are a user with a role")]
+    public class WaterQualityManagementPlanVerifyViewFeature : NeptuneFeature
+    {
+        public WaterQualityManagementPlanVerifyViewFeature()
+            : base(new HashSet<Role> { Role.JurisdictionEditor, Role.JurisdictionManager, Role.Admin, Role.SitkaAdmin })
+        {
+        }
+    }
+}


### PR DESCRIPTION
…, make  sure we don't delete entities ahead of a larger delete which causes entity framework to get upset because it's trying to delete something  that doesn't exist