### PR TITLE
Fix OVTA Record Observations UX (NPT-1031)

### DIFF
--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
@@ -8,8 +8,8 @@
       To move an observation, click the pencil icon and then either drag the marker or click a new location on the map.
     </p>
     <div class="mb-3">
-      <button class="btn btn-primary mr-2" [disabled]="isLoadingSubmit || isAddingObservation || isEditingLocation" (click)="goToCurrentLocation()">Record Observation at Current Location</button>
-      <button class="btn btn-primary mr-2" [disabled]="isLoadingSubmit || isAddingObservation || isEditingLocation" (click)="addObservationMarker()">
+      <button class="btn btn-primary mr-2" [disabled]="!mapIsReady || isLoadingSubmit || isAddingObservation || isEditingLocation" (click)="goToCurrentLocation()">Record Observation at Current Location</button>
+      <button class="btn btn-primary mr-2" [disabled]="!mapIsReady || isLoadingSubmit || isAddingObservation || isEditingLocation" (click)="addObservationMarker()">
         {{ isAddingObservation ? "Click the map to place observation..." : "Add an Observation by clicking the map" }}
       </button>
     </div>
@@ -47,10 +47,10 @@
               <div class="card-header d-flex justify-content-between align-items-center">
                 Selected Observation
                 <div>
-                  <button class="btn btn-sm btn-link" title="Edit Observation Location" [disabled]="isEditingLocation" (click)="editObservationLocation(i)">
+                  <button type="button" class="btn btn-sm btn-link" title="Edit Observation Location" aria-label="Edit Observation Location" [disabled]="isEditingLocation" (click)="editObservationLocation(i)">
                     <i class="fas fa-pencil-alt"></i>
                   </button>
-                  <button class="btn btn-sm btn-link text-danger" title="Delete Observation" (click)="deleteObservation(i)">
+                  <button type="button" class="btn btn-sm btn-link text-danger" title="Delete Observation" aria-label="Delete Observation" (click)="deleteObservation(i)">
                     <i class="fas fa-trash"></i>
                   </button>
                 </div>

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
@@ -5,6 +5,7 @@
     <p class="mb-3">
       Use the buttons below to add observations along your transect. Click "Record Observation at Current Location" to use your device's GPS,
       or "Add an Observation by clicking the map" to place a marker manually. Click a marker on the map to select it, then use the card below to add photos and notes.
