### PR TITLE
NPT-1031: Fix remaining OVTA map-spinning cases (observations-map + fresh OVTA)

### DIFF
--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
@@ -24,7 +24,7 @@
         @if (mapIsReady()) {
           <parcel-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="15" styles="parcel_alt"></parcel-layer>
         }
-        @if (mapIsReady && onlandVisualTrashAssessment.OnlandVisualTrashAssessmentAreaID) {
+        @if (mapIsReady() && onlandVisualTrashAssessment.OnlandVisualTrashAssessmentAreaID) {
           <ovta-area-layer
             [displayOnLoad]="true"
             [map]="map"

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/observations-map/observations-map.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/observations-map/observations-map.component.html
@@ -27,10 +27,10 @@
     </div>
     <div class="g-col-8">
       <neptune-map (onMapLoad)="handleMapReady($event)" [mapHeight]="mapHeight" [showLegend]="true" [boundingBox]="boundingBox">
-        @if (mapIsReady) {
+        @if (mapIsReady()) {
           <land-use-block-layer [displayOnLoad]="true" [map]="map" [layerControl]="layerControl" [sortOrder]="10"></land-use-block-layer>
         }
-        @if (mapIsReady) {
+        @if (mapIsReady()) {
           <ovta-area-layer
             [displayOnLoad]="true"
             [map]="map"
@@ -38,7 +38,7 @@
             [sortOrder]="20"
           [ovtaID]="onlandVisualTrashAssessmentID"></ovta-area-layer>
         }
-        @if (mapIsReady) {
+        @if (mapIsReady()) {
           <transect-line-layer
             [displayOnLoad]="true"
             [map]="map"

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/observations-map/observations-map.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/observations-map/observations-map.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from "@angular/core";
+import { Component, ElementRef, EventEmitter, Input, Output, signal, ViewChild } from "@angular/core";
 import * as L from "leaflet";
 import { BoundingBoxDto } from "src/app/shared/generated/model/bounding-box-dto";
 import { MarkerHelper } from "src/app/shared/helpers/marker-helper";
@@ -24,7 +24,12 @@ export class ObservationsMapComponent {
     @Input() onlandVisualTrashAssessmentID: number;
     public boundingBox: BoundingBoxDto;
 
-    public mapIsReady: boolean = false;
+    // Signal (not plain boolean) so zoneless change detection re-runs the template's @if
+    // guards when Leaflet fires onMapLoad. With a plain field, the ready flag would flip but
+    // the layer @if gates never re-evaluate and the map sits behind the loading spinner
+    // forever. Parallels the fix Jamie landed on trash-ovta-record-observations (commit
+    // dc98dec57).
+    public mapIsReady = signal(false);
     public mapHeight: string = "600px";
 
     @Output()
@@ -50,7 +55,7 @@ export class ObservationsMapComponent {
     public handleMapReady(event: NeptuneMapInitEvent): void {
         this.map = event.map;
         this.layerControl = event.layerControl;
-        this.mapIsReady = true;
+        this.mapIsReady.set(true);
         this.addObservationPointsLayersToMap();
     }
 


### PR DESCRIPTION
## Summary

KE's 4/24 retest caught three pages still spinning after the 4/22 fix:

1. **Review and Finalize map** (\`/trash/onland-visual-trash-assessments/edit/{id}/review-and-finalize\`)
2. **Assessment Detail page** (\`/trash/onland-visual-trash-assessments/{id}\`)
3. **Record Observations** when the user starts a *fresh* OVTA (not a repeat)

Two root causes:

### 1. \`observations-map\` (used by pages #1 and #2) had a plain-boolean \`mapIsReady\`

In zoneless mode the \`@if (mapIsReady)\` gates never re-evaluated after Leaflet's \`onMapLoad\` flipped the flag. Map tiles rendered fine but the layer components underneath never did — same symptom Jamie fixed on record-observations in commit \`dc98dec57\`. Converted to \`signal<boolean>\`, matching that pattern. Template gates now call \`mapIsReady()\`.

### 2. \`trash-ovta-record-observations\` template had a signal-call typo

Line 27's \`@if (mapIsReady && onlandVisualTrashAssessment.OnlandVisualTrashAssessmentAreaID)\` uses the bare signal reference. Angular's template binding tracks signals only when you *invoke* them; the bare reference is the signal function (always truthy) and the guard doesn't re-evaluate on \`set()\`. Only bites on the fresh-OVTA path (no AreaID) where the short-circuit would hide the issue, but still a real latent bug. Added the parens.

## Test plan

- [ ] Open a finalized OVTA → navigate to Review and Finalize — map tiles + layers render without spinner stall.
- [ ] Navigate to the Assessment Detail page on an OVTA with observations — same.
- [ ] Start a fresh OVTA (not a repeat assessment) → reach Record Observations — map loads.
- [ ] Repeat-assessment path still works (unchanged code path for existing signal-based gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)