### PR TITLE
WQMP module rework: NPT-1024, NPT-1026, NPT-1027 + Angular security update

### DIFF
--- a/Neptune.API/Controllers/RegionalSubbasinController.cs
+++ b/Neptune.API/Controllers/RegionalSubbasinController.cs
@@ -61,7 +61,7 @@ public class RegionalSubbasinController : SitkaController<RegionalSubbasinContro
     }
 
     [HttpPost("/graph-trace-as-feature-collection-from-point")]
-    [AdminFeature]
+    [UserViewFeature]
     public ActionResult<FeatureCollection> GetRegionalSubbasinGraphTraceAsFeatureCollectionFromPoint([FromBody] CoordinateDto coordinateDto)
     {
         var featureCollection = RegionalSubbasins.GetRegionalSubbasinGraphTraceAsFeatureCollection(DbContext, coordinateDto);

--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -69,7 +69,7 @@ namespace Neptune.API.Controllers
         }
 
         [HttpPost]
-        [AdminFeature]
+        [JurisdictionEditFeature]
         public async Task<ActionResult<WaterQualityManagementPlanDto>> Create([FromBody] WaterQualityManagementPlanUpsertDto dto)
         {
             var created = await WaterQualityManagementPlans.CreateAsync(DbContext, dto);
@@ -77,7 +77,7 @@ namespace Neptune.API.Controllers
         }
 
         [HttpPut("{waterQualityManagementPlanID}")]
-        [AdminFeature]
+        [JurisdictionEditFeature]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         public async Task<ActionResult<WaterQualityManagementPlanDto>> Update([FromRoute] int waterQualityManagementPlanID, [FromBody] WaterQualityManagementPlanUpsertDto dto)
         {
@@ -162,7 +162,7 @@ namespace Neptune.API.Controllers
         }
 
         [HttpGet("hydrologic-subareas")]
-        [AdminFeature]
+        [UserViewFeature]
         public async Task<ActionResult<List<HydrologicSubareaSimpleDto>>> ListHydrologicSubareas()
         {
             var subareas = await DbContext.HydrologicSubareas

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.ts
@@ -77,6 +77,10 @@ export class TrashOvtaAreaEditLocationComponent {
 
         this.layer.addTo(this.map);
         this.mapIsReady = true;
+
+        if (this.layer.getLayers().length > 0) {
+            this.map.pm.toggleGlobalEditMode();
+        }
     }
 
     public handleLegendControlReady(legendControl: L.Control) {
@@ -171,7 +175,9 @@ export class TrashOvtaAreaEditLocationComponent {
                     featureGroup.addLayer(layer);
                 }
                 layer.on("click", (e) => {
-                    this.selectFeatureImpl();
+                    if (!this.map.pm.globalEditModeEnabled()) {
+                        this.map.pm.toggleGlobalEditMode();
+                    }
                 });
             },
         });
