### PR TITLE
NPT-881: try to prevent overlapping TGUs

### DIFF
--- a/Neptune.QGISAPI/ComputeTrashGeneratingUnits.py
+++ b/Neptune.QGISAPI/ComputeTrashGeneratingUnits.py
@@ -179,7 +179,7 @@ class Flatten:
         res = processing.run("qgis:joinattributesbylocation", {
 	        'INPUT': self.working_layer,
 	        'JOIN': dupe,
-	        'PREDICATE': ['2'], # 5 := Within
+	        'PREDICATE': ['5'], # 5 := Within
 	        'JOIN_FIELDS':'',
 	        'METHOD':'0',
 	        'DISCARD_NONMATCHING':False,


### PR DESCRIPTION
the handleInclusionsInCandidateLayer method should be using PREDICATE = 5 (as in the comment), not 2 (I believe this was a bad copy/paste from the removeEqualitiesFromCandidateLayer method)