### PR TITLE
Features/npt 929

### DIFF
--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.html
@@ -20,8 +20,9 @@
             (onMapLoad)="handleMapReady($event)"
             [selectedValue]="ovtaAreaID"
             [selectionFromMap]="selectionFromMap"
-            (selectedValueChange)="onSelectedOVTAAreaChangedFromGrid($event)">
-            <div mapLayers *ngIf="mapIsReady">
+            (selectedValueChange)="onSelectedOVTAAreaChangedFromGrid($event)"
+            *ngIf="boundingBox$ | async as boundingBox" [boundingBox]="boundingBox">
+            <div mapLayers *ngIf="mapIsReady" >
                 <selected-ovta-area-layer
                     *ngIf="mapIsReady"
                     [displayOnLoad]="true"

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.html
@@ -19,7 +19,8 @@
             entityIDField="OnlandVisualTrashAssessmentAreaID"
             (onMapLoad)="handleMapReady($event)"
             [selectedValue]="ovtaAreaID"
-            (selectedValueChange)="onSelectedOVTAAreaChanged($event)">
+            [selectionFromMap]="selectionFromMap"
+            (selectedValueChange)="onSelectedOVTAAreaChangedFromGrid($event)">
             <div mapLayers *ngIf="mapIsReady">
                 <selected-ovta-area-layer
                     *ngIf="mapIsReady"

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.ts
@@ -22,6 +22,8 @@ import { Alert } from "src/app/shared/models/alert";
 import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 import { AlertService } from "src/app/shared/services/alert.service";
 import { AuthenticationService } from "src/app/services/authentication.service";
