### PR TITLE
bugs/NPT-952

### DIFF
--- a/Neptune.Jobs/Services/OCGISService.cs
+++ b/Neptune.Jobs/Services/OCGISService.cs
@@ -67,7 +67,10 @@ public class OCGISService(
             .ToList();
         dbContext.RegionalSubbasinStagings.AddRange(regionalSubbasinStagings);
         await dbContext.SaveChangesAsync();
+        //We need to delete everything that has a foreign key relationship to RSBs prior to the update for the merge delete to not fail
+        //This is NOT everything, but waiting until we run up against an actual instance of needing to delete the remaining entities before enforcing (ie.ProjectNereidResults)
         await dbContext.Database.ExecuteSqlRawAsync("EXEC dbo.pDeleteLoadGeneratingUnitsPriorToTotalRefresh");
+        await dbContext.Database.ExecuteSqlRawAsync("EXEC dbo.pDeleteNereidResults");
         await dbContext.Database.ExecuteSqlRawAsync("EXEC dbo.pUpdateRegionalSubbasinLiveFromStaging");
         
         // reproject to 4326


### PR DESCRIPTION
-Foreign key issue caused by trying to delete an RSB that was referenced by a NereidResult
-There may end up being more entities to add to this list of pre-deletes, but was instructed that we don't want to delete them all just yet. (IE. ProjectNereidResult being for the Planning Module)