@@ -191,6 +197,9 @@ export class TrashOvtaAreaEditLocationComponent {
         this.canPickParcels = !this.canPickParcels;
         this.layer.clearLayers();
         if (this.canPickParcels) {
+            if (this.map.pm.globalEditModeEnabled()) {
+                this.map.pm.disableGlobalEditMode();
+            }
             this.map.pm.removeControls();
             this.addOVTAAreaToLayer(ovtaAreaID);
             this.addParcelsToLayer(boundingBox);

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-boundary/edit-boundary.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-boundary/edit-boundary.component.html
@@ -11,42 +11,51 @@
 @if (boundaryData$ | async; as boundaryData) {
     <div class="page-body">
         <div class="copy copy-2 mb-3">
-            You may click or tap the edit button (<icon icon="GeomanEdit"></icon>) on the map below to adjust the boundary's vertices. You may drag vertices to move them, click
+            The boundary's vertices are displayed and ready to edit. You may drag vertices to move them, click
             or tap existing vertices to create possible additional vertices near them, click or tap the slightly transparent vertices to create new vertices, or right-click to delete
             them. If a new boundary needs to be drawn, you may delete (<icon icon="GeomanDelete"></icon>) the existing boundary and draw (<icon icon="GeomanPolygon"></icon>) a new one.
+            Click the boundary polygon or the edit button (<icon icon="GeomanEdit"></icon>) to re-enter edit mode if you have exited it.
             <p class="mt-2">
                 Note that the boundary's edges must not intersect each other. If the boundary contains any edges that intersect each other, you will not be able to save.
             </p>
         </div>
 
-        <neptune-map [mapHeight]="mapHeight" [showLegend]="false" [boundingBox]="boundingBox" (onMapLoad)="handleMapReady($event, boundaryData)">
-            @if (mapIsReady) {
-                <parcel-layer [displayOnLoad]="true" [map]="map" [layerControl]="layerControl"></parcel-layer>
-                <wqmps-layer [mode]="OverlayMode.ReferenceOnly" [map]="map" [layerControl]="layerControl"></wqmps-layer>
-            }
-        </neptune-map>
+        <div class="grid-12">
+            <!-- Left panel: Acreage + Parcels + Actions -->
+            <div class="g-col-4">
+                <dl class="grid-12">
+                    <dt class="g-col-5">Calculated Acreage</dt>
+                    <dd class="g-col-7">{{ calculatedAcreage !== null ? calculatedAcreage : "No boundary defined" }}</dd>
+                </dl>
 
-        <dl class="grid-12 mt-3">
-            <dt class="g-col-5">Calculated Acreage of Assigned Boundary</dt>
-            <dd class="g-col-7">{{ calculatedAcreage !== null ? calculatedAcreage : "No boundary defined" }}</dd>
-        </dl>
-
-        <h4 class="mt-3">Associated Parcels</h4>
-        @if (parcels?.length) {
-            <div class="parcel-list">
-                @for (parcel of parcels; track parcel.ParcelID) {
-                    <div class="parcel-list__item">
-                        <span>{{ parcel.ParcelNumber }}</span>
+                <h4 class="mt-3">Associated Parcels</h4>
+                @if (parcels?.length) {
+                    <div class="parcel-list">
+                        @for (parcel of parcels; track parcel.ParcelID) {
+                            <div class="parcel-list__item">
+                                <span>{{ parcel.ParcelNumber }}</span>
+                            </div>
+                        }
                     </div>
+                } @else {
+                    <p class="system-text">No parcels are associated with this WQMP.</p>
                 }
-            </div>
-        } @else {
-            <p class="system-text">No parcels are associated with this WQMP.</p>
-        }
-    </div>
 
-    <div class="page-footer">
-        <button class="btn btn-primary" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
-        <button class="btn btn-secondary-outline" (click)="cancel()">Cancel</button>
+                <div class="mt-3">
+                    <button class="btn btn-primary" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
+                    <button class="btn btn-secondary-outline" (click)="cancel()">Cancel</button>
+                </div>
+            </div>
+
+            <!-- Right panel: Map -->
+            <div class="g-col-8">
+                <neptune-map [mapHeight]="mapHeight" [showLegend]="false" [boundingBox]="boundingBox" (onMapLoad)="handleMapReady($event, boundaryData)">
+                    @if (mapIsReady) {
+                        <parcel-layer [displayOnLoad]="true" [map]="map" [layerControl]="layerControl"></parcel-layer>
+                        <wqmps-layer [mode]="OverlayMode.ReferenceOnly" [map]="map" [layerControl]="layerControl"></wqmps-layer>
+                    }
+                </neptune-map>
+            </div>
+        </div>
     </div>
 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-boundary/edit-boundary.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-boundary/edit-boundary.component.scss
@@ -1,7 +1,7 @@
 @use "/src/scss/abstracts" as *;
 
 .parcel-list {
-    max-height: 300px;
+    max-height: 400px;
     overflow-y: auto;
 
     &__item {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-boundary/edit-boundary.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-boundary/edit-boundary.component.ts
@@ -47,7 +47,7 @@ export class EditBoundaryComponent implements OnInit {
     private leafletHelperService = inject(LeafletHelperService);
 
     public OverlayMode = OverlayMode;
-    public mapHeight = "600px";
+    public mapHeight = "500px";
     public map: L.Map;
     public layerControl: L.Control.Layers;
     public mapIsReady = false;
@@ -85,12 +85,23 @@ export class EditBoundaryComponent implements OnInit {
 
         if (this.layer.getLayers().length > 0) {
             this.map.fitBounds(this.layer.getBounds());
+            this.map.pm.toggleGlobalEditMode();
         }
+
+        this.layer.on("click", () => {
+            if (!this.map.pm.globalEditModeEnabled()) {
+                this.map.pm.toggleGlobalEditMode();
+            }
+        });
     }
 
     public save(): void {
         this.isLoadingSubmit = true;
         this.alertService.clearAlerts();
+
+        if (this.map.pm.globalEditModeEnabled()) {
+            this.map.pm.toggleGlobalEditMode();
+        }
 
         const dto: WaterQualityManagementPlanBoundaryUpsertDto = {};
         this.layer.eachLayer((layer: L.Path & { toGeoJSON: () => GeoJSON.Feature }) => {
@@ -98,10 +109,8 @@ export class EditBoundaryComponent implements OnInit {
         });
 
         this.wqmpService.updateBoundaryWaterQualityManagementPlan(this.waterQualityManagementPlanID, dto).subscribe({
-            next: (response) => {
+            next: () => {
                 this.isLoadingSubmit = false;
-                this.parcels = response.Parcels ?? [];
-                this.calculatedAcreage = response.CalculatedWQMPAcreage ?? null;
                 this.alertService.pushAlert(new Alert("Successfully updated WQMP boundary.", AlertContext.Success));
                 this.router.navigate(["/water-quality-management-plans", this.waterQualityManagementPlanID]);
             },

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-parcels/edit-parcels.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-parcels/edit-parcels.component.ts
@@ -55,6 +55,8 @@ export class EditParcelsComponent implements OnInit {
     public selectedParcelIDs: number[] = [];
     public selectedParcelsLayer: L.GeoJSON<any>;
     public boundingBox: BoundingBoxDto;
+    private dataLoaded = false;
+    private initialLoad = true;
 
     // Search
     public searchControl = new FormControl("");
@@ -79,6 +81,10 @@ export class EditParcelsComponent implements OnInit {
                 this.selectedParcelIDs = parcelIDs ?? [];
                 this.selectedParcelRows.set(boundaryData.Parcels ?? []);
                 this.boundingBox = boundaryData.BoundingBox;
+                this.dataLoaded = true;
+                if (this.mapIsReady) {
+                    this.addSelectedParcelsToMap();
+                }
             }),
             map(() => true),
             shareReplay(1)
@@ -99,14 +105,14 @@ export class EditParcelsComponent implements OnInit {
         });
     }
 
-    private initialLoad = true;
-
     public handleMapReady(event: NeptuneMapInitEvent): void {
         this.map = event.map;
         this.layerControl = event.layerControl;
         this.mapIsReady = true;
-        this.addSelectedParcelsToMap();
         this.enableParcelClickEvent();
+        if (this.dataLoaded) {
+            this.addSelectedParcelsToMap();
+        }
     }
 
     public selectSearchResult(parcel: ParcelDisplayDto): void {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-treatment-bmps-modal/edit-treatment-bmps-modal.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-treatment-bmps-modal/edit-treatment-bmps-modal.component.html
@@ -1,3 +1,4 @@
+<div class="modal">
 <div class="modal-header">
     <h3 class="section-title">Edit Inventoried Structural BMPs</h3>
 </div>
@@ -8,19 +9,20 @@
 
     @if (availableBMPs$ | async; as availableBMPs) {
         <div style="display: flex; gap: 0.5rem; align-items: flex-end; margin-bottom: 1rem">
-            <div style="flex: 1 1 0">
+            <div style="flex: 1 1 0; min-width: 0; overflow: hidden">
                 <ng-select
                     [items]="availableBMPs"
                     bindValue="TreatmentBMPID"
                     [(ngModel)]="pickerBMPID"
                     [searchable]="true"
                     [clearable]="true"
+                    appendTo="body"
                     placeholder="Search for a BMP...">
                     <ng-template ng-option-tmp let-item="item">
                         {{ item.TreatmentBMPName }} ({{ item.TreatmentBMPTypeName }})
                     </ng-template>
                     <ng-template ng-label-tmp let-item="item">
-                        {{ item.TreatmentBMPName }} ({{ item.TreatmentBMPTypeName }})
+                        <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block">{{ item.TreatmentBMPName }} ({{ item.TreatmentBMPTypeName }})</span>
                     </ng-template>
                 </ng-select>
             </div>
@@ -66,4 +68,5 @@
 <div class="modal-footer">
     <button class="btn btn-primary" (click)="save()">Save</button>
     <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
+</div>
 </div>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
@@ -9,6 +9,15 @@
 
     <app-alert-display></app-alert-display>
 
+    @if (currentPersonCanEdit && wqmp.WaterQualityManagementPlanStatusID === WaterQualityManagementPlanStatusEnum.Draft) {
+        <div class="draft-banner mb-3">
+            <span>This WQMP is in <strong>Draft</strong> status.</span>
+            <a [routerLink]="['/water-quality-management-plans', waterQualityManagementPlanID, 'review']" class="btn btn-primary-outline btn-sm">
+                Review AI Extraction
+            </a>
+        </div>
+    }
+
     <div class="grid-12">
         <!-- Left Column -->
         <div class="g-col-6">
@@ -16,7 +25,7 @@
             <div class="card">
                 <div class="card-header">
                     <span class="card-title">Basics</span>
-                    @if (currentPersonCanManage) {
+                    @if (currentPersonCanEdit) {
                         <a (click)="openEditModal(wqmp)" style="cursor: pointer"><icon class="icon-button" icon="CirclePencil"></icon></a>
                     }
                 </div>
@@ -340,7 +349,7 @@
                                 @for (doc of docGroup.documents; track doc.WaterQualityManagementPlanDocumentID) {
                                     <div class="document-entry">
                                         @if (doc.FileResource?.FileResourceGUID) {
-                                            <a [href]="'/FileResource/' + doc.FileResource.FileResourceGUID" target="_blank">
+                                            <a [href]="apiBaseUrl + '/file-resources/' + doc.FileResource.FileResourceGUID" target="_blank">
                                                 {{ doc.DisplayName }} <i class="fa fa-download"></i>
                                             </a>
                                         } @else {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
@@ -34,6 +34,7 @@ import { TreatmentBMPHRUCharacteristicsSummarySimpleDto } from "src/app/shared/g
 import { PersonDto } from "src/app/shared/generated/model/person-dto";
 import { BoundingBoxDto } from "src/app/shared/generated/model/bounding-box-dto";
 import { TrashCaptureStatusTypeEnum } from "src/app/shared/generated/enum/trash-capture-status-type-enum";
+import { WaterQualityManagementPlanStatusEnum } from "src/app/shared/generated/enum/water-quality-management-plan-status-enum";
 import {
     WaterQualityManagementPlanModelingApproachEnum,
     WaterQualityManagementPlanModelingApproaches,
@@ -79,7 +80,9 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
     public OverlayMode = OverlayMode;
     public TrashCaptureStatusTypeEnum = TrashCaptureStatusTypeEnum;
     public WaterQualityManagementPlanModelingApproachEnum = WaterQualityManagementPlanModelingApproachEnum;
+    public WaterQualityManagementPlanStatusEnum = WaterQualityManagementPlanStatusEnum;
     public aboutModelingBMPPerformanceUrl = `${environment.ocStormwaterToolsBaseUrl}/Home/AboutModelingBMPPerformance`;
+    public apiBaseUrl = environment.mainAppApiUrl;
 
     wqmp$: Observable<WaterQualityManagementPlanDto>;
     quickBMPs$: Observable<QuickBMPDto[]>;
@@ -276,6 +279,11 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
             }
             this.treatmentBMPsLayer.addTo(this.map);
             this.layerControl.addOverlay(this.treatmentBMPsLayer, "Treatment BMPs");
+
+            // If no WQMP boundary, zoom to fit the BMP markers
+            if (!this.boundingBox && this.treatmentBMPsLayer.getBounds()?.isValid()) {
+                this.map.fitBounds(this.treatmentBMPsLayer.getBounds());
+            }
         }
     }
 
@@ -289,7 +297,7 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
                 InRouterLink: "/treatment-bmps/",
             }),
             this.utilityFunctionsService.createBasicColumnDef("Type", "TreatmentBMPTypeName"),
-            this.utilityFunctionsService.createBasicColumnDef("Notes", "Notes"),
+            this.utilityFunctionsService.createBasicColumnDef("Notes", "Notes", { MaxWidth: 200 }),
             this.utilityFunctionsService.createBasicColumnDef("Delineation Status", "DelineationStatus"),
             this.utilityFunctionsService.createDecimalColumnDef("Delineation Area (ac)", "Area", { DecimalPlacesToDisplay: 2 }),
         ];
@@ -298,7 +306,7 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
         this.quickBMPColumnDefs = [
             this.utilityFunctionsService.createBasicColumnDef("Name", "QuickBMPName"),
             this.utilityFunctionsService.createBasicColumnDef("Type", "TreatmentBMPTypeName"),
-            this.utilityFunctionsService.createBasicColumnDef("Notes", "QuickBMPNote"),
+            this.utilityFunctionsService.createBasicColumnDef("Notes", "QuickBMPNote", { MaxWidth: 200 }),
             this.utilityFunctionsService.createBasicColumnDef("# Individual BMPs", "NumberOfIndividualBMPs"),
             { headerName: "% Site Treated", field: "PercentOfSiteTreated", valueFormatter: percentFormatter, cellStyle: { "justify-content": "flex-end" } },
             { headerName: "% Captured", field: "PercentCaptured", valueFormatter: percentFormatter, cellStyle: { "justify-content": "flex-end" } },
@@ -319,10 +327,11 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
             this.utilityFunctionsService.createDateColumnDef("Verification Date", "VerificationDate", "MM/dd/yyyy"),
             this.utilityFunctionsService.createDateColumnDef("Last Edited", "LastEditedDate", "MM/dd/yyyy"),
             this.utilityFunctionsService.createBasicColumnDef("Edited By", "LastEditedByPersonFullName"),
-            this.utilityFunctionsService.createBasicColumnDef("Type", "WaterQualityManagementPlanVerifyTypeDisplayName"),
-            this.utilityFunctionsService.createBasicColumnDef("Visit Status", "WaterQualityManagementPlanVisitStatusDisplayName"),
-            this.utilityFunctionsService.createBasicColumnDef("Verify Status", "WaterQualityManagementPlanVerifyStatusDisplayName"),
+            this.utilityFunctionsService.createBasicColumnDef("Type", "WaterQualityManagementPlanVerifyTypeDisplayName", { UseCustomDropdownFilter: true }),
+            this.utilityFunctionsService.createBasicColumnDef("Visit Status", "WaterQualityManagementPlanVisitStatusDisplayName", { UseCustomDropdownFilter: true }),
+            this.utilityFunctionsService.createBasicColumnDef("Verify Status", "WaterQualityManagementPlanVerifyStatusDisplayName", { UseCustomDropdownFilter: true }),
             this.utilityFunctionsService.createBasicColumnDef("Draft/Finalized", "IsDraft", {
+                UseCustomDropdownFilter: true,
                 ValueGetter: (params) => (params.data?.IsDraft ? "Draft" : "Finalized"),
             }),
         ];

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
@@ -161,6 +161,7 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
     }
 
     private loadData(): void {
+        this.boundingBox = undefined;
         this.wqmp$ = this.wqmpService.getWaterQualityManagementPlan(this.waterQualityManagementPlanID).pipe(
             tap((wqmp) => {
                 if (wqmp?.WaterQualityManagementPlanBoundaryBBox) {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-modal/wqmp-modal.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-modal/wqmp-modal.component.html
@@ -1,3 +1,4 @@
+<div class="modal">
 <div class="modal-header">
     <h3>{{ mode === "edit" ? "Edit" : "Add" }} Water Quality Management Plan</h3>
 </div>
@@ -6,10 +7,10 @@
     <form [formGroup]="formGroup">
         <h4 class="section-title underline">Plan Details</h4>
         <div class="grid-12">
-            <form-field class="g-col-6" [formControl]="formGroup.controls.WaterQualityManagementPlanName" fieldLabel="Name" [type]="FormFieldType.Text" [required]="true"
+            <form-field class="g-col-6" [formControl]="formGroup.controls.WaterQualityManagementPlanName" fieldLabel="Name" fieldDefinitionName="WaterQualityManagementPlan" [type]="FormFieldType.Text" [required]="true"
                 placeholder="Plan Name">
             </form-field>
-            <form-field class="g-col-6" [formControl]="formGroup.controls.StormwaterJurisdictionID" fieldLabel="Jurisdiction" [type]="FormFieldType.Select" [required]="true"
+            <form-field class="g-col-6" [formControl]="formGroup.controls.StormwaterJurisdictionID" fieldLabel="Jurisdiction" fieldDefinitionName="Jurisdiction" [type]="FormFieldType.Select" [required]="true"
                 placeholder="Select Jurisdiction" [formInputOptions]="jurisdictionOptions$ | async">
             </form-field>
             <form-field class="g-col-6" [formControl]="formGroup.controls.WaterQualityManagementPlanPriorityID" fieldLabel="Priority" [type]="FormFieldType.Select"
@@ -28,7 +29,7 @@
             </form-field>
             <form-field class="g-col-6" [formControl]="formGroup.controls.DateOfConstruction" fieldLabel="Date of Construction" [type]="FormFieldType.Date">
             </form-field>
-            <form-field class="g-col-6" [formControl]="formGroup.controls.HydromodificationAppliesTypeID" fieldLabel="Hydromodification Applies" [type]="FormFieldType.Select"
+            <form-field class="g-col-6" [formControl]="formGroup.controls.HydromodificationAppliesTypeID" fieldLabel="Hydromodification Applies" fieldDefinitionName="HydromodificationApplies" [type]="FormFieldType.Select"
                 placeholder="Select Option" [formInputOptions]="hydromodificationOptions">
             </form-field>
             <form-field class="g-col-6" [formControl]="formGroup.controls.HydrologicSubareaID" fieldLabel="Hydrologic Subarea" [type]="FormFieldType.Select"
@@ -45,7 +46,7 @@
             <form-field class="g-col-6" [formControl]="formGroup.controls.RecordedWQMPAreaInAcres" fieldLabel="Recorded WQMP Area (Acres)" [type]="FormFieldType.Number"
                 placeholder="Area in Acres">
             </form-field>
-            <form-field class="g-col-6" [formControl]="formGroup.controls.TrashCaptureStatusTypeID" fieldLabel="Trash Capture Status" [type]="FormFieldType.Select"
+            <form-field class="g-col-6" [formControl]="formGroup.controls.TrashCaptureStatusTypeID" fieldLabel="Trash Capture Status" fieldDefinitionName="TrashCaptureStatus" [type]="FormFieldType.Select"
                 [required]="true" placeholder="Select Trash Capture Status" [formInputOptions]="trashCaptureStatusOptions">
             </form-field>
             @if (showTrashCaptureEffectiveness$ | async) {
@@ -82,4 +83,5 @@
 <div class="modal-footer">
     <button class="btn btn-primary" (click)="save()" [disabled]="formGroup.invalid">Save</button>
     <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
+</div>
 </div>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-modal/wqmp-modal.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-modal/wqmp-modal.component.ts
@@ -98,12 +98,16 @@ export class WqmpModalComponent implements OnInit {
         this.alertService.clearAlerts();
         this.mode = this.ref.data.mode;
 
-        this.jurisdictionOptions$ = this.stormwaterJurisdictionService.listStormwaterJurisdiction().pipe(
-            map((jurisdictions) =>
-                jurisdictions.map(
+        this.jurisdictionOptions$ = this.stormwaterJurisdictionService.listViewableStormwaterJurisdiction().pipe(
+            map((jurisdictions) => {
+                const options = jurisdictions.map(
                     (j) => ({ Label: j.StormwaterJurisdictionName, Value: j.StormwaterJurisdictionID, disabled: false }) as SelectDropdownOption
-                )
-            )
+                );
+                if (options.length === 1 && this.mode === "add") {
+                    this.formGroup.controls.StormwaterJurisdictionID.setValue(options[0].Value);
+                }
+                return options;
+            })
         );
 
         this.hydrologicSubareaOptions$ = this.wqmpService.listHydrologicSubareasWaterQualityManagementPlan().pipe(
@@ -117,6 +121,7 @@ export class WqmpModalComponent implements OnInit {
         );
 
         if (this.mode === "edit" && this.ref.data.wqmp) {
+            this.formGroup.controls.StormwaterJurisdictionID.disable();
             const wqmp = this.ref.data.wqmp;
             this.formGroup.patchValue({
                 WaterQualityManagementPlanName: wqmp.WaterQualityManagementPlanName,
@@ -149,7 +154,7 @@ export class WqmpModalComponent implements OnInit {
 
     save(): void {
         if (this.formGroup.invalid) return;
-        const dto = new WaterQualityManagementPlanUpsertDto(this.formGroup.value);
+        const dto = new WaterQualityManagementPlanUpsertDto(this.formGroup.getRawValue());
 
         if (this.mode === "edit") {
             const wqmpID = this.ref.data.wqmp?.WaterQualityManagementPlanID;

--- a/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
@@ -8,7 +8,10 @@
             <a class="dropdown-item" [href]="siteUrl + '/WaterQualityManagementPlan/UploadWqmps'">Bulk Upload WQMPs</a>
             <a class="dropdown-item" [href]="siteUrl + '/WaterQualityManagementPlan/UploadSimplifiedBMPs'">Bulk Upload Simplified BMPs</a>
             <a class="dropdown-item" [href]="siteUrl + '/WaterQualityManagementPlan/UploadWqmpBoundaryFromAPNs'">Bulk Upload WQMP Boundaries From APNs</a>
+            <div class="dropdown-divider"></div>
+            <a href="javascript:void(0);" class="dropdown-item" (click)="pdfFileInput.click()">Upload WQMP PDF (AI Extract)</a>
         </div>
+        <input #pdfFileInput type="file" accept=".pdf" style="display:none" (change)="onPdfSelected($event)" />
     }
 </ng-template>
 <page-header pageTitle="Water Quality Management Plans" [templateRight]="addButton"></page-header>
@@ -30,6 +33,8 @@
                 [layerControl]="layerControl"
                 [mode]="OverlayMode.ReferenceWithInteractivity"
                 [selectedID]="selectedWaterQualityManagementPlanID"
+                [fitBoundsOnSelect]="zoomOnNextSelection"
+                [filterToJurisdictionIDs]="wqmpJurisdictionIDs"
                 (selected)="onSelectedWaterQualityManagementPlanIDChanged($event, true)">
             </wqmps-layer>
             @if (mapIsReady) {

--- a/Neptune.Web/src/app/pages/wqmps/wqmps.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmps.component.ts
@@ -155,7 +155,15 @@ export class WqmpsComponent {
             tap((wqmps) => {
                 this.wqmps = wqmps;
                 if (this.shouldFilterMapByJurisdiction) {
-                    this.wqmpJurisdictionIDs = [...new Set(wqmps.map((w) => w.StormwaterJurisdictionID))];
+                    this.wqmpJurisdictionIDs = [
+                        ...new Set(
+                            wqmps
+                                .map((w) => w.StormwaterJurisdictionID)
+                                .filter((id): id is number => typeof id === "number" && Number.isFinite(id))
+                        ),
+                    ];
+                } else {
+                    this.wqmpJurisdictionIDs = undefined;
                 }
                 this.isLoading = false;
             })

--- a/Neptune.Web/src/app/pages/wqmps/wqmps.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmps.component.ts
@@ -1,5 +1,6 @@
 import { AsyncPipe } from "@angular/common";
 import { Component } from "@angular/core";
+import { Router } from "@angular/router";
 import { ColDef } from "ag-grid-community";
 import { map, Observable, shareReplay, tap } from "rxjs";
 import { DialogService } from "@ngneat/dialog";
@@ -24,6 +25,7 @@ import { OverlayMode } from "src/app/shared/components/leaflet/layers/generic-wm
 import { DropdownToggleDirective } from "src/app/shared/directives/dropdown-toggle.directive";
 import { environment } from "src/environments/environment";
 import { WqmpModalComponent } from "./wqmp-modal/wqmp-modal.component";
+import { WqmpUploadModalComponent } from "./wqmp-upload-modal/wqmp-upload-modal.component";
 
 @Component({
     selector: "wqmps",
@@ -40,7 +42,10 @@ export class WqmpsComponent {
     public layerControl: L.Control.Layers;
     public boundingBox$: Observable<BoundingBoxDto>;
     public selectedWaterQualityManagementPlanID: number;
+    public zoomOnNextSelection = true;
     public mapIsReady = false;
+    public wqmpJurisdictionIDs: number[];
+    private shouldFilterMapByJurisdiction = false;
     public siteUrl = environment.ocStormwaterToolsBaseUrl;
     public currentPersonCanEdit$: Observable<boolean>;
     private wqmps: WaterQualityManagementPlanGridDto[] = [];
@@ -52,12 +57,22 @@ export class WqmpsComponent {
         private authenticationService: AuthenticationService,
         private utilityFunctionsService: UtilityFunctionsService,
         private alertService: AlertService,
-        private dialogService: DialogService
+        private dialogService: DialogService,
+        private router: Router
     ) {}
+
+    private maintenanceContactFields = ["MaintenanceContactOrganization", "MaintenanceContactName", "MaintenanceContactAddress", "MaintenanceContactPhone"];
 
     ngOnInit(): void {
         this.currentPersonCanEdit$ = this.authenticationService.getCurrentUser().pipe(
-            map(() => this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission()),
+            map((user) => {
+                const isAnonymousOrUnassigned = !user || this.authenticationService.isUserUnassigned(user);
+                if (isAnonymousOrUnassigned) {
+                    this.columnDefs = this.columnDefs.filter((c) => !this.maintenanceContactFields.includes(c.field));
+                }
+                this.shouldFilterMapByJurisdiction = !isAnonymousOrUnassigned && !this.authenticationService.isCurrentUserAnAdministrator();
+                return this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission();
+            }),
             tap((canEdit) => {
                 if (canEdit && !this.columnDefs.some((c) => c.field === "IsDraft")) {
                     this.columnDefs = [...this.columnDefs, this.utilityFunctionsService.createBasicColumnDef("Is Draft", "IsDraft", {
@@ -107,14 +122,15 @@ export class WqmpsComponent {
             this.utilityFunctionsService.createBasicColumnDef("Maintenance Contact Name", "MaintenanceContactName"),
             this.utilityFunctionsService.createBasicColumnDef("Maintenance Contact Address", "MaintenanceContactAddress"),
             this.utilityFunctionsService.createBasicColumnDef("Maintenance Contact Phone", "MaintenanceContactPhone"),
-            this.utilityFunctionsService.createBasicColumnDef("# of Inventoried BMPs", "TreatmentBMPCount"),
-            this.utilityFunctionsService.createBasicColumnDef("# of Simplified BMPs", "QuickBMPCount"),
+            this.utilityFunctionsService.createDecimalColumnDef("# of Inventoried BMPs", "TreatmentBMPCount", { DecimalPlacesToDisplay: 0 }),
+            this.utilityFunctionsService.createDecimalColumnDef("# of Simplified BMPs", "QuickBMPCount", { DecimalPlacesToDisplay: 0 }),
             this.utilityFunctionsService.createBasicColumnDef("Modeling Approach", "WaterQualityManagementPlanModelingApproachDisplayName", {
                 UseCustomDropdownFilter: true,
             }),
-            this.utilityFunctionsService.createBasicColumnDef("# of Documents", "DocumentCount"),
+            this.utilityFunctionsService.createDecimalColumnDef("# of Documents", "DocumentCount", { DecimalPlacesToDisplay: 0 }),
             this.utilityFunctionsService.createBasicColumnDef("Has Required Documents", "HasRequiredDocuments", {
                 FieldDefinitionType: "HasAllRequiredDocuments",
+                UseCustomDropdownFilter: true,
                 ValueGetter: (params) => {
                     const value = params.data?.HasRequiredDocuments;
                     if (value == null) return "";
@@ -122,7 +138,7 @@ export class WqmpsComponent {
                 },
             }),
             this.utilityFunctionsService.createBasicColumnDef("Record Number", "RecordNumber"),
-            this.utilityFunctionsService.createBasicColumnDef("Recorded Parcel Acreage", "RecordedWQMPAreaInAcres"),
+            this.utilityFunctionsService.createDecimalColumnDef("Recorded Parcel Acreage", "RecordedWQMPAreaInAcres", { DecimalPlacesToDisplay: 2 }),
             this.utilityFunctionsService.createDecimalColumnDef("Calculated Boundary Acreage", "CalculatedWQMPAcreage", {
                 DecimalPlacesToDisplay: 1,
             }),
@@ -132,12 +148,15 @@ export class WqmpsComponent {
                 UseCustomDropdownFilter: true,
                 FieldDefinitionType: "TrashCaptureStatus",
             }),
-            this.utilityFunctionsService.createBasicColumnDef("Trash Capture Effectiveness (%)", "TrashCaptureEffectiveness"),
+            this.utilityFunctionsService.createDecimalColumnDef("Trash Capture Effectiveness (%)", "TrashCaptureEffectiveness", { DecimalPlacesToDisplay: 0 }),
         ];
 
         this.wqmps$ = this.waterQualityManagementPlanService.listAsGridDtoWaterQualityManagementPlan().pipe(
             tap((wqmps) => {
                 this.wqmps = wqmps;
+                if (this.shouldFilterMapByJurisdiction) {
+                    this.wqmpJurisdictionIDs = [...new Set(wqmps.map((w) => w.StormwaterJurisdictionID))];
+                }
                 this.isLoading = false;
             })
         );
@@ -158,6 +177,7 @@ export class WqmpsComponent {
 
     public onSelectedWaterQualityManagementPlanIDChanged(selectedID: number, fromMap: boolean = false) {
         if (this.selectedWaterQualityManagementPlanID == selectedID) return;
+        this.zoomOnNextSelection = !fromMap;
         this.selectedWaterQualityManagementPlanID = selectedID;
 
         this.alertService.removeAlertByUniqueCode(WqmpsComponent.NO_BOUNDARY_ALERT);
@@ -185,6 +205,28 @@ export class WqmpsComponent {
                         this.wqmps = wqmps;
                     })
                 );
+            }
+        });
+    }
+
+    public onPdfSelected(event: Event): void {
+        const input = event.target as HTMLInputElement;
+        if (!input.files?.length) return;
+        const file = input.files[0];
+        input.value = "";
+
+        if (!file.name.toLowerCase().endsWith(".pdf")) {
+            this.alertService.pushAlert(new Alert("Only PDF files are accepted.", AlertContext.Danger));
+            return;
+        }
+
+        const dialogRef = this.dialogService.open(WqmpUploadModalComponent, {
+            data: { file },
+            width: "600px",
+        });
+        dialogRef.afterClosed$.subscribe((result) => {
+            if (result?.wqmpID) {
+                this.router.navigate(["/water-quality-management-plans", result.wqmpID, "review"]);
             }
         });
     }

--- a/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.scss
+++ b/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.scss
@@ -55,6 +55,10 @@
     // neptune-map's :host { display: block } overrides display: flex set
     // from outside, so we use height: 100% to cascade the height down
     // instead, then flex only inside .map-wrapper.
+    // In map-only mode the grid is hidden so nothing drives height; use min-height.
+    &:has(> .tab-nav-container__panel.hidden) > &__map-panel {
+        min-height: 500px;
+    }
     &__map-panel {
         neptune-map {
             height: 100%;

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/generic-wms-wfs-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/generic-wms-wfs-layer.component.ts
@@ -25,7 +25,7 @@ export class GenericWmsWfsLayerComponent extends MapLayerBase implements OnChang
     @Input() identifierProperty: string;
     @Input() overlayLabel: string;
     @Input() selectedStyle: L.PathOptions = {
-        color: "#fcfc12",
+        color: "#ff6ba9",
         weight: 2,
         opacity: 0.65,
         fillOpacity: 0.1,

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/generic-wms-wfs-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/generic-wms-wfs-layer.component.ts
@@ -32,6 +32,7 @@ export class GenericWmsWfsLayerComponent extends MapLayerBase implements OnChang
     };
     @Input() cqlFilter: string = "1=1";
     @Input() addToLayerControl: boolean = true;
+    @Input() fitBoundsOnSelect: boolean = true;
     @Output() selected = new EventEmitter<number>();
     public wfsLayer: L.FeatureGroup;
     public layer: L.Layer;
@@ -128,8 +129,8 @@ export class GenericWmsWfsLayerComponent extends MapLayerBase implements OnChang
                     this.selected.emit(Number(groupId));
                 });
                 geoJson.addTo(this.wfsLayer);
-                // Zoom to bounds
-                if ("getBounds" in geoJson && typeof geoJson.getBounds === "function" && this.map) {
+                // Zoom to bounds (only if fitBoundsOnSelect is enabled)
+                if (this.fitBoundsOnSelect && "getBounds" in geoJson && typeof geoJson.getBounds === "function" && this.map) {
                     try {
                         const bounds = geoJson.getBounds();
                         if (bounds.isValid()) {

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/wqmps-layer/wqmps-layer.component.html
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/wqmps-layer/wqmps-layer.component.html
@@ -12,6 +12,7 @@
     [identifierProperty]="identifierProperty"
     [overlayLabel]="overlayLabel"
     [selectedStyle]="selectedStyle"
+    [fitBoundsOnSelect]="fitBoundsOnSelect"
     (selected)="selected.emit($event)">
     <ng-template layerName>
         <span>WQMPs</span>

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/wqmps-layer/wqmps-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/wqmps-layer/wqmps-layer.component.ts
@@ -15,7 +15,7 @@ export class WqmpsLayerComponent {
     readonly OVERLAY_LABEL = "WQMPs";
     readonly WMS_STYLE = "";
     readonly DEFAULT_SELECTED_STYLE: L.PathOptions = {
-        color: "#fcfc12",
+        color: "#ff6ba9",
         weight: 2,
         opacity: 0.65,
         fillOpacity: 0.1,

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/wqmps-layer/wqmps-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/wqmps-layer/wqmps-layer.component.ts
@@ -27,6 +27,8 @@ export class WqmpsLayerComponent {
     @Input() sortOrder: number = 1;
     @Input() selectedID: number;
     @Input() displayOnLoad: boolean = false;
+    @Input() fitBoundsOnSelect: boolean = true;
+    @Input() filterToJurisdictionIDs: number[];
     @Output() selected = new EventEmitter<number>();
 
     wfsFeatureType: string = this.WFS_FEATURE_TYPE;
@@ -62,7 +64,9 @@ export class WqmpsLayerComponent {
                 this.interactive = true;
                 this.addToLayerControl = true;
                 this.wmsLayerName = this.WMS_LAYER_NAME;
-                this.cqlFilter = "1=1";
+                this.cqlFilter = this.filterToJurisdictionIDs?.length
+                    ? `StormwaterJurisdictionID IN (${this.filterToJurisdictionIDs.join(",")})`
+                    : "1=1";
                 break;
         }
     }

--- a/Neptune.Web/src/app/shared/components/modeled-bmp-performance/modeled-bmp-performance.component.scss
+++ b/Neptune.Web/src/app/shared/components/modeled-bmp-performance/modeled-bmp-performance.component.scss
@@ -6,7 +6,12 @@
     th,
     td {
         vertical-align: middle;
-        text-align: center;
+    }
+    th:not(.left) {
+        text-align: right;
+    }
+    td:not(.left) {
+        text-align: right;
     }
     thead tr {
         background: #f8f9fa;

--- a/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.ts
+++ b/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.ts
@@ -41,6 +41,7 @@ export class NeptuneGridComponent implements OnInit, OnChanges {
         sortable: true,
         filter: true,
         resizable: true,
+        minWidth: 50,
         tooltipComponent: TooltipComponent,
         tooltipValueGetter: (params) => params.value,
     };

--- a/Neptune.Web/src/scss/components/_ag-grid.scss
+++ b/Neptune.Web/src/scss/components/_ag-grid.scss
@@ -66,11 +66,11 @@
         }
 
         &-selected {
-            background: $white;
+            background: rgba($yellow-selected, 0.25);
             border-bottom: 1px solid rgba($black, 0.15);
 
             &::before {
-                background: rgba($yellow-selected, 0.15);
+                background: rgba($yellow-selected, 0.25);
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Angular upgrade** (21.1.1 → 21.2.8) to fix XSS vulnerability
- **NPT-1026 rework**: WQMP edit parcels, refine area — fix drainage area permissions, polygon color, edit parcels race condition, boundary editor layout/auto-edit/save redirect, OVTA edit-location auto-edit
- **NPT-1024 rework**: WQMP grid — number/checkbox filters, column truncation, map-only height, polygon click zoom, row highlight, jurisdiction-filtered map layer, hidden maintenance columns for public users. Detail page — modeled performance alignment, BMP zoom, Notes column width, document download URL, O&M verification filters, field definitions. Edit modal — permissions (AdminFeature → JurisdictionEditFeature), jurisdiction disabled in edit mode, filtered dropdown, scroll fix, field definitions
- **NPT-1027 rework**: Treatment BMPs modal — dropdown z-index fix, long name truncation, modal scroll wrapper

## Auth changes (intentional)
| Endpoint | Before | After | Reason |
|----------|--------|-------|--------|
| `POST /water-quality-management-plans` | AdminFeature | JurisdictionEditFeature | JM/JE need to create WQMPs |
| `PUT /water-quality-management-plans/{id}` | AdminFeature | JurisdictionEditFeature | JM/JE need to edit WQMPs |
| `GET /water-quality-management-plans/hydrologic-subareas` | AdminFeature | UserViewFeature | Read-only reference data for modal dropdown |
| `POST /graph-trace-as-feature-collection-from-point` | AdminFeature | UserViewFeature | "View Drainage Areas" is read-only, all users need access |

## Test plan
- [ ] Log in as JM — create/edit WQMP without 403, Hydrologic Subarea dropdown renders
- [ ] Log in as JE — edit pencil icon visible on detail page
- [ ] WQMP grid: number filters, checkbox filters, column labels readable, map-only mode, polygon click no zoom, row highlight, jurisdiction-filtered polygons
- [ ] WQMP detail: modeled performance alignment, BMP zoom, document download, O&M filters
- [ ] Edit boundary: 2-column layout, auto-edit mode, save redirects
- [ ] Treatment BMPs modal: dropdown above footer, long names truncated
- [ ] "View Drainage Areas" works for JM on any map

🤖 Generated with [Claude Code](https://claude.com/claude-code)