### PR TITLE
NPT-1046: Update OVTA transect line on backing-assessment observation edits

### DIFF
--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessments.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessments.cs
@@ -199,17 +199,29 @@ public static class OnlandVisualTrashAssessments
                         ?.OnlandVisualTrashAssessmentScoreID;
             }
 
-            if (onlandVisualTrashAssessment.OnlandVisualTrashAssessmentArea.TransectLine == null && onlandVisualTrashAssessment.OnlandVisualTrashAssessmentObservations.Count >= 2)
+            // Recompute the area's transect line when this save belongs to the backing
+            // assessment: either the area has no line yet (first finalize) or this assessment
+            // is flagged as the backing one (return-to-edit). Repeat assessments on an area
+            // that already has a backing-derived transect leave it alone.
+            var wasNeverSet = onlandVisualTrashAssessment.OnlandVisualTrashAssessmentArea.TransectLine == null;
+            var isBackingAssessment = onlandVisualTrashAssessment.IsTransectBackingAssessment || wasNeverSet;
+
+            if (isBackingAssessment && onlandVisualTrashAssessment.OnlandVisualTrashAssessmentObservations.Count >= 2)
             {
                 var transect = GetTransectLine(onlandVisualTrashAssessment);
                 onlandVisualTrashAssessment.OnlandVisualTrashAssessmentArea.TransectLine = transect;
                 onlandVisualTrashAssessment.OnlandVisualTrashAssessmentArea.TransectLine4326 = transect.ProjectTo4326();
-                onlandVisualTrashAssessment.IsTransectBackingAssessment = true;
 
-                var transectBackingAssessment = GetTransectBackingAssessment(dbContext, onlandVisualTrashAssessment.OnlandVisualTrashAssessmentAreaID);
-                if (transectBackingAssessment != null)
+                if (wasNeverSet)
                 {
-                    transectBackingAssessment.IsTransectBackingAssessment = false;
+                    // First finalize — stamp this assessment as backing and demote any stale
+                    // flag elsewhere (defensive for odd states).
+                    onlandVisualTrashAssessment.IsTransectBackingAssessment = true;
+                    var existingBacking = GetTransectBackingAssessment(dbContext, onlandVisualTrashAssessment.OnlandVisualTrashAssessmentAreaID);
+                    if (existingBacking != null && existingBacking.OnlandVisualTrashAssessmentID != onlandVisualTrashAssessment.OnlandVisualTrashAssessmentID)
+                    {
+                        existingBacking.IsTransectBackingAssessment = false;
+                    }
                 }
             }
         }

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
@@ -35,6 +35,7 @@
         }
         @if (mapIsReady()) {
           <transect-line-layer
+            #transectLineLayer
             [displayOnLoad]="true"
             [map]="map"
             [layerControl]="layerControl"

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from "@angular/core";
+import { Component, signal, ViewChild } from "@angular/core";
 import * as L from "leaflet";
 import { PageHeaderComponent } from "../../../../shared/components/page-header/page-header.component";
 import { NeptuneMapComponent, NeptuneMapInitEvent } from "../../../../shared/components/leaflet/neptune-map/neptune-map.component";
@@ -72,6 +72,10 @@ export class TrashOvtaRecordObservationsComponent {
 
     @Input() onlandVisualTrashAssessmentID!: number;
 
+    // Template ref used to ask the transect-line layer to re-fetch + redraw after a save so
+    // the map reflects observation edits on the backing assessment without a full page reload.
+    @ViewChild("transectLineLayer") transectLineLayer?: TransectLineLayerComponent;
+
     constructor(
         private onlandVisualTrashAssessmentService: OnlandVisualTrashAssessmentService,
         private onlandVisualTrashAssessmentObservationService: OnlandVisualTrashAssessmentObservationService,
@@ -101,6 +105,9 @@ export class TrashOvtaRecordObservationsComponent {
                         Longitude: onlandVisualTrashAssessmentObservation.Longitude,
                         FileResourceID: onlandVisualTrashAssessmentObservation.FileResourceID,
                         FileResourceGUID: onlandVisualTrashAssessmentObservation.FileResourceGUID,
+                        // Preserve the original observation timestamp so the transect line
+                        // orders observations the same way across edits.
+                        ObservationDatetime: onlandVisualTrashAssessmentObservation.ObservationDatetime,
                     });
                     formArray.push(observation);
                 });
