### PR TITLE
NPT-1043: Fix broken CSV parser test assertions from 8c69e12bc

### DIFF
--- a/Neptune.Tests/TestTreatmentCSVParser.cs
+++ b/Neptune.Tests/TestTreatmentCSVParser.cs
@@ -884,7 +884,7 @@ Frank,30,10,City of Orange,Sitka Technology Group,2008,ABCD,Perpetuity/Life of P
             foreach (var treatmentBMPTypeID in treatmentBMPTypeIDs)
             {
                 TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out _);
-                Assert.IsTrue(errorList.Any(x => x.Contains("Permanent Pool or Wetland Volume")));
+                Assert.IsTrue(errorList.Any(x => x.Contains("Permanent Pool Or Wetland Volume")));
             }
         }
 
@@ -1165,16 +1165,6 @@ Frank,30,10,City of Orange,Sitka Technology Group,2008,ABCD,Perpetuity/Life of P
             TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out var customAttributes);
             Assert.IsTrue(errorList.Any(x => !x.Contains("Underlying Hydrologic Soil Group")));
             Assert.AreEqual("Liner", customAttributes[0].AttributeValue);
-        }
-
-        [TestMethod]
-        public void TestBMPModelingAttributeUnderlyingHydrologicSoilGroupIDLinerWithBioinfiltrationBioretentionWithRaisedUnderdrainBad()
-        {
-            const string csv = @"BMP Name,Latitude,Longitude,Jurisdiction, Owner,Year Built or Installed,Asset ID in System of Record, Required Lifespan of Installation,Allowable End Date of Installation (if applicable), Required Field Visits Per Year, Required Post-Storm Field Visits Per Year,Notes,Trash Capture Status,Sizing Basis,Underlying Hydrologic Soil Group,  
-Frank,30,10,City of Orange,Sitka Technology Group,2008,ABCD,Perpetuity/Life of Project,11/12/2022,5,6,Happy,Full,Not Provided,Liner";
-            var treatmentBMPTypeID = GetTreatmentBMPTypeIDByModelingTypeEnum(TreatmentBMPModelingTypeEnum.BioinfiltrationBioretentionWithRaisedUnderdrain);
-            TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out _);
-            Assert.IsTrue(errorList.Any(x => x.Contains("Underlying Hydrologic Soil Group")));
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary

Two tests in `Neptune.Tests/TestTreatmentCSVParser.cs` have been failing on `develop` since Mack's commit `8c69e12bc` (2025-06-27, "CSV Parser updated"). Full suite was 174/176; now 175/175.

- **`TestBMPModelingAttributePermanentPoolOrWetlandVolumeBad`** — casing mismatch. The assertion searched `errorList` for lowercase `"Permanent Pool or Wetland Volume"`, but the parser interpolates the DB-stored `CustomAttributeType.CustomAttributeTypeName` which is `"Permanent Pool Or Wetland Volume"` (uppercase "Or"). `.Contains` is case-sensitive. Fixed to uppercase "Or". The Good-variant sibling (line 872) was already updated to uppercase in `8c69e12bc`; the Bad variant was missed.
- **`TestBMPModelingAttributeUnderlyingHydrologicSoilGroupIDLinerWithBioinfiltrationBioretentionWithRaisedUnderdrainBad`** — deleted. Asserted that `"Liner"` should be rejected as `Underlying Hydrologic Soil Group` specifically for `BioinfiltrationBioretentionWithRaisedUnderdrain`. That BMP-type-specific Liner validation lived in `ParseModelingAttributes` + `GetAvailableModelingAttributes`, which `8c69e12bc` deliberately removed when folding modeling attributes into custom attributes. The `PickFromList` schema (`["A","B","C","D","Liner"]`) now accepts "Liner" unconditionally — no code path still rejects it per BMP type. The test asserts behavior that no longer exists. The Good-variant sibling (`TestBMPModelingAttributeUnderlyingHydrologicSoilGroupIDLinerGood`, line 1160) continues to cover the accepted path.

## Test plan

- [x] `dotnet test Neptune.Tests/Neptune.Tests.csproj` — 175 passed, 0 failed
- [ ] If we ever want per-BMP-type Liner rejection back, file a separate ticket with product input on which BMP types disallow it

🤖 Generated with [Claude Code](https://claude.com/claude-code)