### PR TITLE
Features/npt 271

### DIFF
--- a/Source/LtInfo.Common/ImageHelper.cs
+++ b/Source/LtInfo.Common/ImageHelper.cs
@@ -348,6 +348,7 @@ namespace LtInfo.Common
                 {
                     var qualityEncoder = Encoder.Quality;
                     var encoderParameters = new EncoderParameters(1);
+                    //defaulting to 80% quality seems like a good compromise in basic eye testing 
                     encoderParameters.Param[0] = new EncoderParameter(qualityEncoder, 80L);
                     image.Save(outStream, jpgEncoder, encoderParameters);
                 }

--- a/Source/LtInfo.Common/ImageHelper.cs
+++ b/Source/LtInfo.Common/ImageHelper.cs
@@ -314,6 +314,13 @@ namespace LtInfo.Common
             return maxWidth;
         }
 
+        public static byte[] ImageToByteArray(Image imageIn)
+        {
+            MemoryStream ms = new MemoryStream();
+            imageIn.Save(ms, ImageFormat.Bmp);
+            return ms.ToArray();
+        }
+
         public static Image ScaleImage(byte[] imageData, int maxWidth, int maxHeight)
         {
             using (var ms = new MemoryStream(imageData))

--- a/Source/LtInfo.Common/ImageHelper.cs
+++ b/Source/LtInfo.Common/ImageHelper.cs
@@ -313,12 +313,48 @@ namespace LtInfo.Common
             }
             return maxWidth;
         }
+        private static ImageCodecInfo GetEncoder(ImageFormat format)
+        {
+            var codecs = ImageCodecInfo.GetImageDecoders();
+            foreach (var codec in codecs)
+            {
+                if (codec.FormatID == format.Guid)
+                {
+                    return codec;
+                }
+            }
 
-        public static byte[] ImageToByteArray(Image imageIn)
+            return null;
+        }
+
+        public static byte[] ImageToByteArrayAndCompress(Image imageIn)
         {
             MemoryStream ms = new MemoryStream();
-            imageIn.Save(ms, ImageFormat.Bmp);
-            return ms.ToArray();
+            imageIn.Save(ms, ImageFormat.Jpeg);
+            var jpgEncoder = GetEncoder(ImageFormat.Jpeg);
+            using (var inStream = ms)
+            using (var outStream = new MemoryStream())
+            {
+                var image = Image.FromStream(inStream);
+
+                // if we aren't able to retrieve our encoder
+                // we should just save the current image and
+                // return to prevent any exceptions from happening
+                if (jpgEncoder == null)
+                {
+                    image.Save(outStream, ImageFormat.Jpeg);
+                }
+                else
+                {
+                    var qualityEncoder = Encoder.Quality;
+                    var encoderParameters = new EncoderParameters(1);
+                    encoderParameters.Param[0] = new EncoderParameter(qualityEncoder, 80L);
+                    image.Save(outStream, jpgEncoder, encoderParameters);
+                }
+
+                return outStream.ToArray();
+            }
+
         }
 
         public static Image ScaleImage(byte[] imageData, int maxWidth, int maxHeight)
@@ -327,7 +363,9 @@ namespace LtInfo.Common
             {
                 using (var image = Image.FromStream(ms))
                 {
-                    return ScaleImage(image, maxWidth, maxHeight);
+                    var scaledImage = ScaleImage(image, maxWidth, maxHeight);
+
+                    return scaledImage;
                 }
             }
         }
@@ -343,6 +381,8 @@ namespace LtInfo.Common
 
             var newImage = new Bitmap(newWidth, newHeight);
             Graphics.FromImage(newImage).DrawImage(image, 0, 0, newWidth, newHeight);
+
+
             return newImage;
         }
     }

--- a/Source/Neptune.Web/Areas/Trash/Controllers/OnlandVisualTrashAssessmentPhotoController.cs
+++ b/Source/Neptune.Web/Areas/Trash/Controllers/OnlandVisualTrashAssessmentPhotoController.cs
@@ -55,7 +55,8 @@ namespace Neptune.Web.Areas.Trash.Controllers
                 ImageHelper.ScaleImage(
                     FileResource.ConvertHttpPostedFileToByteArray(observationPhotoStagingSimple.Photo), 750, 750);
 
