### PR TITLE
Features/npt 927

### DIFF
--- a/Neptune.Web/src/app/app.routes.ts
+++ b/Neptune.Web/src/app/app.routes.ts
@@ -56,18 +56,20 @@ export const routeParams = {
 export const routes: Routes = [
     {
         path: `planning`,
-        title: "Stormwater Tools | Orange County | Planning Module",
+        title: "Stormwater Tools",
         component: PlanningSiteLayoutComponent,
         children: [
             { path: "", title: "Home", component: PlanningHomeComponent },
             { path: "about", component: PlanningAboutComponent, canActivate: [UnauthenticatedAccessGuard] },
             {
                 path: "grant-programs",
+                title: "Grant Program",
                 canActivate: [UnauthenticatedAccessGuard, OCTAGrantReviewerOnlyGuard],
                 children: [{ path: "octa-m2-tier-2", component: OCTAM2Tier2DashboardComponent }],
             },
             {
                 path: "projects",
+                title: "Projects",
                 canActivate: [UnauthenticatedAccessGuard],
                 children: [
                     { path: "", component: ProjectListComponent, canActivate: [JurisdictionManagerOrEditorOnlyGuard] },
@@ -77,8 +79,8 @@ export const routes: Routes = [
                         canActivate: [JurisdictionManagerOrEditorOnlyGuard],
                         children: [
                             { path: "", redirectTo: "instructions", pathMatch: "full" },
-                            { path: "instructions", component: ProjectInstructionsComponent },
-                            { path: "project-basics", component: ProjectBasicsComponent, canDeactivate: [UnsavedChangesGuard] },
+                            { path: "instructions", title: "Instructions", component: ProjectInstructionsComponent },
+                            { path: "project-basics", title: "Basics", component: ProjectBasicsComponent, canDeactivate: [UnsavedChangesGuard] },
                         ],
                     },
                     {
@@ -87,71 +89,76 @@ export const routes: Routes = [
                         canActivate: [JurisdictionManagerOrEditorOnlyGuard],
                         children: [
                             { path: "", redirectTo: "instructions", pathMatch: "full" },
-                            { path: "instructions", component: ProjectInstructionsComponent },
-                            { path: "project-basics", component: ProjectBasicsComponent, canDeactivate: [UnsavedChangesGuard] },
+                            { path: "instructions", title: "Instructions", component: ProjectInstructionsComponent },
+                            { path: "project-basics", title: "Basics", component: ProjectBasicsComponent, canDeactivate: [UnsavedChangesGuard] },
                             {
                                 path: "stormwater-treatments",
                                 children: [
                                     { path: "", redirectTo: "treatment-bmps", pathMatch: "full" },
-                                    { path: "treatment-bmps", component: TreatmentBmpsComponent, canDeactivate: [UnsavedChangesGuard] },
-                                    { path: "delineations", component: DelineationsComponent, canDeactivate: [UnsavedChangesGuard] },
-                                    { path: "modeled-performance-and-metrics", component: ModeledPerformanceComponent },
+                                    { path: "treatment-bmps", title: "Treatment BMPs", component: TreatmentBmpsComponent, canDeactivate: [UnsavedChangesGuard] },
+                                    { path: "delineations", title: "Delineations", component: DelineationsComponent, canDeactivate: [UnsavedChangesGuard] },
+                                    { path: "modeled-performance-and-metrics", title: "Modeled Performance and Metrics", component: ModeledPerformanceComponent },
                                 ],
                             },
-                            { path: "attachments", component: ProjectAttachmentsComponent },
-                            { path: "review-and-share", component: ReviewComponent },
+                            { path: "attachments", title: "Attachments", component: ProjectAttachmentsComponent },
+                            { path: "review-and-share", title: "Review and Share", component: ReviewComponent },
                         ],
                     },
                     { path: `:${routeParams.projectID}`, component: ProjectDetailComponent },
                 ],
             },
-            { path: "planning-map", component: PlanningMapComponent, canActivate: [UnauthenticatedAccessGuard, JurisdictionManagerOrEditorOnlyGuard] },
-            { path: "training", component: TrainingComponent, canActivate: [UnauthenticatedAccessGuard] },
+            { path: "planning-map", title: "Planning Map", component: PlanningMapComponent, canActivate: [UnauthenticatedAccessGuard, JurisdictionManagerOrEditorOnlyGuard] },
+            { path: "training", title: "Training", component: TrainingComponent, canActivate: [UnauthenticatedAccessGuard] },
         ],
     },
     {
         path: `trash`,
-        title: "Stormwater Tools | Orange County | Trash Module",
+        title: "Stormwater Tools",
         component: TrashSiteLayoutComponent,
         children: [
             { path: "", title: "Home", component: TrashHomeComponent },
             {
                 path: "land-use-blocks",
+                title: "Land Use Blocks",
                 component: TrashLandUseBlockIndexComponent,
                 canActivate: [UnauthenticatedAccessGuard],
             },
             {
                 path: "onland-visual-trash-assessments",
+                title: "OVTAs",
                 children: [
-                    { path: "", component: TrashOvtaIndexComponent, canActivate: [UnauthenticatedAccessGuard] },
+                    { path: "",  component: TrashOvtaIndexComponent, canActivate: [UnauthenticatedAccessGuard] },
                     { path: `:${routeParams.onlandVisualTrashAssessmentID}`, component: TrashOvtaDetailComponent, canActivate: [UnauthenticatedAccessGuard] },
                 ],
             },
             {
                 path: "onland-visual-trash-assessments/new",
+                title: "OVTAs",
                 component: TrashOvtaWorkflowOutletComponent,
                 children: [
                     { path: "", redirectTo: "instructions", pathMatch: "full" },
-                    { path: "instructions", component: TrashOvtaInstructionsComponent, canActivate: [UnauthenticatedAccessGuard] },
-                    { path: "initiate-ovta", component: TrashInitiateOvtaComponent, canActivate: [UnauthenticatedAccessGuard] },
+                    { path: "instructions", title: "Instructions", component: TrashOvtaInstructionsComponent, canActivate: [UnauthenticatedAccessGuard] },
+                    { path: "initiate-ovta", title: "Initiate OVTA", component: TrashInitiateOvtaComponent, canActivate: [UnauthenticatedAccessGuard] },
                 ],
             },
             {
                 path: `onland-visual-trash-assessments/edit/:${routeParams.onlandVisualTrashAssessmentID}`,
+                title: "OVTAs",
                 component: TrashOvtaWorkflowOutletComponent,
                 children: [
                     { path: "", redirectTo: "instructions", pathMatch: "full" },
-                    { path: "instructions", component: TrashOvtaInstructionsComponent, canActivate: [UnauthenticatedAccessGuard] },
-                    { path: "initiate-ovta", component: TrashInitiateOvtaComponent, canActivate: [UnauthenticatedAccessGuard] },
-                    { path: "record-observations", component: TrashOvtaRecordObservationsComponent, canActivate: [UnauthenticatedAccessGuard] },
-                    { path: "add-or-remove-parcels", component: TrashOvtaAddRemoveParcelsComponent, canActivate: [UnauthenticatedAccessGuard] },
-                    { path: "refine-assessment-area", component: TrashOvtaRefineAssessmentAreaComponent, canActivate: [UnauthenticatedAccessGuard] },
-                    { path: "review-and-finalize", component: TrashOvtaReviewAndFinalizeComponent, canActivate: [UnauthenticatedAccessGuard] },
+                    { path: "instructions", title: "Instructions", component: TrashOvtaInstructionsComponent, canActivate: [UnauthenticatedAccessGuard] },
+                    { path: "initiate-ovta", title: "Initiate OVTA", component: TrashInitiateOvtaComponent, canActivate: [UnauthenticatedAccessGuard] },
+                    { path: "record-observations", title: "Record Observations", component: TrashOvtaRecordObservationsComponent, canActivate: [UnauthenticatedAccessGuard] },
+                    { path: "add-or-remove-parcels", title: "Add or Remove Parcels", component: TrashOvtaAddRemoveParcelsComponent, canActivate: [UnauthenticatedAccessGuard] },
+                    { path: "refine-assessment-area", title: "Refine Assessment Area", component: TrashOvtaRefineAssessmentAreaComponent, canActivate: [UnauthenticatedAccessGuard] },
+                    { path: "review-and-finalize", title: "Review and Finalize", component: TrashOvtaReviewAndFinalizeComponent, canActivate: [UnauthenticatedAccessGuard] },
                 ],
             },
 
             {
                 path: "onland-visual-trash-assessment-areas",
+                title: "OVTA Areas",
                 children: [
                     { path: "", component: TrashOvtaAreaIndexComponent, canActivate: [UnauthenticatedAccessGuard] },
                     {
@@ -168,6 +175,7 @@ export const routes: Routes = [
             },
             {
                 path: "trash-generating-units",
+                title: "Trash Analysis Areas",
                 component: TrashTrashGeneratingUnitIndexComponent,
                 canActivate: [UnauthenticatedAccessGuard],
             },
@@ -178,14 +186,14 @@ export const routes: Routes = [
     { path: "signin-oidc", component: LoginCallbackComponent },
     {
         path: ``,
-        title: "Stormwater Tools | Orange County",
+        title: "Stormwater Tools",
         component: SiteLayoutComponent,
         children: [
             { path: "", component: HomeIndexComponent },
             { path: "about", component: AboutComponent },
             { path: "modeling", component: ModelingAboutComponent },
             { path: `labels-and-definitions/:${routeParams.definitionID}`, component: FieldDefinitionEditComponent, canActivate: [UnauthenticatedAccessGuard, ManagerOnlyGuard] },
-            { path: "labels-and-definitions", component: FieldDefinitionListComponent, canActivate: [UnauthenticatedAccessGuard, ManagerOnlyGuard] },
+            { path: "labels-and-definitions", title: "Labels and Definitions", component: FieldDefinitionListComponent, canActivate: [UnauthenticatedAccessGuard, ManagerOnlyGuard] },
         ],
     },
     { path: "not-found", component: NotFoundComponent },

--- a/Neptune.Web/src/app/pages/home/home-index/home-index.component.html
+++ b/Neptune.Web/src/app/pages/home/home-index/home-index.component.html
@@ -88,6 +88,7 @@
                     <ul>
                         <li><a [routerLink]="['/trash']">Results</a></li>
                         <li><a [routerLink]="['/trash/onland-visual-trash-assessments']">View All OVTAs</a></li>
+                        <li><a [routerLink]="['/trash/onland-visual-trash-assessment-areas']">View All OVTA Areas</a></li>
                     </ul>
                 </div>
             </div>

--- a/Neptune.Web/src/app/pages/planning-module/planning-home/planning-home/planning-home.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/planning-home/planning-home/planning-home.component.html
@@ -1,7 +1,7 @@
 <div class="grid-12 page-wrapper">
     <div class="g-col-8">
         <app-alert-display></app-alert-display>
-        <h1 class="text-primary mt-4 mb-4">Planning Module</h1>
+        <h1 class="page-title mt-4 mb-4">Planning Module</h1>
 
         <ng-container *ngIf="currentUser$ | async as currentUser">
             <div *ngIf="userIsUnassigned(currentUser)" class="alert alert-info">

--- a/Neptune.Web/src/app/pages/site-layout/site-layout.component.html
+++ b/Neptune.Web/src/app/pages/site-layout/site-layout.component.html
@@ -2,35 +2,47 @@
     <header-nav moduleTitle=""></header-nav>
 
     <nav class="site-nav">
-        <div class="collapse navbar-collapse" *ngIf="currentUser$ | async as currentUser">
-            <ul class="site-nav__links site-nav__main">
-                <li class="nav-item" routerLinkActive="active">
-                    <a [href]="siteUrl + '/DataHub/Index'" class="nav-link" role="button"> Data Hub </a>
-                </li>
-                <li class="nav-item dropdown" routerLinkActive="active" *ngIf="isAdministrator(currentUser) || isJurisdicionManager(currentUser)">
-                    <a
-                        href="javascript:void(0);"
-                        [dropdownToggle]="manageToggle"
-                        class="nav-link dropdown-toggle"
-                        role="button"
-                        data-toggle="dropdown"
-                        aria-haspopup="true"
-                        aria-expanded="false">
-                        <span class="nav-link__label">
-                            Manage
-                            <icon icon="AngleDown"></icon>
-                        </span>
-                    </a>
-
-                    <div #manageToggle class="dropdown-menu" aria-labelledby="navbarDropdown">
-                        <div class="dropdown-divider"></div>
-                        <a href="{{ usersListUrl() }}" class="dropdown-item" *ngIf="isAdministrator(currentUser) || isJurisdicionManager(currentUser)"> Users </a>
-                        <a href="{{ organizationsIndexUrl() }}" class="dropdown-item" *ngIf="isAdministrator(currentUser)"> Organizations </a>
-                        <a [routerLink]="['/labels-and-definitions']" class="dropdown-item" *ngIf="isAdministrator(currentUser)"> Labels and Definitions </a>
-                    </div>
-                </li>
-            </ul>
+        <div  *ngIf="currentUser$ | async as currentUser" style="width: 100%">
+            <button class="hamburger-btn navbar-toggle collapsed" type="button" [dropdownToggle]="mainMenuToggle" aria-controls="hamburger-btn" aria-expanded="false">
+                <span class="sr-only">Open main menu</span>
+                <svg aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        fill-rule="evenodd"
+                        d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+                        clip-rule="evenodd"></path>
+                </svg>
+            </button>
+            <div #mainMenuToggle class="site-nav__wrapper collapse navbar-collapse">
+                <ul class="site-nav__links site-nav__main">
+                    <li class="nav-item" routerLinkActive="active">
+                        <a [href]="siteUrl + '/DataHub/Index'" class="nav-link" role="button"> Data Hub </a>
+                    </li>
+                    <li class="nav-item dropdown" routerLinkActive="active" *ngIf="isAdministrator(currentUser) || isJurisdicionManager(currentUser)">
+                        <a
+                            href="javascript:void(0);"
+                            [dropdownToggle]="manageToggle"
+                            class="nav-link dropdown-toggle"
+                            role="button"
+                            data-toggle="dropdown"
+                            aria-haspopup="true"
+                            aria-expanded="false">
+                            <span class="nav-link__label">
+                                Manage
+                                <icon icon="AngleDown"></icon>
+                            </span>
+                        </a>
+    
+                        <div #manageToggle class="dropdown-menu" aria-labelledby="navbarDropdown">
+                            <div class="dropdown-divider"></div>
+                            <a href="{{ usersListUrl() }}" class="dropdown-item" *ngIf="isAdministrator(currentUser) || isJurisdicionManager(currentUser)"> Users </a>
+                            <a href="{{ organizationsIndexUrl() }}" class="dropdown-item" *ngIf="isAdministrator(currentUser)"> Organizations </a>
+                            <a [routerLink]="['/labels-and-definitions']" class="dropdown-item" *ngIf="isAdministrator(currentUser)"> Labels and Definitions </a>
+                        </div>
+                    </li>
+                </ul>
+            </div>
         </div>
+       
     </nav>
 </header>
 

--- a/Neptune.Web/src/app/pages/site-layout/site-layout.component.scss
+++ b/Neptune.Web/src/app/pages/site-layout/site-layout.component.scss
@@ -1,103 +1,6 @@
 @use "/src/scss/abstracts" as *;
 
-.admin-nav {
-    color: white;
-    //  height: 5rem;
-    //        padding: 1.5rem 2rem;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
 
-    &__wrapper {
-        @include desktop-medium-max {
-            padding: 2rem;
-            position: fixed;
-            top: 0;
-            left: 0;
-            z-index: 7777;
-            display: flex;
-            flex-direction: column;
-            height: 100vh;
-            width: 100vw;
-            max-width: 30rem;
-            background-color: $primary;
-            outline: 0;
-            transform: translateX(-30rem);
-            transition: transform 0.3s ease-in-out;
-            visibility: hidden;
-
-            &.active {
-                visibility: visible;
-                transform: translateX(0);
-            }
-        }
-
-        @include desktop-medium {
-            padding: 0.5rem;
-            flex: 1;
-            display: flex;
-            align-items: center;
-        }
-    }
-
-    &__close {
-        background: transparent;
-        border: none;
-        color: $white;
-        font-size: $type-size-400;
-        position: absolute;
-        right: 0;
-        top: 0;
-        padding: 1rem;
-
-        @include desktop-medium {
-            display: none;
-        }
-    }
-
-    &__links {
-        @include desktop-medium {
-            display: flex;
-            align-items: center;
-        }
-    }
-
-    &__utilities {
-        margin-top: 2rem;
-        border-top: 1px solid white;
-        padding-top: 2rem;
-
-        @include desktop-medium {
-            padding-top: 0;
-            margin-left: auto;
-            margin-top: 0;
-            border-top: none;
-        }
-
-        .nav-link {
-            color: $primary;
-
-            &__label {
-                color: $primary;
-            }
-        }
-    }
-
-    &__main {
-        .nav-link {
-            color: $teal-800;
-
-            &__label {
-                color: $teal-800;
-                margin-right: 2rem;
-            }
-        }
-    }
-
-    a.navbar-brand {
-        font-size: $type-size-400;
-    }
-}
 .site-nav {
     background-color: $primary;
     color: $white;
@@ -107,32 +10,39 @@
     align-items: center;
     justify-content: space-between;
 
+    @include desktop-medium-max {
+        justify-content: end;
+        height: unset;
+        padding: .5rem 2rem;
+    }
+
     &__wrapper {
         @include desktop-medium-max {
-            padding: 2rem;
-            position: fixed;
-            top: 0;
+            
+            position: relative;
+            height: 0;
+            max-height: 0;
             left: 0;
             z-index: 7777;
             display: flex;
             flex-direction: column;
-            height: 100vh;
+            
             width: 100vw;
             max-width: 30rem;
             background-color: $primary;
             outline: 0;
-            transform: translateX(-30rem);
-            transition: transform 0.3s ease-in-out;
+            transition: max-height 0.3s ease-in-out;
             visibility: hidden;
 
             &.active {
+                padding: 2rem;
+                height: auto;
+                max-height: 1000px;
                 visibility: visible;
-                transform: translateX(0);
             }
         }
 
         @include desktop-medium {
-            padding-top: 0.5rem;
             flex: 1;
             display: flex;
             align-items: center;
@@ -198,6 +108,7 @@
     margin: 0;
     border: none;
     display: block;
+    justify-self: end;
 
     @include desktop-medium {
         display: none;
@@ -232,6 +143,8 @@
                 border-top: none;
                 padding-top: 0;
             }
+
+            
         }
 
         .username {
@@ -242,6 +155,10 @@
         .dropdown-item{
             padding: 5px 20px;
             font-weight: bold;
+
+            @include desktop-medium-max{
+                color: white;
+            }
         }
     }
 
@@ -298,6 +215,11 @@
             cursor: default;
         }
     }
+
+    @include desktop-medium-max {
+        display: block;
+    }
+
 }
 
 .dropdown-toggle {
@@ -317,5 +239,21 @@
                 height: 100%;
             }
         }
+    }
+}
+
+.qa-warning {
+    margin: 0;
+    padding: 1rem;
+    font-size: $type-size-200;
+    background: $black;
+    text-align: center;
+    color: $white;
+    z-index: 1;
+    position: relative;
+
+    span.fa {
+        padding-right: 0.5rem;
+        color: $red-default;
     }
 }

--- a/Neptune.Web/src/app/pages/trash-module/trash-home/trash-home.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/trash-home/trash-home.component.html
@@ -1,7 +1,7 @@
 <div class="grid-12 page-wrapper">
     <div class="g-col-8">
         <app-alert-display></app-alert-display>
-        <h1 class="text-primary mt-4 mb-4">Trash Module</h1>
+        <h1 class="page-title mt-4 mb-4">Trash Module</h1>
         <custom-rich-text [customRichTextTypeID]="richTextTypeID"></custom-rich-text>
     </div>
 

--- a/Neptune.Web/src/app/pages/trash-module/trash-land-use-block-index/trash-land-use-block-index.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/trash-land-use-block-index/trash-land-use-block-index.component.ts
@@ -33,12 +33,19 @@ export class TrashLandUseBlockIndexComponent {
     ngOnInit() {
         this.landUseBlockColumnDefs = [
             this.utilityFunctionsService.createBasicColumnDef("Block ID", "LandUseBlockID"),
-            this.utilityFunctionsService.createBasicColumnDef("Land Use Type", "PriorityLandUseTypeName"),
+            this.utilityFunctionsService.createBasicColumnDef("Land Use Type", "PriorityLandUseTypeName", {
+                CustomDropdownFilterField: "PriorityLandUseTypeName",
+            }),
             this.utilityFunctionsService.createBasicColumnDef("Jurisdiction", "StormwaterJurisdictionName", {
                 CustomDropdownFilterField: "StormwaterJurisdictionName",
             }),
             this.utilityFunctionsService.createDecimalColumnDef("Block Area", "Area"),
-            this.utilityFunctionsService.createDecimalColumnDef("Trash Generation Rate", "TrashGenerationRate"),
+            this.utilityFunctionsService.createDecimalColumnDef("Trash Generation Rate", "TrashGenerationRate", {
+                CustomDropdownFilterField: "TrashGenerationRate",
+            }),
+            this.utilityFunctionsService.createBasicColumnDef("Land Use Description", "LandUseDescription", {
+                CustomDropdownFilterField: "LandUseDescription",
+            }),
             this.utilityFunctionsService.createDecimalColumnDef("Median Household Income Residential", "MedianHouseholdIncomeResidential"),
             this.utilityFunctionsService.createDecimalColumnDef("Median Household Income Retail", "MedianHouseholdIncomeRetail"),
             this.utilityFunctionsService.createDecimalColumnDef("Trash Results Area", "MedianHouseholdIncomeRetail"),

--- a/Neptune.Web/src/app/pages/trash-module/trash-trash-generating-unit-index/trash-trash-generating-unit-index.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/trash-trash-generating-unit-index/trash-trash-generating-unit-index.component.ts
@@ -27,28 +27,46 @@ export class TrashTrashGeneratingUnitIndexComponent {
     ngOnInit() {
         this.trashGeneratingUnitsColumnDefs = [
             this.utilityFunctionsService.createBasicColumnDef("Trash Analysis Area ID", "TrashGeneratingUnitID"),
-            this.utilityFunctionsService.createBasicColumnDef("Land Use Type", "PriorityLandUseTypeDisplayName"),
-            this.utilityFunctionsService.createLinkColumnDef("Governing OVTA Area", "OnlandVisualTrashAssessmentAreaName", "OnlandVisualTrashAssessmentAreaID", {
-                InRouterLink: "../onland-visual-trash-assessment-area/",
+            this.utilityFunctionsService.createBasicColumnDef("Land Use Type", "PriorityLandUseTypeDisplayName", {
+                CustomDropdownFilterField: "PriorityLandUseTypeDisplayName",
             }),
-            this.utilityFunctionsService.createBasicColumnDef("Governing OVTA Area Baseline Score", "OnlandVisualTrashAssessmentAreaBaselineScore"),
+            this.utilityFunctionsService.createLinkColumnDef("Governing OVTA Area", "OnlandVisualTrashAssessmentAreaName", "OnlandVisualTrashAssessmentAreaID", {
+                InRouterLink: "../onland-visual-trash-assessment-area/"
+            }),
+            this.utilityFunctionsService.createBasicColumnDef("Governing OVTA Area Baseline Score", "OnlandVisualTrashAssessmentAreaBaselineScore", {
+                CustomDropdownFilterField: "OnlandVisualTrashAssessmentAreaBaselineScore",
+            }),
             this.utilityFunctionsService.createBasicColumnDef("Governing Treatment BMP", ""),
             this.utilityFunctionsService.createBasicColumnDef("Governing WQMP", "WaterQualityManagementPlanName"),
             this.utilityFunctionsService.createBasicColumnDef("Jurisdiction", "StormwaterJurisdictionName", {
                 CustomDropdownFilterField: "StormwaterJurisdictionName",
             }),
             this.utilityFunctionsService.createDecimalColumnDef("Area", "Area"),
-            this.utilityFunctionsService.createDecimalColumnDef("Baseline Loading Rate", "BaselineLoadingRate"),
-            this.utilityFunctionsService.createDecimalColumnDef("Current Loading Rate", "CurrentLoadingRate"),
+            this.utilityFunctionsService.createDecimalColumnDef("Baseline Loading Rate", "BaselineLoadingRate", {
+                CustomDropdownFilterField: "BaselineLoadingRate",
+            }),
+            this.utilityFunctionsService.createDecimalColumnDef("Current Loading Rate", "CurrentLoadingRate", {
+                CustomDropdownFilterField: "CurrentLoadingRate",
+            }),
             this.utilityFunctionsService.createBasicColumnDef("Trash Capture Status via BMP", "TrashCaptureStatusBMP"),
             this.utilityFunctionsService.createBasicColumnDef("Trash Capture Status via WQMP", "TrashCaptureStatusWQMP"),
-            this.utilityFunctionsService.createBasicColumnDef("Trash Capture Effectiveness via BMP", "TrashCaptureStatusBMP"),
-            this.utilityFunctionsService.createBasicColumnDef("Trash Capture Effectiveness via WQMP", "TrashCaptureStatusWQMP"),
+            this.utilityFunctionsService.createBasicColumnDef("Trash Capture Effectiveness via BMP", "TrashCaptureStatusBMP", {
+                CustomDropdownFilterField: "TrashCaptureStatusBMP",
+            }),
+            this.utilityFunctionsService.createBasicColumnDef("Trash Capture Effectiveness via WQMP", "TrashCaptureStatusWQMP", {
+                CustomDropdownFilterField: "TrashCaptureStatusWQMP",
+            }),
             this.utilityFunctionsService.createDecimalColumnDef("Median Household Income (Residential)", "MedianHouseholdIncomeResidential"),
             this.utilityFunctionsService.createDecimalColumnDef("Median Household Income (Retail)", "MedianHouseholdIncomeRetail"),
-            this.utilityFunctionsService.createBasicColumnDef("Permit Class", "PermitTypeName"),
-            this.utilityFunctionsService.createBasicColumnDef("Land Use for TGR", "LandUseForTGR"),
-            this.utilityFunctionsService.createBasicColumnDef("Land Use Default TGR", "TrashGenerationRate"),
+            this.utilityFunctionsService.createBasicColumnDef("Permit Class", "PermitTypeName", {
+                CustomDropdownFilterField: "PermitTypeName",
+            }),
+            this.utilityFunctionsService.createBasicColumnDef("Land Use for TGR", "LandUseForTGR", {
+                CustomDropdownFilterField: "LandUseForTGR",
+            }),
+            this.utilityFunctionsService.createBasicColumnDef("Land Use Default TGR", "TrashGenerationRate", {
+                CustomDropdownFilterField: "TrashGenerationRate",
+            }),
             this.utilityFunctionsService.createDateColumnDef("Last Updated Date", "LastUpdateDate", "MM/dd/yyyy"),
         ];
         this.trashGeneratingUnits$ = this.trashGeneratingUnitService.trashGeneratingUnitsGet().pipe(tap((x) => (this.isLoading = false)));

--- a/Neptune.Web/src/app/strategies/page-title-strategy.ts
+++ b/Neptune.Web/src/app/strategies/page-title-strategy.ts
@@ -11,7 +11,7 @@ export class PageTitleStrategy extends TitleStrategy {
     override updateTitle(routerState: RouterStateSnapshot) {
         const titles = this.getTitleHierarchyFromActivatedRouteShapshot(routerState);
         if (titles.length > 0) {
-            const fullTitle = titles.join(" - ");
+            const fullTitle = titles.join(" | ");
             this.title.setTitle(`${fullTitle}`);
         } else {
             this.title.setTitle(`Stormwater Tools | Orange County`);
@@ -24,7 +24,8 @@ export class PageTitleStrategy extends TitleStrategy {
         let params = [];
         while (activatedRouteSnapshot.firstChild != null) {
             activatedRouteSnapshot = activatedRouteSnapshot.firstChild;
-            titles = activatedRouteSnapshot.title ? [...titles, activatedRouteSnapshot.title] : [...titles];
+            // only add the title if it doesn't match one already in the array
+            titles = activatedRouteSnapshot.title && !titles.includes(activatedRouteSnapshot.title) ? [...titles, activatedRouteSnapshot.title] : [...titles];
             // lets just take the last params
             params = Object.values(activatedRouteSnapshot.params);
         }

--- a/Neptune.Web/src/scss/utilities/_headings.scss
+++ b/Neptune.Web/src/scss/utilities/_headings.scss
@@ -13,7 +13,7 @@ h6 {
     font-weight: 400;
     font-size: $type-size-600;
     padding-bottom: 0.5rem;
-    color: $gray-1000;
+    color: $primary;
 
     @include desktop-small {
         font-size: $type-size-700;

--- a/Neptune.WebMvc/Views/DataHub/IndexViewData.cs
+++ b/Neptune.WebMvc/Views/DataHub/IndexViewData.cs
@@ -132,9 +132,9 @@ namespace Neptune.WebMvc.Views.DataHub
             
             WQMPListUrl = SitkaRoute<WaterQualityManagementPlanController>.BuildUrlFromExpression(linkGenerator, x => x.Index());
 
-            OVTAListUrl = $"{webConfiguration.PlanningModuleBaseUrl}/trash/onland-visual-trash-assessment";
-            TrashGeneratingUnitsAuditListUrl = $"{webConfiguration.PlanningModuleBaseUrl}/trash/trash-generating-unit";
-            LandUseBlocksUrl = $"{webConfiguration.PlanningModuleBaseUrl}/trash/land-use-block";
+            OVTAListUrl = $"{webConfiguration.PlanningModuleBaseUrl}/trash/onland-visual-trash-assessments";
+            TrashGeneratingUnitsAuditListUrl = $"{webConfiguration.PlanningModuleBaseUrl}/trash/trash-generating-units";
+            LandUseBlocksUrl = $"{webConfiguration.PlanningModuleBaseUrl}/trash/land-use-blocks";
             
             ParcelMapUrl = SitkaRoute<ParcelController>.BuildUrlFromExpression(linkGenerator, x => x.Index());
             


### PR DESCRIPTION
Added titles to app.routes.ts and updated logic in page-title-strategy.ts so duplicates are not included (e.g. "Stormwater Tools" is not repeated if the route does not have another title). Fixed typo in links from Data Hub. Made Trash home and Planning home page titles use the pate-title class to better match other pages (gave that class the teal color). Add link for "View All OVTA Areas" to main home page.

 nice to haves: changed the filters for several grid columns of Land Use Blocks and Trash Analysis Areas to be checkboxes instead of general search filters.