+import { StormwaterJurisdictionService } from "src/app/shared/generated/api/stormwater-jurisdiction.service";
+import { BoundingBoxDto } from "src/app/shared/generated/model/bounding-box-dto";
 
 @Component({
     selector: "trash-ovta-area-index",
@@ -42,6 +44,7 @@ export class TrashOvtaAreaIndexComponent {
     public layerControl: layerControl;
     public bounds: any;
     public mapIsReady: boolean = false;
+    public boundingBox$: Observable<BoundingBoxDto>;
 
     constructor(
         private onlandVisualTrashAssessmentService: OnlandVisualTrashAssessmentService,
@@ -50,7 +53,8 @@ export class TrashOvtaAreaIndexComponent {
         private router: Router,
         private alertService: AlertService,
         private confirmService: ConfirmService,
-        private authenticationService: AuthenticationService
+        private authenticationService: AuthenticationService,
+        private stormwaterJurisdictionService: StormwaterJurisdictionService 
     ) {}
 
     ngOnInit(): void {
@@ -80,6 +84,7 @@ export class TrashOvtaAreaIndexComponent {
             this.utilityFunctionsService.createBasicColumnDef("Description", "AssessmentAreaDescription"),
         ];
         this.onlandVisualTrashAssessmentAreas$ = this.onlandVisualTrashAssessmentAreaService.onlandVisualTrashAssessmentAreasGet().pipe(tap((x) => (this.isLoading = false)));
+        this.boundingBox$ = this.stormwaterJurisdictionService.jurisdictionsBoundingBoxGet();
     }
 
     public handleMapReady(event: NeptuneMapInitEvent) {

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.ts
@@ -36,6 +36,7 @@ export class TrashOvtaAreaIndexComponent {
     public isLoading: boolean = true;
     public url = environment.ocStormwaterToolsBaseUrl;
     public ovtaAreaID: number;
+    public selectionFromMap: boolean;
 
     public map: Map;
     public layerControl: layerControl;
@@ -56,7 +57,7 @@ export class TrashOvtaAreaIndexComponent {
         this.ovtaAreaColumnDefs = [
             this.utilityFunctionsService.createActionsColumnDef((params: any) => {
                 return [
-                    { ActionName: "View", ActionHandler: () => this.router.navigate(["trash", "onland-visual-trash-assessments", params.data.OnlandVisualTrashAssessmentID]) },
+                    { ActionName: "View", ActionHandler: () => this.router.navigate(["trash", "onland-visual-trash-assessment-areas", params.data.OnlandVisualTrashAssessmentAreaID]) },
                     {
                         ActionName: "Add New OVTA",
                         ActionHandler: () =>
@@ -87,10 +88,19 @@ export class TrashOvtaAreaIndexComponent {
         this.mapIsReady = true;
     }
 
+    public onSelectedOVTAAreaChangedFromGrid(selectedOVTAAreaID) {
+        if (this.ovtaAreaID == selectedOVTAAreaID) return;
+
+        this.ovtaAreaID = selectedOVTAAreaID;
+        this.selectionFromMap = false;
+        return this.ovtaAreaID; 
+    }
+
     public onSelectedOVTAAreaChanged(selectedOVTAAreaID) {
         if (this.ovtaAreaID == selectedOVTAAreaID) return;
 
         this.ovtaAreaID = selectedOVTAAreaID;
+        this.selectionFromMap = true;
         return this.ovtaAreaID;
     }
 

--- a/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.html
+++ b/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.html
@@ -42,7 +42,7 @@
     </div>
 
     <div class="tab-nav-panel" [class.g-col-6]="selectedPanel === 'Hybrid'" [class.g-col-12]="selectedPanel === 'Map'" [class.hidden]="selectedPanel === 'Grid'">
-        <neptune-map class="location-card" [mapHeight]="mapHeight" (onMapLoad)="handleMapReady($event)">
+        <neptune-map class="location-card" [mapHeight]="mapHeight" (onMapLoad)="handleMapReady($event)" [boundingBox]="boundingBox">
             <ng-container *ngIf="mapIsReady">
                 <ng-content select="[mapLayers]"></ng-content>
             </ng-container>

--- a/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.ts
+++ b/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.ts
@@ -8,6 +8,7 @@ import { CommonModule } from "@angular/common";
 import { NeptuneGridHeaderComponent } from "../neptune-grid-header/neptune-grid-header.component";
 import { NeptuneGridComponent } from "../neptune-grid/neptune-grid.component";
 import { NeptuneMapComponent, NeptuneMapInitEvent } from "../leaflet/neptune-map/neptune-map.component";
+import { BoundingBoxDto } from "../../generated/model/bounding-box-dto";
 
 @Component({
     selector: "hybrid-map-grid",
@@ -24,6 +25,7 @@ export class HybridMapGridComponent {
     @Input() selectionFromMap: boolean;
     @Input() entityIDField: string = "";
     @Input() mapHeight: string = "720px";
+    @Input() boundingBox: BoundingBoxDto;
 
     @Output() onMapLoad: EventEmitter<NeptuneMapInitEvent> = new EventEmitter();
     @Output() selectedValueChange: EventEmitter<number> = new EventEmitter<number>();

--- a/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.ts
+++ b/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.ts
@@ -21,6 +21,7 @@ export class HybridMapGridComponent {
     @Input() columnDefs: ColDef[];
     @Input() downloadFileName: string;
     @Input() selectedValue: number = null;
+    @Input() selectionFromMap: boolean;
     @Input() entityIDField: string = "";
     @Input() mapHeight: string = "720px";
 
@@ -43,7 +44,15 @@ export class HybridMapGridComponent {
         if (changes.selectedValue) {
             if (changes.selectedValue.previousValue == changes.selectedValue.currentValue) return;
             this.selectedValue = changes.selectedValue.currentValue;
-            this.onMapSelectionChanged(this.selectedValue);
+            
+            // only want to call onMapSelectionChanged if the change to selectedValue originated from the Map.
+            // This will find the row in the grid for the selectedValue and scroll it to the top of the grid
+            if (changes.selectionFromMap){
+                this.selectionFromMap = changes.selectionFromMap.currentValue;
+            }
+            if (this.selectionFromMap){
+                this.onMapSelectionChanged(this.selectedValue);
+            }
         }
     }
 
@@ -87,12 +96,7 @@ export class HybridMapGridComponent {
         const selectedNodes = this.gridApi.getSelectedNodes();
 
         this.selectedValue = selectedNodes.length > 0 ? selectedNodes[0].data[this.entityIDField] : null;
-        this.gridApi.forEachNode((node, index) => {
-            if (node.data[this.entityIDField] == this.selectedValue) {
-                node.setSelected(true, true);
-                this.gridApi.ensureIndexVisible(index, "top");
-            }
-        });
+        // do not scroll the row for the selected value to the top. Since the selection origniated from clicking the grid, it is already in view
         this.selectedValueChange.emit(this.selectedValue);
     }
 

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/selected-ovta-area-layer/selected-ovta-area-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/selected-ovta-area-layer/selected-ovta-area-layer.component.ts
@@ -125,10 +125,6 @@ export class SelectedOvtaAreaLayerComponent extends MapLayerBase implements OnCh
 
                     geoJson.addTo(this.layer);
                 });
-
-                const bounds = this.layer.getBounds();
-                this.map.fitBounds(bounds);
-                this.layerBoundsCalculated.emit(bounds);
             });
     }
 


### PR DESCRIPTION
- Fixed typo in "View" action of the Action drop down.
- Changes to hybrid-map-grid: need to pay attention to whether the selectedValue change is coming from a grid row selection or map area selection.  If it is a grid row selection, we will no longer scroll the selected row to the top (the user clicked the row on the grid so it is already visible and the scroll is jarring when using the Actions dropdown).  If the selectedValue change is coming from the map, then we do need to scroll the row for that selectedValue into view in the grid.
- pass in a boundingBox to hybrid-map-grid (it will use the defaultBoundingBox if not passed in) so that we can bound the OVTA Area map to a user's jurisdiction(s). Do not fit bounds in selected-ovta-area-layer as that will zoom the map back out to show all of the layer instead of just bounded to a user's jurisdictions.