### PR TITLE
NPT-934: Delineation upload tweaks/bug fix

### DIFF
--- a/Neptune.EFModels/Entities/Delineation.cs
+++ b/Neptune.EFModels/Entities/Delineation.cs
@@ -47,5 +47,28 @@ namespace Neptune.EFModels.Entities
             await dbContext.ProjectNereidResults.Where(x => x.DelineationID == DelineationID).ExecuteDeleteAsync();
             await dbContext.Delineations.Where(x => x.DelineationID == DelineationID).ExecuteDeleteAsync();
         }
+
+        public static async Task DeleteFull(NeptuneDbContext dbContext, int delineationID)
+        {
+            await dbContext.DelineationOverlaps.Where(x => x.DelineationID == delineationID).ExecuteDeleteAsync();
+            await dbContext.DelineationOverlaps.Where(x => x.OverlappingDelineationID == delineationID).ExecuteDeleteAsync();
+            await dbContext.DirtyModelNodes.Where(x => x.DelineationID == delineationID).ExecuteDeleteAsync();
+            await dbContext.HRUCharacteristics.Include(x => x.LoadGeneratingUnit).Where(x => x.LoadGeneratingUnit.DelineationID == delineationID)
+                .ExecuteDeleteAsync();
+            await dbContext.LoadGeneratingUnits.Where(x => x.DelineationID == delineationID)
+                .ExecuteDeleteAsync();
+            await dbContext.LoadGeneratingUnit4326s.Where(x => x.DelineationID == delineationID)
+                .ExecuteDeleteAsync();
+            await dbContext.NereidResults.Where(x => x.DelineationID == delineationID).ExecuteDeleteAsync();
+            await dbContext.ProjectHRUCharacteristics
+                .Include(x => x.ProjectLoadGeneratingUnit)
+                .Where(x => x.ProjectLoadGeneratingUnit.DelineationID == delineationID).ExecuteDeleteAsync();
+            await dbContext.ProjectLoadGeneratingUnits.Where(x => x.DelineationID == delineationID)
+                .ExecuteDeleteAsync();
+            await dbContext.TrashGeneratingUnits.Where(x => x.DelineationID == delineationID)
+                .ExecuteDeleteAsync();
+            await dbContext.ProjectNereidResults.Where(x => x.DelineationID == delineationID).ExecuteDeleteAsync();
+            await dbContext.Delineations.Where(x => x.DelineationID == delineationID).ExecuteDeleteAsync();
+        }
     }
 }

--- a/Neptune.WebMvc/Views/DelineationGeometry/UpdateDelineationGeometry.cshtml
+++ b/Neptune.WebMvc/Views/DelineationGeometry/UpdateDelineationGeometry.cshtml
@@ -57,6 +57,15 @@
                         </div>
                     </div>
                     <div class="row form-group">
+                        <div class="col-md-6">
+                            @Html.LabelWithSugarFor(x => x.DelineationStatusField)
+                        </div>
+                        <div class="col-md-6">
+                            @Html.TextBoxFor(x => x.DelineationStatusField, new { @class = "form-control" })
+                            @Html.ValidationMessageFor(x => x.DelineationStatusField)
+                        </div>
+                    </div>
+                    <div class="row form-group">
                         <div class="col-md-12">
                             @Html.EditorFor(x => x.FileResourceData)
                             @Html.ValidationMessageFor(x => x.FileResourceData)

--- a/Neptune.WebMvc/Views/DelineationGeometry/UpdateDelineationGeometryViewModel.cs
+++ b/Neptune.WebMvc/Views/DelineationGeometry/UpdateDelineationGeometryViewModel.cs
@@ -19,5 +19,8 @@ namespace Neptune.WebMvc.Views.DelineationGeometry
         [Required]
         [DisplayName("Stormwater Jurisdiction")]
         public int? StormwaterJurisdictionID { get; set; }
+
+        [DisplayName("Delineation Status Field")]
+        public string DelineationStatusField { get; set; }
     }
 }


### PR DESCRIPTION
bug fix for ApproveDelineationGisUpload POST (old code was not working if Delineations needed to be deleted because of change tracking. Fix is to not load Delineations into the _dbContext before they are deleted.  Only load the TreatmentBMPs and Delineations after the DeleteFull is called). Added an optional field to UpdateDelineationGeometryViewModel for DelineationStatus.  If it is not provided, we will not include that column in the select list when processing the provided gdb.zip file.