### PR TITLE
NPT-1045: Preserve Assessment Date on Return to Edit of finalized OVTA

### DIFF
--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentExtensionMethods.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentExtensionMethods.cs
@@ -100,7 +100,10 @@ public static class OnlandVisualTrashAssessmentExtensionMethods
             AssessmentAreaDescription = onlandVisualTrashAssessment.OnlandVisualTrashAssessmentArea != null ? onlandVisualTrashAssessment.OnlandVisualTrashAssessmentArea.AssessmentAreaDescription : onlandVisualTrashAssessment.DraftAreaDescription,
             AssessingNewArea = onlandVisualTrashAssessment.AssessingNewArea ?? false,
             IsProgressAssessment = onlandVisualTrashAssessment.IsProgressAssessment,
-            AssessmentDate = DateOnly.FromDateTime(DateTime.UtcNow),
+            // Preserve the originally-finalized Assessment Date on return-to-edit. Fall back to
+            // today only when CompletedDate has never been set (initial finalize of a new OVTA),
+            // so the form still pre-fills a reasonable default for brand-new records.
+            AssessmentDate = onlandVisualTrashAssessment.CompletedDate ?? DateOnly.FromDateTime(DateTime.UtcNow),
             OnlandVisualTrashAssessmentStatusID = onlandVisualTrashAssessment.OnlandVisualTrashAssessmentStatusID,
         };
 


### PR DESCRIPTION
## Summary

\`AsReviewAndFinalizeDto\` was hardcoding today's date into the DTO's \`AssessmentDate\` on every call, so the "Return to Edit" flow on a finalized OVTA silently replaced the historical Assessment Date (e.g. 2019) with today. If the reviewer saved without noticing, the save path at \`OnlandVisualTrashAssessments.cs:180\` committed today's date back into \`CompletedDate\`, destroying the original value.

## Fix

One line in \`Neptune.EFModels/Entities/OnlandVisualTrashAssessmentExtensionMethods.cs:103\`:

\`\`\`csharp
// Before
AssessmentDate = DateOnly.FromDateTime(DateTime.UtcNow),

// After
AssessmentDate = onlandVisualTrashAssessment.CompletedDate ?? DateOnly.FromDateTime(DateTime.UtcNow),
\`\`\`

Fall back to today only when \`CompletedDate\` has never been set (initial finalize of a brand-new OVTA), so the form still pre-fills a reasonable default for new records. The save path already persists \`dto.AssessmentDate\` into \`CompletedDate\` — no changes needed there. DTO type (\`DateOnly?\`) and entity column type (\`DateOnly?\`) already align, so no schema or codegen change.

## Test plan

- [ ] Open a finalized OVTA with a historical Assessment Date (e.g. 2019), click Return to Edit → field shows 2019, not today
- [ ] Save without changing the date → DB \`CompletedDate\` still 2019
- [ ] Start a brand-new OVTA → Review & Finalize field pre-fills today (unchanged behavior)
- [ ] Return to Edit an existing record and change the Assessment Date to a different historical date → save, reload, value round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)