+      To move an observation, click the pencil icon and then either drag the marker or click a new location on the map.
     </p>
     <div class="mb-3">
       <button class="btn btn-primary mr-2" [disabled]="isLoadingSubmit || isAddingObservation || isEditingLocation" (click)="goToCurrentLocation()">Record Observation at Current Location</button>

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
@@ -2,9 +2,15 @@
 @if (onlandVisualTrashAssessment$ | async; as onlandVisualTrashAssessment) {
   <workflow-body>
     <app-alert-display></app-alert-display>
+    <p class="mb-3">
+      Use the buttons below to add observations along your transect. Click "Record Observation at Current Location" to use your device's GPS,
+      or "Add an Observation by clicking the map" to place a marker manually. Click a marker on the map to select it, then use the card below to add photos and notes.
+    </p>
     <div class="mb-3">
-      <button class="btn btn-primary mr-2" [disabled]="isLoadingSubmit" (click)="goToCurrentLocation()">Record Observation at Current Location</button>
-      <button class="btn btn-primary mr-2" [disabled]="isLoadingSubmit" (click)="addObservationMarker()">Add an Observation by clicking the map</button>
+      <button class="btn btn-primary mr-2" [disabled]="isLoadingSubmit || isAddingObservation || isEditingLocation" (click)="goToCurrentLocation()">Record Observation at Current Location</button>
+      <button class="btn btn-primary mr-2" [disabled]="isLoadingSubmit || isAddingObservation || isEditingLocation" (click)="addObservationMarker()">
+        {{ isAddingObservation ? "Click the map to place observation..." : "Add an Observation by clicking the map" }}
+      </button>
     </div>
     @if (onlandVisualTrashAssessmentObservations$ | async) {
       <neptune-map (onMapLoad)="handleMapReady($event, onlandVisualTrashAssessment)" mapHeight="600px" [showLegend]="true">
@@ -37,22 +43,15 @@
         <ng-container formArrayName="Observations">
           @if (selectedOnlandVisualTrashAssessmentObservationID === control.controls.OnlandVisualTrashAssessmentObservationID.value) {
             <div class="card">
-              <div class="card-header">
+              <div class="card-header d-flex justify-content-between align-items-center">
                 Selected Observation
-                <a
-                  href="javascript:void(0);"
-                  [dropdownToggle]="observationDropdownMenu"
-                  class="nav-link dropdown-toggle"
-                  role="button"
-                  data-toggle="dropdown"
-                  aria-haspopup="true"
-                  aria-expanded="false">
-                  <i class="fas fa-bars"></i>
-                </a>
-                <div #observationDropdownMenu class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <div class="dropdown-divider"></div>
-                  <button class="dropdown-item" (click)="editObservationLocation(i)">Edit Observation Location</button>
-                  <button class="dropdown-item" (click)="deleteObservation(i)">Delete Selected Observation</button>
+                <div>
+                  <button class="btn btn-sm btn-link" title="Edit Observation Location" [disabled]="isEditingLocation" (click)="editObservationLocation(i)">
+                    <i class="fas fa-pencil-alt"></i>
+                  </button>
+                  <button class="btn btn-sm btn-link text-danger" title="Delete Observation" (click)="deleteObservation(i)">
+                    <i class="fas fa-trash"></i>
+                  </button>
                 </div>
               </div>
               <div class="card-body grid-12">

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.ts
@@ -253,16 +253,56 @@ export class TrashOvtaRecordObservationsComponent {
     public editObservationLocation(index: number) {
         this.isEditingLocation = true;
         this.map.getContainer().style.cursor = "crosshair";
-        this.map.on("click", (e: L.LeafletMouseEvent) => {
-            const observation = this.formGroup.controls.Observations.controls[index].value;
-            observation.Latitude = e.latlng.lat;
-            observation.Longitude = e.latlng.lng;
-            this.formGroup.controls.Observations.controls[index].patchValue(observation);
-            this.addObservationPointsLayersToMap();
-            this.map.off("click");
+
+        // Find the selected marker and enable dragging
+        const selectedMarker = this.getSelectedMarker();
+        if (selectedMarker) {
+            selectedMarker.dragging.enable();
+        }
+
+        const exitEditMode = () => {
+            this.map.off("click", onMapClick);
+            if (selectedMarker) {
+                selectedMarker.off("dragend", onDragEnd);
+                selectedMarker.dragging.disable();
+            }
             this.isEditingLocation = false;
             this.map.getContainer().style.cursor = "grab";
-        });
+        };
+
+        const updateObservation = (latlng: L.LatLng) => {
+            const observation = this.formGroup.controls.Observations.controls[index].value;
+            observation.Latitude = latlng.lat;
+            observation.Longitude = latlng.lng;
+            this.formGroup.controls.Observations.controls[index].patchValue(observation);
+            this.addObservationPointsLayersToMap();
+            exitEditMode();
+        };
+
+        const onMapClick = (e: L.LeafletMouseEvent) => {
+            updateObservation(e.latlng);
+        };
+
+        const onDragEnd = (e: L.DragEndEvent) => {
+            updateObservation((e.target as L.Marker).getLatLng());
+        };
+
+        this.map.on("click", onMapClick);
+        if (selectedMarker) {
+            selectedMarker.on("dragend", onDragEnd);
+        }
+    }
+
+    private getSelectedMarker(): L.Marker | null {
+        let selectedMarker: L.Marker = null;
+        if (this.ovtaObservationLayer) {
+            this.ovtaObservationLayer.eachLayer((layer: L.Marker) => {
+                if (layer.feature?.properties?.OnlandVisualTrashAssessmentObservationID === this.selectedOnlandVisualTrashAssessmentObservationID) {
+                    selectedMarker = layer;
+                }
+            });
+        }
+        return selectedMarker;
     }
 
     public deleteObservation(index: number) {

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { ApplicationRef, Component } from "@angular/core";
 import * as L from "leaflet";
 import { PageHeaderComponent } from "../../../../shared/components/page-header/page-header.component";
 import { NeptuneMapComponent, NeptuneMapInitEvent } from "../../../../shared/components/leaflet/neptune-map/neptune-map.component";
@@ -9,7 +9,6 @@ import { Input } from "@angular/core";
 import { OnlandVisualTrashAssessmentDetailDto } from "src/app/shared/generated/model/onland-visual-trash-assessment-detail-dto";
 import { OnlandVisualTrashAssessmentService } from "src/app/shared/generated/api/onland-visual-trash-assessment.service";
 import { MarkerHelper } from "src/app/shared/helpers/marker-helper";
-import { DropdownToggleDirective } from "src/app/shared/directives/dropdown-toggle.directive";
 import { FormArray, FormBuilder, FormControl, FormGroup, FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { FormFieldComponent, FormFieldType } from "src/app/shared/components/forms/form-field/form-field.component";
 import { AlertDisplayComponent } from "../../../../shared/components/alert-display/alert-display.component";
@@ -35,7 +34,6 @@ import { TransectLineLayerComponent } from "src/app/shared/components/leaflet/la
     imports: [
         PageHeaderComponent,
         NeptuneMapComponent,
-        DropdownToggleDirective,
         AsyncPipe,
         FormFieldComponent,
         ReactiveFormsModule,
@@ -64,6 +62,8 @@ export class TrashOvtaRecordObservationsComponent {
 
     public selectedOnlandVisualTrashAssessmentObservationID: number;
     public newObservationIDIndex: number = -1;
+    public isAddingObservation = false;
+    public isEditingLocation = false;
 
     public onlandVisualTrashAssessmentObservations$: Observable<OnlandVisualTrashAssessmentObservationWithPhotoDto[]>;
 
@@ -78,7 +78,8 @@ export class TrashOvtaRecordObservationsComponent {
         private ovtaWorkflowProgressService: OvtaWorkflowProgressService,
         private router: Router,
         private wfsService: WfsService,
-        private formBuilder: FormBuilder
+        private formBuilder: FormBuilder,
+        private appRef: ApplicationRef
     ) {}
 
     ngOnInit() {
@@ -135,12 +136,20 @@ export class TrashOvtaRecordObservationsComponent {
                     this.map.fitBounds(L.geoJson(response as any).getBounds());
                 });
         }
+
+        // Ensure the view updates immediately in zoneless mode.
+        // (Output emissions and Leaflet callbacks don't always schedule a render on their own.)
+        Promise.resolve().then(() => this.appRef.tick());
     }
 
     public addObservationMarker() {
+        this.isAddingObservation = true;
+        this.map.getContainer().style.cursor = "crosshair";
         this.map.on("click", (e: L.LeafletMouseEvent) => {
             this.addObservation(e.latlng);
             this.map.off("click");
+            this.isAddingObservation = false;
+            this.map.getContainer().style.cursor = "grab";
         });
     }
 
@@ -242,6 +251,8 @@ export class TrashOvtaRecordObservationsComponent {
     }
 
     public editObservationLocation(index: number) {
+        this.isEditingLocation = true;
+        this.map.getContainer().style.cursor = "crosshair";
         this.map.on("click", (e: L.LeafletMouseEvent) => {
             const observation = this.formGroup.controls.Observations.controls[index].value;
             observation.Latitude = e.latlng.lat;
@@ -249,6 +260,8 @@ export class TrashOvtaRecordObservationsComponent {
             this.formGroup.controls.Observations.controls[index].patchValue(observation);
             this.addObservationPointsLayersToMap();
             this.map.off("click");
+            this.isEditingLocation = false;
+            this.map.getContainer().style.cursor = "grab";
         });
     }
 

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-workflow-outlet/trash-ovta-workflow-outlet.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-workflow-outlet/trash-ovta-workflow-outlet.component.html
@@ -5,12 +5,7 @@
             <h5 class="sidebar-title">
                 <div>
                     <p class="ovta-label">
-                        Onland Visual Trash Assessment @if (progressDto?.OnlandVisualTrashAssessmentStatus?.OnlandVisualTrashAssessmentStatusID !=
-                        OnlandVisualTrashAssessmentStatus.Complete) {
-                        <a class="ml-2 delete" title="Delete OVTA" (click)="deleteOVTA(progressDto.OnlandVisualTrashAssessmentID, progressDto.CreatedDate)">
-                            <icon icon="Delete"></icon>
-                        </a>
-                        }
+                        Onland Visual Trash Assessment
                     </p>
                     @if (progressDto?.OnlandVisualTrashAssessmentAreaID) {
                     <p>

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-workflow-outlet/trash-ovta-workflow-outlet.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-workflow-outlet/trash-ovta-workflow-outlet.component.ts
@@ -2,21 +2,14 @@ import { Component, OnInit, Input } from "@angular/core";
 import { Router, RouterLink, RouterOutlet } from "@angular/router";
 import { Observable, tap } from "rxjs";
 import { OvtaWorkflowProgressService } from "src/app/shared/services/ovta-workflow-progress.service";
-import { AsyncPipe, DatePipe } from "@angular/common";
+import { AsyncPipe } from "@angular/common";
 import { OnlandVisualTrashAssessmentWorkflowProgressDto } from "src/app/shared/generated/model/onland-visual-trash-assessment-workflow-progress-dto";
-import { OnlandVisualTrashAssessmentStatusEnum } from "src/app/shared/generated/enum/onland-visual-trash-assessment-status-enum";
-import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
-import { OnlandVisualTrashAssessmentService } from "src/app/shared/generated/api/onland-visual-trash-assessment.service";
-import { Alert } from "src/app/shared/models/alert";
-import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
-import { AlertService } from "src/app/shared/services/alert.service";
 import { WorkflowNavComponent } from "../../../../shared/components/workflow-nav/workflow-nav.component";
 import { WorkflowNavItemComponent } from "../../../../shared/components/workflow-nav/workflow-nav-item/workflow-nav-item.component";
-import { IconComponent } from "../../../../shared/components/icon/icon.component";
 
 @Component({
     selector: "trash-ovta-workflow-outlet",
-    imports: [RouterOutlet, RouterLink, AsyncPipe, WorkflowNavComponent, WorkflowNavItemComponent, IconComponent],
+    imports: [RouterOutlet, RouterLink, AsyncPipe, WorkflowNavComponent, WorkflowNavItemComponent],
     templateUrl: "./trash-ovta-workflow-outlet.component.html",
     styleUrl: "./trash-ovta-workflow-outlet.component.scss",
     standalone: true,
@@ -24,16 +17,11 @@ import { IconComponent } from "../../../../shared/components/icon/icon.component
 export class TrashOvtaWorkflowOutletComponent implements OnInit {
     public submitted: boolean = false;
     public progress$: Observable<OnlandVisualTrashAssessmentWorkflowProgressDto>;
-    public OnlandVisualTrashAssessmentStatus = OnlandVisualTrashAssessmentStatusEnum;
     @Input() onlandVisualTrashAssessmentID: number | null = null;
 
     constructor(
         private router: Router,
-        private ovtaProgressService: OvtaWorkflowProgressService,
-        private onlandVisualTrashAssessmentService: OnlandVisualTrashAssessmentService,
-        private confirmService: ConfirmService,
-        private alertService: AlertService,
-        private datePipe: DatePipe
+        private ovtaProgressService: OvtaWorkflowProgressService
     ) {}
 
     ngOnInit() {
@@ -43,20 +31,5 @@ export class TrashOvtaWorkflowOutletComponent implements OnInit {
             })
         );
         this.ovtaProgressService.getProgress(this.onlandVisualTrashAssessmentID);
-    }
-
-    public deleteOVTA(onlandVisualTrashAssessmentID: number, createdDate: string) {
-        const modalContents = `<p>Are you sure you want to delete the assessment from ${this.datePipe.transform(createdDate, "MM/dd/yyyy")}?<\/p>`;
-        this.confirmService
-            .confirm({ buttonClassYes: "btn-primary", buttonTextYes: "Delete", buttonTextNo: "Cancel", title: "Delete OVTA", message: modalContents })
-            .then((confirmed) => {
-                if (confirmed) {
-                    this.onlandVisualTrashAssessmentService.deleteOnlandVisualTrashAssessment(onlandVisualTrashAssessmentID).subscribe(() => {
-                        this.alertService.clearAlerts();
-                        this.alertService.pushAlert(new Alert("Your OVTA was successfully deleted.", AlertContext.Success));
-                        this.router.navigate([`/trash/onland-visual-trash-assessments`]);
-                    });
-                }
-            });
     }
 }

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
@@ -77,7 +77,7 @@ export class TrashOvtaAreaDetailComponent {
     ngOnInit(): void {
         this.ovtaColumnDefs = [
             this.utilityFunctionsService.createActionsColumnDef((params: any) => {
-                return [
+                const actions = [
                     { ActionName: "View", ActionHandler: () => this.router.navigate(["trash", "onland-visual-trash-assessments", params.data.OnlandVisualTrashAssessmentID]) },
                     {
                         ActionName: params.data.OnlandVisualTrashAssessmentStatusID == OnlandVisualTrashAssessmentStatusEnum.Complete ? "Return to Edit" : "Edit",
@@ -87,12 +87,15 @@ export class TrashOvtaAreaDetailComponent {
                                 ? this.confirmEditOVTA(params.data.OnlandVisualTrashAssessmentID, params.data.CompletedDate)
                                 : this.router.navigateByUrl(`/trash/onland-visual-trash-assessments/edit/${params.data.OnlandVisualTrashAssessmentID}/record-observations`),
                     },
-                    {
+                ];
+                if (params.data.OnlandVisualTrashAssessmentStatusID != OnlandVisualTrashAssessmentStatusEnum.Complete) {
+                    actions.push({
                         ActionName: "Delete",
                         ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.deleteOVTA(params.data.OnlandVisualTrashAssessmentID, params.data.CreatedDate),
-                    },
-                ];
+                    });
+                }
+                return actions;
             }),
             this.utilityFunctionsService.createLinkColumnDef("Assessment ID", "OnlandVisualTrashAssessmentID", "OnlandVisualTrashAssessmentID", {
                 InRouterLink: "../../onland-visual-trash-assessments/",

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
@@ -52,6 +52,9 @@ export class TrashOvtaAreaDetailComponent {
     public refreshOVTAAreasTrigger: BehaviorSubject<void> = new BehaviorSubject(null);
     public refreshOVTAAreasTrigger$: Observable<void> = this.refreshOVTAAreasTrigger.asObservable();
 
+    public refreshOVTAGridTrigger: BehaviorSubject<void> = new BehaviorSubject(null);
+    public refreshOVTAGridTrigger$: Observable<void> = this.refreshOVTAGridTrigger.asObservable();
+
     public map: L.Map;
     public mapIsReady: boolean = false;
     public layerControl: L.Control.Layers;
@@ -84,7 +87,11 @@ export class TrashOvtaAreaDetailComponent {
                                 ? this.confirmEditOVTA(params.data.OnlandVisualTrashAssessmentID, params.data.CompletedDate)
                                 : this.router.navigateByUrl(`/trash/onland-visual-trash-assessments/edit/${params.data.OnlandVisualTrashAssessmentID}/record-observations`),
                     },
-                    //{ ActionName: "Delete", ActionIcon: "fa fa-trash text-danger", ActionHandler: () => this.deleteModal(params) },
+                    {
+                        ActionName: "Delete",
+                        ActionIcon: "fas fa-trash text-danger",
+                        ActionHandler: () => this.deleteOVTA(params.data.OnlandVisualTrashAssessmentID, params.data.CreatedDate),
+                    },
                 ];
             }),
             this.utilityFunctionsService.createLinkColumnDef("Assessment ID", "OnlandVisualTrashAssessmentID", "OnlandVisualTrashAssessmentID", {
@@ -113,9 +120,11 @@ export class TrashOvtaAreaDetailComponent {
             })
         );
 
-        this.onlandVisualTrashAssessments$ = this.onlandVisualTrashAssessmentAreaService
-            .listAssessmentsByOVTAIDOnlandVisualTrashAssessmentArea(this.onlandVisualTrashAssessmentAreaID)
-            .pipe(tap(() => (this.isLoadingGrid = false)));
+        this.onlandVisualTrashAssessments$ = this.refreshOVTAGridTrigger$.pipe(
+            tap(() => (this.isLoadingGrid = true)),
+            switchMap(() => this.onlandVisualTrashAssessmentAreaService.listAssessmentsByOVTAIDOnlandVisualTrashAssessmentArea(this.onlandVisualTrashAssessmentAreaID)),
+            tap(() => (this.isLoadingGrid = false))
+        );
     }
 
     public handleMapReady(event: NeptuneMapInitEvent): void {
@@ -168,10 +177,11 @@ export class TrashOvtaAreaDetailComponent {
             .confirm({ buttonClassYes: "btn-primary", buttonTextYes: "Delete", buttonTextNo: "Cancel", title: "Delete OVTA", message: modalContents })
             .then((confirmed) => {
                 if (confirmed) {
-                    this.onlandVisualTrashAssessmentService.deleteOnlandVisualTrashAssessment(onlandVisualTrashAssessmentID).subscribe((response) => {
+                    this.onlandVisualTrashAssessmentService.deleteOnlandVisualTrashAssessment(onlandVisualTrashAssessmentID).subscribe(() => {
                         this.alertService.clearAlerts();
                         this.alertService.pushAlert(new Alert("Your OVTA was successfully deleted.", AlertContext.Success));
-                        this.router.navigate([`/trash/onland-visual-trash-assessments`]);
+                        this.refreshOVTAGridTrigger.next();
+                        this.refreshOVTAAreasTrigger.next();
                     });
                 }
             });

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-detail/trash-ovta-detail.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-detail/trash-ovta-detail.component.html
@@ -9,17 +9,25 @@
       <div class="flex-between mb-3">
         <a
           class="btn btn-primary"
-                    (click)="
-                        confirmEditOVTA(
-                            onlandVisualTrashAssessment.OnlandVisualTrashAssessmentID,
-                            onlandVisualTrashAssessment.OnlandVisualTrashAssessmentStatusID,
-                            onlandVisualTrashAssessment.CompletedDate
-                        )
-                    "
-          >Edit</a
-          >
-        </div>
-      </ng-template>
+          (click)="
+              confirmEditOVTA(
+                  onlandVisualTrashAssessment.OnlandVisualTrashAssessmentID,
+                  onlandVisualTrashAssessment.OnlandVisualTrashAssessmentStatusID,
+                  onlandVisualTrashAssessment.CompletedDate
+              )
+          "
+          >Edit</a>
+        <button
+          class="btn btn-danger ml-2"
+          (click)="
+              deleteOVTA(
+                  onlandVisualTrashAssessment.OnlandVisualTrashAssessmentID,
+                  onlandVisualTrashAssessment.CreatedDate
+              )
+          "
+          >Delete</button>
+      </div>
+    </ng-template>
     </page-header>
     <app-alert-display></app-alert-display>
     <div class="grid-12 mt-2 mb-3">

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-detail/trash-ovta-detail.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-detail/trash-ovta-detail.component.html
@@ -17,15 +17,17 @@
               )
           "
           >Edit</a>
-        <button
-          class="btn btn-danger ml-2"
-          (click)="
-              deleteOVTA(
-                  onlandVisualTrashAssessment.OnlandVisualTrashAssessmentID,
-                  onlandVisualTrashAssessment.CreatedDate
-              )
-          "
-          >Delete</button>
+        @if (onlandVisualTrashAssessment.OnlandVisualTrashAssessmentStatusID != OnlandVisualTrashAssessmentStatusEnum.Complete) {
+          <button
+            class="btn btn-danger ml-2"
+            (click)="
+                deleteOVTA(
+                    onlandVisualTrashAssessment.OnlandVisualTrashAssessmentID,
+                    onlandVisualTrashAssessment.CreatedDate
+                )
+            "
+            >Delete</button>
+        }
       </div>
     </ng-template>
     </page-header>

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-detail/trash-ovta-detail.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-detail/trash-ovta-detail.component.ts
@@ -27,6 +27,7 @@ export class TrashOvtaDetailComponent {
     public onlandVisualTrashAssessment$: Observable<OnlandVisualTrashAssessmentDetailDto>;
     public onlandVisualTrashAssessmentObservations$: Observable<OnlandVisualTrashAssessmentObservationWithPhotoDto[]>;
     public PreliminarySourceIdentificationCategories = PreliminarySourceIdentificationCategories;
+    public OnlandVisualTrashAssessmentStatusEnum = OnlandVisualTrashAssessmentStatusEnum;
 
     @Input() onlandVisualTrashAssessmentID!: number;
     constructor(

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-detail/trash-ovta-detail.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-detail/trash-ovta-detail.component.ts
@@ -1,7 +1,6 @@
 import { AsyncPipe, DatePipe } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
-import { Input } from "@angular/core";
 import { Observable, switchMap } from "rxjs";
 import { OnlandVisualTrashAssessmentService } from "src/app/shared/generated/api/onland-visual-trash-assessment.service";
 import { OnlandVisualTrashAssessmentDetailDto } from "src/app/shared/generated/model/onland-visual-trash-assessment-detail-dto";
@@ -70,5 +69,20 @@ export class TrashOvtaDetailComponent {
         } else {
             this.router.navigateByUrl(`/trash/onland-visual-trash-assessments/edit/${onlandVisualTrashAssessmentID}/record-observations`);
         }
+    }
+
+    public deleteOVTA(onlandVisualTrashAssessmentID: number, createdDate: string) {
+        const modalContents = `<p>Are you sure you want to delete the assessment from ${this.datePipe.transform(createdDate, "MM/dd/yyyy")}?</p>`;
+        this.confirmService
+            .confirm({ buttonClassYes: "btn-primary", buttonTextYes: "Delete", buttonTextNo: "Cancel", title: "Delete OVTA", message: modalContents })
+            .then((confirmed) => {
+                if (confirmed) {
+                    this.onlandVisualTrashAssessmentService.deleteOnlandVisualTrashAssessment(onlandVisualTrashAssessmentID).subscribe(() => {
+                        this.alertService.clearAlerts();
+                        this.alertService.pushAlert(new Alert("Your OVTA was successfully deleted.", AlertContext.Success));
+                        this.router.navigate(["/trash/onland-visual-trash-assessments"]);
+                    });
+                }
+            });
     }
 }


### PR DESCRIPTION
## Summary
- **Fix map spinner hanging** in zoneless mode by adding `appRef.tick()` after `handleMapReady()` — same pattern used in project-map component
- **Replace hamburger menu** with direct pencil/trash icon buttons in the selected observation card header
- **Add crosshair cursor + button state** when in click-to-place mode for both add and edit observation interactions
- **Add marker dragging** — when editing an observation location, the marker is draggable AND click-to-relocate works; whichever fires first cleanly exits edit mode
- **Add instruction text** above the map explaining how to use the page
- **Relocate delete action** — remove (x) delete from workflow sidebar; add Delete to OVTA Area detail grid (with in-page refresh) and OVTA detail page

## Test plan
- [ ] Navigate to Record Observations via all 3 entry paths (area detail, grid action, Add OVTA) — map should load without spinner hanging
- [ ] Select an observation marker — card header should show pencil and trash icons (no hamburger)
- [ ] Click "Add an Observation by clicking the map" — cursor changes to crosshair, button text changes, buttons disable; placing the marker resets everything
- [ ] Click pencil icon on selected observation — cursor changes to crosshair; drag the marker OR click a new spot to relocate
- [ ] Instruction text is visible above the buttons
- [ ] No (x) delete button in the workflow sidebar
- [ ] Delete action works from OVTA Area detail grid actions dropdown (grid refreshes after delete)
- [ ] Delete button works on OVTA detail page next to Edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)