### PR TITLE
NPT-1031: Fix map spinner stall under zoneless CD

### DIFF
--- a/Neptune.Web/src/app/shared/components/leaflet/neptune-map/neptune-map.component.html
+++ b/Neptune.Web/src/app/shared/components/leaflet/neptune-map/neptune-map.component.html
@@ -51,7 +51,7 @@
         [id]="mapID"
         [style.height]="mapHeight"
         [style.cursor]="cursorStyle"
-        [loadingSpinner]="{ isLoading: (isAnyLayerLoading$ | async) ?? false, loadingHeight: null }">
+        [loadingSpinner]="{ isLoading: isAnyLayerLoading(), loadingHeight: null }">
         @if (showLegend) {
             <div class="legend leaflet-control-layers leaflet-control-layers-expanded" [id]="legendID">
                 <a class="leaflet-control-layers-toggle">

--- a/Neptune.Web/src/app/shared/components/leaflet/neptune-map/neptune-map.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/neptune-map/neptune-map.component.ts
@@ -1,4 +1,5 @@
-import { AfterViewInit, Component, DestroyRef, EventEmitter, Injector, Input, OnDestroy, OnInit, Output, afterNextRender, inject, runInInjectionContext } from "@angular/core";
+import { AfterViewInit, Component, DestroyRef, EventEmitter, Injector, Input, OnDestroy, OnInit, Output, Signal, afterNextRender, inject, runInInjectionContext } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
 import { CommonModule } from "@angular/common";
 import { Control, LeafletEvent, Map as LeafletMap, MapOptions, DomUtil, ControlPosition } from "leaflet";
 import "src/scripts/leaflet.groupedlayercontrol.js";
@@ -72,6 +73,14 @@ export class NeptuneMapComponent implements OnInit, AfterViewInit, OnDestroy {
         distinctUntilChanged(),
         shareReplay({ bufferSize: 1, refCount: true })
     );
+
+    // Zoneless Angular needs a signal here — not `async` pipe. The loading state flips from
+    // RxJS `finalize` teardown (MapLayerLoadingService.track$) and Leaflet event handlers, both
+    // of which run outside Angular's scheduler. `markForCheck` from the async pipe was not
+    // reliably triggering a CD tick, so the spinner kept animating even after state went false
+    // until a user click incidentally ran CD. Signals guarantee scheduler notification in
+    // zoneless mode.
+    public readonly isAnyLayerLoading: Signal<boolean> = toSignal(this.isAnyLayerLoading$, { initialValue: false });
 
     private readonly trackedLayerLoadingState = new Map<any, boolean>();
     private readonly trackedLayerListeners = new Map<


### PR DESCRIPTION
## Summary
- The `[loadingSpinner]` binding on `<neptune-map>` was using `async` pipe on `isAnyLayerLoading$`. The counter flips happen inside RxJS `finalize` teardown (`MapLayerLoadingService.track$`) and Leaflet layer event handlers — both run outside Angular's zoneless scheduler, so `markForCheck` did not reliably schedule a CD tick and the spinner kept animating after state went false until a stray click incidentally ran CD.
- Swap the async-pipe binding for a `toSignal(isAnyLayerLoading$)` signal. Signals integrate with the zoneless scheduler directly and guarantee the `[loadingSpinner]` input re-reads on each flip.

## Test plan
- [ ] Open Review and Finalize on a finalized OVTA — map loads and spinner fades out on its own (no click required).
- [ ] Open OVTA Assessment Detail (read-only view) — same behavior.
- [ ] Record Observations on a fresh OVTA (no observations yet) — spinner clears without user interaction.
- [ ] Existing map pages that already loaded cleanly still work (no regression): Treatment BMPs, WQMP map, OVTA Add/Remove Parcels.
- [ ] Verify the spinner briefly appears while layers load (not permanently suppressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)