### PR TITLE
Rework/NPT-286

### DIFF
--- a/Source/Neptune.Web/Controllers/WaterQualityManagementPlanController.cs
+++ b/Source/Neptune.Web/Controllers/WaterQualityManagementPlanController.cs
@@ -451,7 +451,7 @@ namespace Neptune.Web.Controllers
             var wqmpParcelGeometries =
                 waterQualityManagementPlan.WaterQualityManagementPlanParcels.Select(x => x.Parcel.ParcelGeometry4326);
             var wqmpJurisdiction = waterQualityManagementPlan.StormwaterJurisdiction;
-            var mapInitJson = new MapInitJson("editWqmpParcelMap", 0, new List<LayerGeoJson>(), wqmpParcelGeometries.Count() > 0 ? 
+            var mapInitJson = new MapInitJson("editWqmpParcelMap", 0, new List<LayerGeoJson>(), wqmpParcelGeometries.Any() ? 
                     new BoundingBox(wqmpParcelGeometries) : BoundingBox.GetBoundingBox(new List<StormwaterJurisdiction> { wqmpJurisdiction }));
             var viewData = new EditWqmpParcelsViewData(CurrentPerson, waterQualityManagementPlan, mapInitJson);
             return RazorView<EditWqmpParcels, EditWqmpParcelsViewData, EditWqmpParcelsViewModel>(viewData, viewModel);

--- a/Source/Neptune.Web/Views/WaterQualityManagementPlan/Detail.cshtml
+++ b/Source/Neptune.Web/Views/WaterQualityManagementPlan/Detail.cshtml
@@ -333,10 +333,10 @@
             <div class="panel panelNeptune">
                 <div class="panel-heading panelTitle">
                     Locations
-                    @if (ViewDataTyped.CurrentPersonCanManageWaterQualityManagementPlans)
+                    @if (ViewDataTyped.CurrentPersonCanManageWaterQualityManagementPlans && ViewDataTyped.WaterQualityManagementPlan.WaterQualityManagementPlanBoundary != null)
                     {
                         <span class="pull-right">
-                            <a href="@ViewDataTyped.EditParcelsUrl">
+                            <a href="@ViewDataTyped.EditWqmpBoundaryUrl">
                                 @BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-edit")
                             </a>
                         </span>

--- a/Source/Neptune.Web/Views/WaterQualityManagementPlan/DetailViewData.cs
+++ b/Source/Neptune.Web/Views/WaterQualityManagementPlan/DetailViewData.cs
@@ -21,6 +21,7 @@ namespace Neptune.Web.Views.WaterQualityManagementPlan
         public string EditSimplifiedStructuralBMPsUrl { get; }
         public string EditSourceControlBMPsUrl { get; }
         public string EditParcelsUrl { get; }
+        public string EditWqmpBoundaryUrl { get; }
         public string NewDocumentUrl { get; }
         public MapInitJson MapInitJson { get; }
         public ParcelGridSpec ParcelGridSpec { get; }
@@ -93,6 +94,9 @@ namespace Neptune.Web.Views.WaterQualityManagementPlan
             EditParcelsUrl =
                 SitkaRoute<WaterQualityManagementPlanController>.BuildUrlFromExpression(c =>
                     c.EditWqmpParcels(WaterQualityManagementPlan));
+            EditWqmpBoundaryUrl =
+                SitkaRoute<WaterQualityManagementPlanController>.BuildUrlFromExpression(c =>
+                    c.EditWqmpBoundary(WaterQualityManagementPlan));
             NewDocumentUrl =
                 SitkaRoute<WaterQualityManagementPlanDocumentController>.BuildUrlFromExpression(c =>
                     c.New(waterQualityManagementPlan));

--- a/Source/Neptune.Web/Views/WaterQualityManagementPlan/EditWqmpParcels.cshtml
+++ b/Source/Neptune.Web/Views/WaterQualityManagementPlan/EditWqmpParcels.cshtml
@@ -119,13 +119,7 @@
         <div class="col-xs-12">
             <hr/>
         </div>
-        <div class="col-xs-12 col-sm-2">
-            <div>
-                <a href="@ViewDataTyped.RefineAreaUrl" class="btn btn-neptune"> Refine Area </a>
-                @*<sup>@Html.Raw(BootstrapHtmlHelpers.RequiredIcon)</sup> Required Field*@
-            </div>
-        </div>
-        <div class="col-xs-12 col-sm-10" style="text-align: right">
+        <div class="col-xs-12 col-sm-12" style="text-align: right">
             <button type="submit" class="btn btn-neptune" value="false" name="@Html.NameFor(x => x.AutoAdvance)"> Save </button>
             <a href="@ViewDataTyped.SubEntityUrl" class="btn btn-neptune"> Cancel </a>
         </div>

--- a/Source/Neptune.Web/Views/WaterQualityManagementPlan/EditWqmpParcelsViewData.cs
+++ b/Source/Neptune.Web/Views/WaterQualityManagementPlan/EditWqmpParcelsViewData.cs
@@ -11,7 +11,6 @@ namespace Neptune.Web.Views.WaterQualityManagementPlan
         public Models.WaterQualityManagementPlan WaterQualityManagementPlan { get; }
         public EditWqmpParcelsViewDataForAngular ViewDataForAngular { get; }
         public decimal? RecordedWQMPAreaInAcres { get; }
-        public string RefineAreaUrl { get; set; }
 
         public EditWqmpParcelsViewData(Person currentPerson,
             Models.WaterQualityManagementPlan waterQualityManagementPlan,
@@ -23,9 +22,6 @@ namespace Neptune.Web.Views.WaterQualityManagementPlan
             EntityUrl = SitkaRoute<WaterQualityManagementPlanController>.BuildUrlFromExpression(c => c.Index());
             SubEntityName = waterQualityManagementPlan.WaterQualityManagementPlanName;
             SubEntityUrl = waterQualityManagementPlan.GetDetailUrl();
-            RefineAreaUrl =
-                SitkaRoute<WaterQualityManagementPlanController>.BuildUrlFromExpression(c =>
-                    c.EditWqmpBoundary(WaterQualityManagementPlan));
             PageTitle = "Edit Associated Parcels";
             RecordedWQMPAreaInAcres = waterQualityManagementPlan.RecordedWQMPAreaInAcres;
             ViewDataForAngular = new EditWqmpParcelsViewDataForAngular(mapInitJson,


### PR DESCRIPTION
Setting bounding boxes based on stormwater jurisdiction when no parcels are associated with a WQMP on detail page and parcel picker page
Fixed null handling of WQMP boundary on detail page