### PR TITLE
NPT-1046 rework: return-to-edit transect, parcel click zoom, column rename

### DIFF
--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentObservations.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentObservations.cs
@@ -88,6 +88,34 @@ namespace Neptune.EFModels.Entities
                 .Where(x => x.OnlandVisualTrashAssessmentID == onlandVisualTrashAssessmentID).ExecuteDeleteAsync();
 
             await dbContext.SaveChangesAsync();
+
+            // Return-to-Edit path: if the user edited observations on the area's backing
+            // assessment after it was already finalized, recompute the area's stored
+            // TransectLine from the new geometry. Mirrors the logic in
+            // OnlandVisualTrashAssessments.Update (the finalize path) so both save paths
+            // keep the area's transect in sync with the backing assessment's observations.
+            // Repeat assessments (IsTransectBackingAssessment == false) don't hit this branch
+            // and the area's transect stays anchored to the original backing as intended.
+            var assessment = await dbContext.OnlandVisualTrashAssessments
+                .Include(x => x.OnlandVisualTrashAssessmentArea)
+                .Include(x => x.OnlandVisualTrashAssessmentObservations)
+                .SingleOrDefaultAsync(x => x.OnlandVisualTrashAssessmentID == onlandVisualTrashAssessmentID);
+
+            if (assessment?.OnlandVisualTrashAssessmentArea == null) return;
+
+            var wasNeverSet = assessment.OnlandVisualTrashAssessmentArea.TransectLine == null;
+            var isBacking = assessment.IsTransectBackingAssessment || wasNeverSet;
+
+            if (isBacking && assessment.OnlandVisualTrashAssessmentObservations.Count >= 2)
+            {
+                var transect = OnlandVisualTrashAssessments.GetTransectLine(assessment.OnlandVisualTrashAssessmentObservations);
+                if (transect != null)
+                {
+                    assessment.OnlandVisualTrashAssessmentArea.TransectLine = transect;
+                    assessment.OnlandVisualTrashAssessmentArea.TransectLine4326 = transect.ProjectTo4326();
+                    await dbContext.SaveChangesAsync();
+                }
+            }
         }
     }
 }

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-add-remove-parcels/trash-ovta-add-remove-parcels.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-add-remove-parcels/trash-ovta-add-remove-parcels.component.ts
@@ -76,12 +76,13 @@ export class TrashOvtaAddRemoveParcelsComponent {
     public handleMapReady(event: NeptuneMapInitEvent, onlandVisualTrashAssessment: OnlandVisualTrashAssessmentAddRemoveParcelsDto): void {
         this.map = event.map;
         this.layerControl = event.layerControl;
-        this.addSelectedParcelsToMap();
+        // Initial load: fit to the selection so the user starts zoomed at the right scale.
+        this.addSelectedParcelsToMap(true);
         this.enableDisableParcelClickEvent(onlandVisualTrashAssessment);
         this.mapIsReady = true;
     }
 
-    private addSelectedParcelsToMap() {
+    private addSelectedParcelsToMap(shouldFitBounds: boolean = false) {
         if (this.selectedParcelsLayer) {
             this.map.removeLayer(this.selectedParcelsLayer);
         }
@@ -89,7 +90,12 @@ export class TrashOvtaAddRemoveParcelsComponent {
             this.wfsService.getGeoserverWFSLayerWithCQLFilter("OCStormwater:Parcels", `ParcelID in (${this.selectedParcelIDs.join(",")})`, "ParcelID").subscribe((response) => {
                 this.selectedParcelsLayer = L.geoJSON(response as any, { style: this.highlightStyle });
                 this.selectedParcelsLayer.addTo(this.map);
-                this.map.fitBounds(this.selectedParcelsLayer.getBounds());
+                // Only fit bounds on initial load / explicit refresh, not on every parcel
+                // click — otherwise the map yanks the user's zoom each time they add or
+                // remove a parcel and makes bulk selection nearly impossible.
+                if (shouldFitBounds) {
+                    this.map.fitBounds(this.selectedParcelsLayer.getBounds());
+                }
             });
         }
     }
@@ -110,7 +116,8 @@ export class TrashOvtaAddRemoveParcelsComponent {
     public refreshParcels() {
         this.onlandVisualTrashAssessmentService.refreshOnlandVisualTrashAssessmentParcelsOnlandVisualTrashAssessment(this.onlandVisualTrashAssessmentID).subscribe((ovta) => {
             this.selectedParcelIDs = ovta.SelectedParcelIDs;
-            this.addSelectedParcelsToMap();
+            // Explicit refresh — fit bounds so the new selection is visible in full.
+            this.addSelectedParcelsToMap(true);
             this.enableDisableParcelClickEvent(ovta);
             this.onlandVisualTrashAssessment$ = of(ovta);
         });

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-index/trash-ovta-index.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-index/trash-ovta-index.component.ts
@@ -69,7 +69,7 @@ export class TrashOvtaIndexComponent {
                 CustomDropdownFilterField: "OnlandVisualTrashAssessmentScoreName",
             }),
             this.utilityFunctionsService.createBasicColumnDef("Assessment Type", "IsProgressAssessment", { CustomDropdownFilterField: "IsProgressAssessment" }),
-            this.utilityFunctionsService.createDateColumnDef("Last Assessment Date", "CompletedDate", "shortDate"),
+            this.utilityFunctionsService.createDateColumnDef("Assessment Date", "CompletedDate", "shortDate"),
             this.utilityFunctionsService.createBasicColumnDef("Status", "OnlandVisualTrashAssessmentStatusName", {
                 CustomDropdownFilterField: "OnlandVisualTrashAssessmentStatusName",
             }),


### PR DESCRIPTION
## Summary

Three items KE left red on NPT-1046 after the 4/24 retest.

### 1. Return-to-edit now updates the area's transect line

The original NPT-1046 fix recomputed the transect in \`OnlandVisualTrashAssessments.Update\` (the finalize save path). **Return-to-Edit** saves observations through the observation controller → \`OnlandVisualTrashAssessmentObservations.Update\`, which re-inserted observation rows and never touched the area. Added the same guarded recompute after \`SaveChangesAsync\`: when the current assessment is the backing (or the area still has a null TransectLine), regenerate from the freshly-saved observations via the existing \`OnlandVisualTrashAssessments.GetTransectLine\` helper. Repeat assessments remain untouched.

### 2. Parcel clicks no longer yank the zoom

\`trash-ovta-add-remove-parcels.component.ts\`'s \`addSelectedParcelsToMap\` always ran \`fitBounds\` — fine on initial load but annoying on every add/remove click. Added a \`shouldFitBounds\` parameter defaulting to \`false\`. \`handleMapReady\` (initial load) and \`refreshParcels\` (explicit refresh) pass \`true\`; the click handler uses the default so zoom stays put during bulk selection.

### 3. "Last Assessment Date" → "Assessment Date"

Grid column in \`trash-ovta-index.component.ts:72\`. Each row is one assessment, "Last" was misleading.

## Test plan
- [ ] Open finalized backing assessment → Return to Edit → drag a point → save → reload the OVTA Area detail — transect reflects the new point position (DB \`OnlandVisualTrashAssessmentArea.TransectLine\` updated).
- [ ] Repeat assessment on same area → edit its observations → save → area's TransectLine UNCHANGED (regression check).
- [ ] Add/Remove Parcels at street-level zoom: click parcel → selection toggles, zoom/center unchanged. Click Refresh Parcels → fits to selection.
- [ ] Grid at \`/trash/onland-visual-trash-assessments\` shows column "Assessment Date" (not "Last Assessment Date").

🤖 Generated with [Claude Code](https://claude.com/claude-code)