-            var resizedImageBytes = ImageHelper.ImageToByteArray(resizedImage);
+
+            var resizedImageBytes = ImageHelper.ImageToByteArrayAndCompress(resizedImage);
 
             var fileResource = FileResource.CreateNewResizedImageFileResource(observationPhotoStagingSimple.Photo, resizedImageBytes, CurrentPerson);
 

--- a/Source/Neptune.Web/Areas/Trash/Controllers/OnlandVisualTrashAssessmentPhotoController.cs
+++ b/Source/Neptune.Web/Areas/Trash/Controllers/OnlandVisualTrashAssessmentPhotoController.cs
@@ -54,8 +54,7 @@ namespace Neptune.Web.Areas.Trash.Controllers
             var resizedImage =
                 ImageHelper.ScaleImage(
                     FileResource.ConvertHttpPostedFileToByteArray(observationPhotoStagingSimple.Photo), 750, 750);
-
-
+            
             var resizedImageBytes = ImageHelper.ImageToByteArrayAndCompress(resizedImage);
 
             var fileResource = FileResource.CreateNewResizedImageFileResource(observationPhotoStagingSimple.Photo, resizedImageBytes, CurrentPerson);

--- a/Source/Neptune.Web/Areas/Trash/Controllers/OnlandVisualTrashAssessmentPhotoController.cs
+++ b/Source/Neptune.Web/Areas/Trash/Controllers/OnlandVisualTrashAssessmentPhotoController.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Web;
@@ -49,7 +50,14 @@ namespace Neptune.Web.Areas.Trash.Controllers
                 });
             }
 
-            var fileResource = FileResource.CreateNewFromHttpPostedFile(observationPhotoStagingSimple.Photo, CurrentPerson);
+            // for now, setting arbitrary-ish (750) max height and width that roughly corresponds with the largest rendered size on the detail page
+            var resizedImage =
+                ImageHelper.ScaleImage(
+                    FileResource.ConvertHttpPostedFileToByteArray(observationPhotoStagingSimple.Photo), 750, 750);
+
+            var resizedImageBytes = ImageHelper.ImageToByteArray(resizedImage);
+
+            var fileResource = FileResource.CreateNewResizedImageFileResource(observationPhotoStagingSimple.Photo, resizedImageBytes, CurrentPerson);
 
             var staging = new OnlandVisualTrashAssessmentObservationPhotoStaging(fileResource,
                 onlandVisualTrashAssessmentPrimaryKey.EntityObject);

--- a/Source/Neptune.Web/Models/FileResource.cs
+++ b/Source/Neptune.Web/Models/FileResource.cs
@@ -118,7 +118,7 @@ namespace Neptune.Web.Models
         /// </summary>
         /// <param name="httpPostedFileBase"></param>
         /// <returns></returns>
-        private static byte[] ConvertHttpPostedFileToByteArray(HttpPostedFileBase httpPostedFileBase)
+        public static byte[] ConvertHttpPostedFileToByteArray(HttpPostedFileBase httpPostedFileBase)
         {
             byte[] fileResourceData;
             using (var binaryReader = new BinaryReader(httpPostedFileBase.InputStream))
@@ -156,6 +156,22 @@ namespace Neptune.Web.Models
             var originalFilenameInfo = new FileInfo(fileName);
             var baseFilenameWithoutExtension = originalFilenameInfo.Name.Remove(originalFilenameInfo.Name.Length - originalFilenameInfo.Extension.Length, originalFilenameInfo.Extension.Length);
             var fileResourceData = ConvertHttpPostedFileToByteArray(httpPostedFileBase);
+            var fileResourceMimeTypeID = GetFileResourceMimeTypeForFile(httpPostedFileBase).FileResourceMimeTypeID;
+            var fileResource = new FileResource(fileResourceMimeTypeID, baseFilenameWithoutExtension, originalFilenameInfo.Extension, Guid.NewGuid(), fileResourceData, currentPerson.PersonID, DateTime.Now);
+            return fileResource;
+        }
+
+        public static FileResource CreateNewResizedImageFileResource(HttpPostedFileBase httpPostedFileBase, byte[] resizedImageBytes, Person currentPerson)
+        {
+            var fileName = httpPostedFileBase.FileName;
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                fileName = Guid.NewGuid().ToString() + ".jpg";
+            }
+
+            var originalFilenameInfo = new FileInfo(fileName);
+            var baseFilenameWithoutExtension = originalFilenameInfo.Name.Remove(originalFilenameInfo.Name.Length - originalFilenameInfo.Extension.Length, originalFilenameInfo.Extension.Length);
+            var fileResourceData = resizedImageBytes;
             var fileResourceMimeTypeID = GetFileResourceMimeTypeForFile(httpPostedFileBase).FileResourceMimeTypeID;
             var fileResource = new FileResource(fileResourceMimeTypeID, baseFilenameWithoutExtension, originalFilenameInfo.Extension, Guid.NewGuid(), fileResourceData, currentPerson.PersonID, DateTime.Now);
             return fileResource;

