### PR TITLE
NPT-1017: Make [showFind] explicit on WQMP review PDF viewer

### DIFF
--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
@@ -42,6 +42,7 @@
                     #pdfViewer
                     [pdfSrc]="pdfBlob"
                     [zoom]="'page-width'"
+                    [showFind]="true"
                     [showViewBookmark]="false"
                     [showOpenFile]="false"
                     [showDownload]="false"


### PR DESCRIPTION
## Summary

KE's 4/16 rework pass on NPT-1017 flagged two red items on the AI review page:

1. **PDF toolbar text search doesn't seem to work** (red "nit"). `ng2-pdfjs-viewer` v25.0.18 already defaults `showFind` to `true`, and nothing in our URL-building or SCSS disables it, so the search button should already be visible and functional. This PR sets the input explicitly to match the pattern of the other `[show*]="false"` bindings on the same element, making it obvious at a glance that search is intentionally surfaced. If KE still reports search broken, we'll need a screenshot + repro PDF (most likely suspect: image-only scan with no text layer, which pdf.js can't search).
2. **Click-to-navigate from extracted field → PDF location doesn't work.** No code change here — the infrastructure is complete (`WqmpReviewComponent.navigateToSource()` + `FieldCardComponent` event emission) and only requires the extraction JSON to include `ExtractionEvidence` and `DocumentSource`. KE tested pre-NPT-1037 Anthropic migration, same situation as NPT-1015's "nothing populates via AI" item. Flagging to KE to re-verify on the next QA deploy now that the Anthropic migration has landed.

## Test plan

- [ ] Open the WQMP review page on dev / QA, confirm the magnifying-glass search button is visible in the PDF toolbar.
- [ ] Type a word that's known to appear in the PDF — highlighted occurrences scroll into view.
- [ ] (Item 2) Upload a fresh PDF via the NPT-1015 upload flow, open the review page, click a field with non-empty evidence → PDF scrolls to the page and the snippet highlights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)