### PR TITLE
NPT-927: rework for dropdown select grid filters

### DIFF
--- a/Neptune.Web/src/app/shared/components/custom-dropdown-filter/custom-dropdown-filter.component.html
+++ b/Neptune.Web/src/app/shared/components/custom-dropdown-filter/custom-dropdown-filter.component.html
@@ -5,7 +5,7 @@
         <input type="radio" name="select-all" id="deselect" [checked]="state.deselectAll" (change)="onDeselectAll()" />
         <label for="deselect">Deselect All</label>
     </div>
-    <div id="filter-options" class="pt-2 pl-2">
+    <div id="filter-options" class="pt-2 pl-2 pb-2 pr-2">
         <div *ngFor="let element of getDropdownValues()">
             <input type="checkbox" name="{{ element }}" [(ngModel)]="state.filterOptions[element]" (ngModelChange)="updateFilter()" checked />
             <label for="{{ element }}" class="ml-2">{{ element }}</label>

--- a/Neptune.Web/src/app/shared/components/custom-dropdown-filter/custom-dropdown-filter.component.ts
+++ b/Neptune.Web/src/app/shared/components/custom-dropdown-filter/custom-dropdown-filter.component.ts
@@ -147,6 +147,19 @@ export class CustomDropdownFilterComponent implements AgFilterComponent {
     }
 
     getDropdownValues() {
+        // sort numbers numerically (not as strings). Check the first and last item of the array because there can be at most one "null" element
+        if(this.dropdownValues.length > 0 && (typeof(this.dropdownValues[0]) == 'number' || typeof(this.dropdownValues[this.dropdownValues.length - 1]) == 'number')){
+            return this.dropdownValues.sort(function(a, b) { 
+                if(a != null && b != null){
+                    return a - b; 
+                }
+                // sort the null/blank item first
+                if(a == null){
+                    return -1
+                }
+                return 1
+            });
+        }
         return this.dropdownValues.sort();
     }
 


### PR DESCRIPTION
 increase padding for grid custom dropdown filter.  Update sort logic for custom-dropdown-filter so number columns have a filter options sorted numerically (with the null/blank option first to match string column dropdowns)