### PR TITLE
NPT-1015: AI WQMP workflow rework (Name in upload modal, Jurisdiction pre-populate, WCAG contrast)

### DIFF
--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -439,11 +439,22 @@ namespace Neptune.API.Controllers
         [RequestSizeLimit(200 * 1024 * 1024)]
         [RequestFormLimits(MultipartBodyLengthLimit = 200 * 1024 * 1024)]
         public async Task<ActionResult<WaterQualityManagementPlanExtractionResultDto>> UploadAndExtract(
-            IFormFile file, [FromForm] int stormwaterJurisdictionID, [FromForm] bool overwrite = false)
+            IFormFile file, [FromForm] int stormwaterJurisdictionID, [FromForm] string wqmpName, [FromForm] bool overwrite = false)
         {
             if (file == null || file.Length == 0)
             {
                 return BadRequest("No file provided.");
+            }
+
+            if (string.IsNullOrWhiteSpace(wqmpName))
+            {
+                return BadRequest("WQMP name is required.");
+            }
+
+            wqmpName = wqmpName.Trim();
+            if (wqmpName.Length > 100)
+            {
+                return BadRequest("WQMP name must be 100 characters or fewer.");
             }
 
             const long maxPdfSizeBytes = 50L * 1024 * 1024;
@@ -458,8 +469,6 @@ namespace Neptune.API.Controllers
             {
                 return BadRequest("Only PDF files are accepted.");
             }
-
-            var wqmpName = Path.GetFileNameWithoutExtension(file.FileName);
 
             // Check for existing WQMP with the same name in this jurisdiction
             var existing = await WaterQualityManagementPlans.GetByNameAndJurisdiction(DbContext, wqmpName, stormwaterJurisdictionID);
@@ -531,6 +540,7 @@ namespace Neptune.API.Controllers
                 {
                     WaterQualityManagementPlanID = wqmpDto.WaterQualityManagementPlanID,
                     WaterQualityManagementPlanDocumentID = document.WaterQualityManagementPlanDocumentID,
+                    StormwaterJurisdictionID = stormwaterJurisdictionID,
                     ExtractionResultJson = extractionResult.FinalOutput,
                     ExtractedAt = storedResult.ExtractedAt,
                     FileResourceGuid = fileResource.FileResourceGUID.ToString(),

--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -9405,6 +9405,9 @@
                     "type": "integer",
                     "format": "int32"
                   },
+                  "wqmpName": {
+                    "type": "string"
+                  },
                   "overwrite": {
                     "type": "boolean",
                     "default": false
@@ -9416,6 +9419,9 @@
                   "style": "form"
                 },
                 "stormwaterJurisdictionID": {
+                  "style": "form"
+                },
+                "wqmpName": {
                   "style": "form"
                 },
                 "overwrite": {
@@ -16216,6 +16222,10 @@
             "format": "int32"
           },
           "WaterQualityManagementPlanDocumentID": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "StormwaterJurisdictionID": {
             "type": "integer",
             "format": "int32"
           },

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlanExtractionResult.DtoProjections.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlanExtractionResult.DtoProjections.cs
@@ -9,6 +9,7 @@ public static class WaterQualityManagementPlanExtractionResultProjections
     {
         WaterQualityManagementPlanID = x.WaterQualityManagementPlanID,
         WaterQualityManagementPlanDocumentID = x.WaterQualityManagementPlanDocumentID,
+        StormwaterJurisdictionID = x.WaterQualityManagementPlan.StormwaterJurisdictionID,
         ExtractionResultJson = x.ExtractionResultJson,
         ExtractedAt = x.ExtractedAt,
         FileResourceGuid = x.WaterQualityManagementPlanDocument.FileResource.FileResourceGUID.ToString(),

--- a/Neptune.Models/DataTransferObjects/WaterQualityManagementPlan/WaterQualityManagementPlanExtractionResultDto.cs
+++ b/Neptune.Models/DataTransferObjects/WaterQualityManagementPlan/WaterQualityManagementPlanExtractionResultDto.cs
@@ -4,6 +4,7 @@ public class WaterQualityManagementPlanExtractionResultDto
 {
     public int WaterQualityManagementPlanID { get; set; }
     public int WaterQualityManagementPlanDocumentID { get; set; }
+    public int StormwaterJurisdictionID { get; set; }
     public string ExtractionResultJson { get; set; }
     public DateTime ExtractedAt { get; set; }
     public string FileResourceGuid { get; set; }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.scss
@@ -23,7 +23,7 @@
     &__label {
         font-size: $type-size-200;
         font-weight: 500;
-        color: $gray-400;
+        color: $gray-600;
         margin-bottom: 1.25rem;
     }
 
@@ -77,7 +77,7 @@
         font-weight: 600;
         flex-shrink: 0;
         border: 1.5px solid $gray-300;
-        color: $gray-400;
+        color: $gray-600;
     }
 
     &__item--current &__number {
@@ -102,7 +102,7 @@
 
     &__desc {
         font-size: $type-size-200;
-        color: $gray-400;
+        color: $gray-600;
         line-height: 1.3;
         margin-top: 2px;
     }
@@ -132,7 +132,7 @@
 
     &__label {
         font-size: $type-size-200;
-        color: $gray-400;
+        color: $gray-600;
     }
 }
 
@@ -187,7 +187,7 @@
 
     &__back {
         font-size: $type-size-200;
-        color: $gray-400;
+        color: $gray-600;
         text-decoration: none;
 
         &:hover {
@@ -201,7 +201,7 @@
 
     &__desc {
         font-size: $type-size-200;
-        color: $gray-400;
+        color: $gray-600;
         margin: 0;
     }
 

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -547,6 +547,21 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 allFields.push(this.makeField(key, wqmp[key], 2));
             }
 
+            // The Jurisdiction the user picked in the upload modal is authoritative —
+            // override any AI-extracted value and mark as accepted so the user doesn't
+            // need to re-confirm a selection they already made.
+            const confirmedJurisdictionID = this.currentResult()?.StormwaterJurisdictionID;
+            if (confirmedJurisdictionID) {
+                const jurisdictionField = allFields.find((f) => f.key === "Jurisdiction");
+                if (jurisdictionField) {
+                    const confirmedValue = String(confirmedJurisdictionID);
+                    jurisdictionField.value = confirmedValue;
+                    jurisdictionField.acceptedValue = confirmedValue;
+                    jurisdictionField.state = "accepted";
+                    jurisdictionField.confidence = "high";
+                }
+            }
+
             this.fields.set(allFields);
         } catch {
             this.fields.set([]);

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-upload-modal/wqmp-upload-modal.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-upload-modal/wqmp-upload-modal.component.html
@@ -12,6 +12,13 @@
         <strong>File:</strong> {{ file.name }}
     </div>
 
+    <form-field
+        fieldLabel="WQMP Name"
+        [type]="FormFieldType.Text"
+        [formControl]="wqmpNameControl"
+        placeholder="Enter a name for this WQMP">
+    </form-field>
+
     @if (jurisdictionOptions$ | async; as opts) {
         <form-field
             fieldLabel="Jurisdiction"
@@ -29,6 +36,6 @@
     }
 </div>
 <div class="modal-footer">
-    <button class="btn btn-primary" (click)="upload()" [disabled]="jurisdictionControl.invalid || isUploading()">Upload & Extract</button>
+    <button class="btn btn-primary" (click)="upload()" [disabled]="jurisdictionControl.invalid || wqmpNameControl.invalid || isUploading()">Upload & Extract</button>
     <button class="btn btn-secondary-outline" (click)="cancel()" [disabled]="isUploading()">Cancel</button>
 </div>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-upload-modal/wqmp-upload-modal.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-upload-modal/wqmp-upload-modal.component.ts
@@ -23,6 +23,10 @@ import { environment } from "src/environments/environment";
 export class WqmpUploadModalComponent implements OnInit {
     public ref: DialogRef<{ file: File }, { wqmpID: number }> = inject(DialogRef);
     public FormFieldType = FormFieldType;
+    public wqmpNameControl = new FormControl<string>("", {
+        nonNullable: true,
+        validators: [Validators.required, Validators.maxLength(100)],
+    });
     public jurisdictionControl = new FormControl<number | null>(null, { validators: [Validators.required] });
     public jurisdictionOptions$: Observable<FormInputOption[]>;
     public isUploading = signal(false);
@@ -50,7 +54,7 @@ export class WqmpUploadModalComponent implements OnInit {
     }
 
     upload(overwrite = false): void {
-        if (this.jurisdictionControl.invalid) return;
+        if (this.jurisdictionControl.invalid || this.wqmpNameControl.invalid) return;
         this.isUploading.set(true);
         this.alertService.clearAlerts();
 
@@ -96,6 +100,7 @@ export class WqmpUploadModalComponent implements OnInit {
         const formData = new FormData();
         formData.append("file", this.file);
         formData.append("stormwaterJurisdictionID", this.jurisdictionControl.value.toString());
+        formData.append("wqmpName", this.wqmpNameControl.value.trim());
         if (overwrite) {
             formData.append("overwrite", "true");
         }

--- a/Neptune.Web/src/app/shared/generated/api/water-quality-management-plan.service.ts
+++ b/Neptune.Web/src/app/shared/generated/api/water-quality-management-plan.service.ts
@@ -2005,14 +2005,15 @@ export class WaterQualityManagementPlanService extends BaseService {
     /**
      * @param file 
      * @param stormwaterJurisdictionID 
+     * @param wqmpName 
      * @param overwrite 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public uploadAndExtractWaterQualityManagementPlan(file?: Blob, stormwaterJurisdictionID?: number, overwrite?: boolean, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<WaterQualityManagementPlanExtractionResultDto>;
-    public uploadAndExtractWaterQualityManagementPlan(file?: Blob, stormwaterJurisdictionID?: number, overwrite?: boolean, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<WaterQualityManagementPlanExtractionResultDto>>;
-    public uploadAndExtractWaterQualityManagementPlan(file?: Blob, stormwaterJurisdictionID?: number, overwrite?: boolean, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<WaterQualityManagementPlanExtractionResultDto>>;
-    public uploadAndExtractWaterQualityManagementPlan(file?: Blob, stormwaterJurisdictionID?: number, overwrite?: boolean, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+    public uploadAndExtractWaterQualityManagementPlan(file?: Blob, stormwaterJurisdictionID?: number, wqmpName?: string, overwrite?: boolean, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<WaterQualityManagementPlanExtractionResultDto>;
+    public uploadAndExtractWaterQualityManagementPlan(file?: Blob, stormwaterJurisdictionID?: number, wqmpName?: string, overwrite?: boolean, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<WaterQualityManagementPlanExtractionResultDto>>;
+    public uploadAndExtractWaterQualityManagementPlan(file?: Blob, stormwaterJurisdictionID?: number, wqmpName?: string, overwrite?: boolean, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<WaterQualityManagementPlanExtractionResultDto>>;
+    public uploadAndExtractWaterQualityManagementPlan(file?: Blob, stormwaterJurisdictionID?: number, wqmpName?: string, overwrite?: boolean, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
 
         let localVarHeaders = this.defaultHeaders;
 
@@ -2053,6 +2054,9 @@ export class WaterQualityManagementPlanService extends BaseService {
         }
         if (stormwaterJurisdictionID !== undefined) {
             localVarFormParams = localVarFormParams.append('stormwaterJurisdictionID', <any>stormwaterJurisdictionID) as any || localVarFormParams;
+        }
+        if (wqmpName !== undefined) {
+            localVarFormParams = localVarFormParams.append('wqmpName', <any>wqmpName) as any || localVarFormParams;
         }
         if (overwrite !== undefined) {
             localVarFormParams = localVarFormParams.append('overwrite', <any>overwrite) as any || localVarFormParams;

--- a/Neptune.Web/src/app/shared/generated/model/water-quality-management-plan-extraction-result-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/water-quality-management-plan-extraction-result-dto.ts
@@ -13,6 +13,7 @@ import { FormControl, FormControlOptions, FormControlState, Validators } from "@
 export class WaterQualityManagementPlanExtractionResultDto { 
     WaterQualityManagementPlanID?: number;
     WaterQualityManagementPlanDocumentID?: number;
+    StormwaterJurisdictionID?: number;
     ExtractionResultJson?: string | null;
     ExtractedAt?: string;
     FileResourceGuid?: string | null;
@@ -29,6 +30,7 @@ export class WaterQualityManagementPlanExtractionResultDto {
 export interface WaterQualityManagementPlanExtractionResultDtoForm { 
     WaterQualityManagementPlanID?: FormControl<number>;
     WaterQualityManagementPlanDocumentID?: FormControl<number>;
+    StormwaterJurisdictionID?: FormControl<number>;
     ExtractionResultJson?: FormControl<string>;
     ExtractedAt?: FormControl<string>;
     FileResourceGuid?: FormControl<string>;
@@ -51,6 +53,16 @@ export class WaterQualityManagementPlanExtractionResultDtoFormControls {
         }
     );
     public static WaterQualityManagementPlanDocumentID = (value: FormControlState<number> | number = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<number>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static StormwaterJurisdictionID = (value: FormControlState<number> | number = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<number>(
         value,
         formControlOptions ?? 
         {


### PR DESCRIPTION
## Summary

Addresses KE's 4/16 rework pass on NPT-1015 (AI Module: Initiate a New WQMP AI Workflow).

- **Upload modal now collects WQMP Name.** Adds a required Text form-field (`Validators.required` + `maxLength(100)`) alongside the Jurisdiction dropdown. The backend endpoint accepts `[FromForm] string wqmpName`, trims, validates non-empty and ≤100 chars. Replaces the prior `Path.GetFileNameWithoutExtension(file.FileName)` source — the user's explicit name now flows into the WQMP row and the duplicate-name check.
- **Jurisdiction pre-populated and auto-accepted on review page.** Extraction result DTO now carries the confirmed `StormwaterJurisdictionID`, projected from the parent WQMP record. `parseExtractionResult` overrides the Jurisdiction field with that value and marks it `state: "accepted"` with high confidence so the user doesn't re-confirm a selection they already made in the upload modal.
- **WCAG 2.2 AA contrast fix.** Six `color: $gray-400` usages in `wqmp-review.component.scss` swapped to `$gray-600` (3.0:1 → 4.7:1 on white). Borders left alone — only text failed AA.

Fourth red rework item ("I'm not seeing anything populate via AI yet") predated the NPT-1037 Anthropic migration and should be resolved on `develop` now; will ask KE to re-verify.

## Test plan

- [ ] Open the upload modal. Upload button is disabled until both Name and Jurisdiction are filled.
- [ ] Upload with a typed name that differs from the filename. On the review page, Basics shows the typed name (not the filename).
- [ ] Re-upload with the same name + jurisdiction as an existing Draft WQMP → 409 overwrite confirm dialog still fires.
- [ ] Upload with Jurisdiction = Aliso Viejo. Review page Location step shows Aliso Viejo preselected (and marked accepted / counted in the "confirmed" progress) even on a PDF that doesn't mention any jurisdiction.
- [ ] Lighthouse Accessibility on the review page reports no contrast findings on `.review-sidebar__label`, `.step-nav__desc`, `.progress-bar__label`, `.review-panel__back`, `.review-panel__desc`.
- [ ] Upload one of KE's original sample PDFs and confirm at least one Basics field comes back non-blank (post-Anthropic-migration sanity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)