### PR TITLE
Pipeline: pass projectName + imageNames to docker-template

### DIFF
--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -112,8 +112,9 @@ stages:
         SecretsFilter: '*'
         RunAsPreJob: true
 
-    - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates 
+    - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates
       parameters:
+        projectName: 'neptune'
         displayName: 'API'
         subscription: '$(azureSubscription)'
         containerRegistry: '$(kv-containerRegistry)'
@@ -122,6 +123,10 @@ stages:
         additionalImageTags: |
           $(Build.BuildNumber)-$(environment)
         includeLatestTag: true
+        imageNames:
+          - neptune/webmvc
+          - neptune/api
+          - neptune/gdalapi
 
 
   - job: BuildWeb
@@ -140,8 +145,9 @@ stages:
         SecretsFilter: '*'
         RunAsPreJob: true
 
-    - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates 
+    - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates
       parameters:
+        projectName: 'neptune'
         displayName: 'Web'
         subscription: '$(azureSubscription)'
         containerRegistry: '$(kv-containerRegistry)'
@@ -150,6 +156,8 @@ stages:
         additionalImageTags: |
           $(Build.BuildNumber)-$(environment)
         includeLatestTag: true
+        imageNames:
+          - neptune/web
 
   - job: BuildQGIS
     displayName: Build QGISApi
@@ -167,8 +175,9 @@ stages:
         SecretsFilter: '*'
         RunAsPreJob: true
 
-    - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates 
+    - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates
       parameters:
+        projectName: 'neptune'
         displayName: 'QGISApi'
         subscription: '$(azureSubscription)'
         containerRegistry: '$(kv-containerRegistry)'
@@ -177,6 +186,8 @@ stages:
         additionalImageTags: |
           $(Build.BuildNumber)-$(environment)
         includeLatestTag: true
+        imageNames:
+          - neptune/qgisapi
 
 - stage: BuildNereid
   displayName: Build Nereid


### PR DESCRIPTION
## Summary
- Wires Microsoft Defender for Cloud per-image container scans into the API, Web, and QGISApi build jobs by passing `imageNames` to the updated `docker-template.yml@BuildTemplates`.
- Also sets the now-required `projectName: 'neptune'` on all three template calls.

## Context
BuildTemplates' `docker-template` now emits one `MicrosoftSecurityDevOps@1` (Trivy) scan per `imageName` at compile time — feeding Defender for Cloud and the ADO Scans tab. Without `imageNames` it falls back to scanning only the first compose image discovered at runtime. Listing every image here ensures full coverage.

`imageNames` values match the compose `image:` declarations and the repositories already referenced in the helm `overrideValues`:
- API compose (`docker-compose/docker-compose.yml`): `neptune/webmvc`, `neptune/api`, `neptune/gdalapi`
- Web compose (`Neptune.Web/docker-compose/docker-compose.yml`): `neptune/web`
- QGISApi compose (`docker-compose/docker-compose.qgisapi.yml`): `neptune/qgisapi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)