@@ -171,6 +178,10 @@ export class TrashOvtaRecordObservationsComponent {
             Longitude: latlng.lng,
             FileResourceID: null,
             FileResourceGUID: null,
+            // Stamp new observations with the client clock at add-time so each one gets a
+            // distinct timestamp (avoids the backend's UtcNow fallback collapsing everything
+            // into a single value and breaking transect-line ordering).
+            ObservationDatetime: new Date().toISOString(),
         });
         const formArray = this.formGroup.controls.Observations as FormArray;
         formArray.push(observation);
@@ -213,6 +224,9 @@ export class TrashOvtaRecordObservationsComponent {
                 this.alertService.clearAlerts();
                 this.alertService.pushAlert(new Alert("Your observations were successfully updated.", AlertContext.Success));
                 this.ovtaWorkflowProgressService.updateProgress(this.onlandVisualTrashAssessmentID);
+                // Observation edits may have redrawn the area's transect line (when this is
+                // the backing assessment). Ask the layer to re-fetch so the map stays current.
+                this.transectLineLayer?.refresh();
 
                 if (andContinue) {
                     this.onlandVisualTrashAssessmentService.getWorkflowProgressOnlandVisualTrashAssessment(this.onlandVisualTrashAssessmentID).subscribe((response) => {

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/transect-line-layer/transect-line-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/transect-line-layer/transect-line-layer.component.ts
@@ -37,6 +37,23 @@ export class TransectLineLayerComponent extends MapLayerBase implements OnChange
     public featureCollection$: Observable<IFeature[]>;
 
     ngAfterViewInit(): void {
+        this.loadLayer();
+    }
+
+    /**
+     * Drop the current layer from the map and re-fetch the transect line. Parent components
+     * call this after a save that can change observation geometry (e.g. record-observations
+     * save) so the map reflects the new line without requiring a full page reload.
+     */
+    public refresh(): void {
+        if (this.layer) {
+            this.layer.remove();
+            this.layer = undefined;
+        }
+        this.loadLayer();
+    }
+
+    private loadLayer(): void {
         if (this.ovtaID) {
             const request$ = this.onlandVisualTrashAssessmentService.getTransectLineAsFeatureCollectionOnlandVisualTrashAssessment(this.ovtaID);
             this.featureCollection$ = this.trackLayerRequest$(request$).pipe(


### PR DESCRIPTION
## Summary

Three compounding bugs prevented the OVTA Area's transect line from reflecting observation-point edits on the **backing assessment** (first assessment for a given area). Repeat assessments on an existing area continue to leave the stored line untouched, per AC.

## Fixes

### 1. Backend write-once guard → backing-assessment-aware
**File:** \`Neptune.EFModels/Entities/OnlandVisualTrashAssessments.cs\`

The guard only recomputed when the Area's \`TransectLine\` was null, so return-to-edit never redrew. Replaced with a check that fires when the current assessment is flagged \`IsTransectBackingAssessment\` **or** the Area has never had a line yet. Repeat assessments (non-backing) still skip the recompute.

### 2. \`ObservationDatetime\` preserved through the form
**File:** \`Neptune.Web/.../trash-ovta-record-observations.component.ts\`

Neither form group included the field, so save sent \`null\` for every observation and the backend's \`?? UtcNow\` fallback collapsed every timestamp into a single value — scrambling the transect line's \`OrderBy(ObservationDatetime)\`. Existing-obs path now pipes the stored datetime through; new-obs path stamps \`new Date().toISOString()\` at add-time so each point gets a unique timestamp.

### 3. Map layer refreshes after save
**Files:** \`transect-line-layer.component.ts\`, \`trash-ovta-record-observations.component.{ts,html}\`

\`TransectLineLayerComponent\` fetched once in \`ngAfterViewInit\` and never reloaded. Extracted \`loadLayer()\` and added a public \`refresh()\` that removes the old layer and re-runs the fetch. The observations page grabs the component via \`@ViewChild\` and calls \`refresh()\` from the \`save()\` success callback.

## Test plan

- [ ] **AC1 — New path.** Start a brand-new OVTA, drop 3 points, finalize. Area has transect line connecting the three. Return to edit, drag a point, save → line on map updates; DB-stored \`TransectLine\` matches new geometry.
- [ ] **AC2 — Return-to-edit on backing.** Open an existing finalized OVTA that is the backing assessment. Drag a point, save → stored transect updates, layer redraws.
- [ ] **AC3 — Repeat assessment preserves transect.** On an area with a backing assessment, create a repeat assessment. Add observations, save → area's \`TransectLine\` UNCHANGED.
- [ ] **ObservationDatetime round-trip.** Edit a backing assessment, move one point only, save → DB shows the other observations keep their original timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)