--- a/Source/Neptune.Web/Views/FieldVisit/AssessmentPhotosViewModel.cs
+++ b/Source/Neptune.Web/Views/FieldVisit/AssessmentPhotosViewModel.cs
@@ -60,7 +60,7 @@ namespace Neptune.Web.Views.FieldVisit
                     ImageHelper.ScaleImage(
                         FileResource.ConvertHttpPostedFileToByteArray(Photo), 800, 800);
 
-                var resizedImageBytes = ImageHelper.ImageToByteArray(resizedImage);
+                var resizedImageBytes = ImageHelper.ImageToByteArrayAndCompress(resizedImage);
 
                 var fileResource = FileResource.CreateNewResizedImageFileResource(Photo, resizedImageBytes, currentPerson);
 

--- a/Source/Neptune.Web/Views/FieldVisit/AssessmentPhotosViewModel.cs
+++ b/Source/Neptune.Web/Views/FieldVisit/AssessmentPhotosViewModel.cs
@@ -55,7 +55,15 @@ namespace Neptune.Web.Views.FieldVisit
             // Create new photo if it exists
             if (Photo != null)
             {
-                var fileResource = FileResource.CreateNewFromHttpPostedFile(Photo, currentPerson);
+                // for now, setting arbitrary-ish (800) max height and width that roughly corresponds with the largest rendered size on the detail page
+                var resizedImage =
+                    ImageHelper.ScaleImage(
+                        FileResource.ConvertHttpPostedFileToByteArray(Photo), 800, 800);
+
+                var resizedImageBytes = ImageHelper.ImageToByteArray(resizedImage);
+
+                var fileResource = FileResource.CreateNewResizedImageFileResource(Photo, resizedImageBytes, currentPerson);
+
                 new TreatmentBMPAssessmentPhoto(fileResource, treatmentBMPAssessment) {Caption = Caption};
             }
         }

--- a/Source/Neptune.Web/Views/FieldVisit/Detail.cshtml
+++ b/Source/Neptune.Web/Views/FieldVisit/Detail.cshtml
@@ -232,7 +232,10 @@
                                     <label>Type:</label>
                                 </div>
                                 <div class="col-sm-9">
-                                    @ViewDataTyped.MaintenanceRecord.MaintenanceRecordType.MaintenanceRecordTypeDisplayName
+                                    @if (ViewDataTyped.MaintenanceRecord.MaintenanceRecordType != null)
+                                    {
+                                        @ViewDataTyped.MaintenanceRecord.MaintenanceRecordType.MaintenanceRecordTypeDisplayName
+                                    }
                                 </div>
                             </div>
                             <div class="row">


### PR DESCRIPTION
I made a couple of judgment calls on the image sizing based on the relevant detail pages: based on the current layout, 750 and 800 px for OVTA and Field Visit respectively seems like it covers most of the responsive layouts adequately.

I also found a bug: When visiting a completed field visit detail page, there is a null reference error for Maintenance Record Type. I was able to save a field visit in this state, but not sure if this is something that actually occurs in regular usage. I just added a quick null check to avoid the error for now