### PR TITLE
NPT-1030 rework: LGU Delineations layers + WQMP edit-boundary save perf

### DIFF
--- a/Neptune.Database/Neptune.Database.sqlproj
+++ b/Neptune.Database/Neptune.Database.sqlproj
@@ -347,6 +347,7 @@
     <Build Include="dbo\Procs\dbo.pDeleteNereidResults.sql" />
     <Build Include="dbo\Procs\dbo.pDeleteProjectLoadGeneratingUnitsPriorToRefreshForProject.sql" />
     <Build Include="dbo\Procs\dbo.pDeleteProjectNereidResults.sql" />
+    <Build Include="dbo\Procs\dbo.pDelineationMakeValid.sql" />
     <Build Include="dbo\Procs\dbo.pDelineationMarkThoseThatHaveDiscrepancies.sql" />
     <Build Include="dbo\Procs\dbo.pFixInvalidRegionalSubbasinGeometries.sql" />
     <Build Include="dbo\Procs\dbo.pLandUseBlockStagingDeleteByPersonID.sql" />

--- a/Neptune.Database/Scripts/ReleaseScripts/024 - MakeValid on invalid Delineation geometries.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/024 - MakeValid on invalid Delineation geometries.sql
@@ -1,0 +1,4 @@
+-- NPT-1030: Backfill SQL-valid geometry on Delineation rows whose DelineationGeometry or DelineationGeometry4326
+-- columns fail SQL Server's STIsValid() check. Invalid rows cause GeoServer to throw SQL error 24144 when
+-- rendering WMS tiles, silently breaking the Provisional Delineations layer on the LGU map.
+EXEC dbo.pDelineationMakeValid;

--- a/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -54,4 +54,6 @@ GO
 GO
 :r ".\023 - Associate TrainingVideos with NeptuneArea modules.sql"
 GO
+:r ".\024 - MakeValid on invalid Delineation geometries.sql"
+GO
 

--- a/Neptune.Database/dbo/Procs/dbo.pDelineationMakeValid.sql
+++ b/Neptune.Database/dbo/Procs/dbo.pDelineationMakeValid.sql
@@ -1,0 +1,9 @@
+create procedure dbo.pDelineationMakeValid
+as
+begin
+
+    update dbo.Delineation set DelineationGeometry = DelineationGeometry.MakeValid() where DelineationGeometry.STIsValid() = 0
+    update dbo.Delineation set DelineationGeometry4326 = DelineationGeometry4326.MakeValid() where DelineationGeometry4326.STIsValid() = 0
+end
+
+GO

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlanParcels.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlanParcels.cs
@@ -73,7 +73,10 @@ public static class WaterQualityManagementPlanParcels
         const int toleranceInSquareMeters = 200;
         var boundaryGeometry = boundary.GeometryNative;
 
+        // Prefilter with Intersects (spatial index) before the expensive Intersection().Area check
+        // so we don't compute per-row intersections against ~1M OC parcels.
         var intersectingParcelIDs = dbContext.ParcelGeometries
+            .Where(pg => pg.GeometryNative.Intersects(boundaryGeometry))
             .Where(pg => pg.GeometryNative.Intersection(boundaryGeometry).Area > toleranceInSquareMeters)
             .Select(pg => pg.ParcelID)
             .ToList();

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-boundary/edit-boundary.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-boundary/edit-boundary.component.html
@@ -42,8 +42,13 @@
                 }
 
                 <div class="mt-3">
-                    <button class="btn btn-primary mr-2" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
-                    <button class="btn btn-secondary-outline" (click)="cancel()">Cancel</button>
+                    <button class="btn btn-primary mr-2" (click)="save()" [disabled]="isLoadingSubmit">
+                        @if (isLoadingSubmit) {
+                            <span class="fa fa-spinner loading-spinner"></span>
+                        }
+                        Save
+                    </button>
+                    <button class="btn btn-secondary-outline" (click)="cancel()" [disabled]="isLoadingSubmit">Cancel</button>
                 </div>
             </div>
 

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.html
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.html
@@ -2,9 +2,11 @@
     <span>Delineations ({{ delineationStatus }})</span>
 </ng-template>
 <ng-template #legend>
-    @if (delineationStatus === "Verified") {
-        <img src="./assets/main/map-legend-images/delineationVerified.png" style="margin-bottom: 3px" />
-    } @else {
-        <img src="./assets/main/map-legend-images/delineationProvisional.png" style="margin-bottom: 3px" />
-    }
+    <p>
+        @if (delineationStatus === "Verified") {
+            <img src="./assets/main/map-legend-images/delineationVerified.png" style="margin-bottom: 3px" />
+        } @else {
+            <img src="./assets/main/map-legend-images/delineationProvisional.png" style="margin-bottom: 3px" />
+        }
+    </p>
 </ng-template>

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.ts
@@ -28,6 +28,7 @@ export class DelineationsLayerComponent extends MapLayerBase implements OnChange
             transparent: true,
             format: "image/png",
             tiled: true,
+            styles: "delineation",
             cql_filter: cqlFilter,
             maxZoom: 22,
         } as any;


### PR DESCRIPTION
## Summary

- **LGU Delineations layers** — legend scoping (each "Delineations" header now shows only its own 3 symbology rows), Provisional layer renders again, and a backfill release script + `dbo.pDelineationMakeValid` proc to repair the 8 invalid Provisional geometries that were causing GeoServer to throw SQL `24144` on every WMS tile.
- **WQMP Edit Boundary save perf** — the parcel-rebuild query was running `.Intersection().Area > tolerance` against all ~980K OC parcels (no spatial index pruning). Adding a `.Intersects()` prefilter cuts that to a single-digit-row geometric compute. Same semantic result.
- **Save UX** — fa-spinner inside the Save button while submitting; Cancel disabled mid-save so users can't bail.

## Notes for reviewers

- `dbo.pDelineationMakeValid` is **not yet wired** into the three Delineation save paths (`DelineationController.ForTreatmentBMP`, `DelineationGeometryController.ApproveDelineationGisUpload`, `Delineations.MergeDelineations`). The release script does a one-time backfill; save-path wiring is a follow-up commit pending coworker review for testing capacity. Newly-created invalid rows after this deploy won't be auto-sanitized until that lands.
- No backend signature changes, no codegen needed.
- The legacy MVC `LoadGeneratingUnit/Index.cshtml` already uses the same dual-`<delineations-layer>` pattern with explicit `styles: "delineation"`; the Angular code now matches it.

## Test plan

- [ ] LGU page — toggle both Delineations layers; confirm each legend header shows only its own 3 palette swatches (Verified palette `#611570`/`#0000ff`/`#de54b2`, Provisional `#af25cb`/`#8ac0ff`/`#eda1d5`).
- [ ] LGU page — Provisional Delineations layer renders polygons in the Provisional palette.
- [ ] WQMP detail → Edit Boundary → modify polygon → Save: redirect to detail page with success toast; save completes substantially faster than before (especially on QA).
- [ ] Save button shows a spinner while the request is in flight; Cancel is disabled during save.
- [ ] After deploy, run `SELECT COUNT(*) FROM dbo.Delineation WHERE DelineationGeometry4326.STIsValid() = 0 OR DelineationGeometry.STIsValid() = 0;` to confirm 0 invalid rows.
- [ ] Re-verify the two WQMP items KE flagged earlier (Edit Boundary redirect + Modeling Approach modal refresh) — code already looks correct in HEAD; just needs a fresh tester pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)