### PR TITLE
NPT-395 & NPT-881

### DIFF
--- a/Neptune.Database/dbo/Procs/dbo.pTrashGeneratingUnit4326MakeValid.sql
+++ b/Neptune.Database/dbo/Procs/dbo.pTrashGeneratingUnit4326MakeValid.sql
@@ -3,6 +3,8 @@ as
 begin
 
     update dbo.TrashGeneratingUnit4326 set TrashGeneratingUnit4326Geometry = TrashGeneratingUnit4326Geometry.MakeValid() where TrashGeneratingUnit4326Geometry.STIsValid() = 0
+    -- buffering by a very small number to get rid of GeometryCollection
+    update dbo.TrashGeneratingUnit4326 set TrashGeneratingUnit4326Geometry = TrashGeneratingUnit4326Geometry.STBuffer(.000000000001) where TrashGeneratingUnit4326Geometry.STGeometryType() = 'GeometryCollection'
 end
 
 GO

--- a/Neptune.Database/dbo/Views/dbo.vPyQgisOnlandVisualTrashAssessmentAreaDated.sql
+++ b/Neptune.Database/dbo/Views/dbo.vPyQgisOnlandVisualTrashAssessmentAreaDated.sql
@@ -11,10 +11,10 @@ from dbo.OnlandVisualTrashAssessmentArea a
 			ovta.OnlandVisualTrashAssessmentAreaID,
 			ovta.OnlandVisualTrashAssessmentScoreID,
 			ovta.CompletedDate,
-			rownumber = Row_Number() over (partition by ovta.OnlandVisualTrashAssessmentAreaID order by ovta.CompletedDate desc)
+			rownumber = Row_Number() over (partition by ovta.OnlandVisualTrashAssessmentAreaID order by ovta.CompletedDate desc),
+			AssessmentCount = count(*) over (partition by ovta.OnlandVisualTrashAssessmentAreaID)
 		from dbo.OnlandVisualTrashAssessment ovta
 		where CompletedDate is not null
 	) q 
-		on a.OnlandVisualTrashAssessmentAreaID = q.OnlandVisualTrashAssessmentAreaID
-	where rownumber = 1
+		on a.OnlandVisualTrashAssessmentAreaID = q.OnlandVisualTrashAssessmentAreaID and q.AssessmentCount > 1 and q.rownumber = 1
 GO


### PR DESCRIPTION
NPT-395: only include OVTA Areas with at least 2 Assessments in the view vPyQgisOnlandVisualTrashAssessmentAreaDated.

NPT-881: after converting TGU Geometries to 4326 we were getting many GeometryCollections (of LineString and Polygon). We need them to be POLYGON or MULTIPOLYGON only for the map display. The fix: split multi-part features into single features in qgis and remove any line strings or features with very small areas. Then after we call MakeValid on the 4326 Geometry, we buffer by a very small numbers to get rid of any remaining GeometryCollection.