### PR TITLE
NPT-1031: Fix map spin-forever by re-measuring after layout settles

### DIFF
--- a/Neptune.Web/src/app/shared/components/leaflet/neptune-map/neptune-map.component.html
+++ b/Neptune.Web/src/app/shared/components/leaflet/neptune-map/neptune-map.component.html
@@ -51,7 +51,7 @@
         [id]="mapID"
         [style.height]="mapHeight"
         [style.cursor]="cursorStyle"
-        [loadingSpinner]="{ isLoading: isAnyLayerLoading(), loadingHeight: null }">
+        [loadingSpinner]="{ isLoading: (isAnyLayerLoading$ | async) ?? false, loadingHeight: null }">
         @if (showLegend) {
             <div class="legend leaflet-control-layers leaflet-control-layers-expanded" [id]="legendID">
                 <a class="leaflet-control-layers-toggle">

--- a/Neptune.Web/src/app/shared/components/leaflet/neptune-map/neptune-map.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/neptune-map/neptune-map.component.ts
@@ -1,5 +1,4 @@
-import { AfterViewInit, Component, DestroyRef, EventEmitter, Injector, Input, OnDestroy, OnInit, Output, Signal, afterNextRender, inject, runInInjectionContext } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { AfterViewInit, Component, DestroyRef, EventEmitter, Injector, Input, OnDestroy, OnInit, Output, afterNextRender, inject, runInInjectionContext } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { Control, LeafletEvent, Map as LeafletMap, MapOptions, DomUtil, ControlPosition } from "leaflet";
 import "src/scripts/leaflet.groupedlayercontrol.js";
@@ -73,14 +72,6 @@ export class NeptuneMapComponent implements OnInit, AfterViewInit, OnDestroy {
         distinctUntilChanged(),
         shareReplay({ bufferSize: 1, refCount: true })
     );
-
-    // Zoneless Angular needs a signal here — not `async` pipe. The loading state flips from
-    // RxJS `finalize` teardown (MapLayerLoadingService.track$) and Leaflet event handlers, both
-    // of which run outside Angular's scheduler. `markForCheck` from the async pipe was not
-    // reliably triggering a CD tick, so the spinner kept animating even after state went false
-    // until a user click incidentally ran CD. Signals guarantee scheduler notification in
-    // zoneless mode.
-    public readonly isAnyLayerLoading: Signal<boolean> = toSignal(this.isAnyLayerLoading$, { initialValue: false });
 
     private readonly trackedLayerLoadingState = new Map<any, boolean>();
     private readonly trackedLayerListeners = new Map<
@@ -406,6 +397,26 @@ export class NeptuneMapComponent implements OnInit, AfterViewInit, OnDestroy {
 
         if (!this.map || !this.layerControl) {
             return;
+        }
+
+        // When <neptune-map> mounts inside a parent `@if (...$ | async)` gate (e.g. the
+        // OVTA Review-and-Finalize and Record-Observations pages, which wait on observation
+        // data before rendering the map), the container's layout often hasn't settled when
+        // L.map() ran in ngAfterViewInit — Leaflet measured 0x0, fitBounds picked the wrong
+        // zoom, and the WMS base tile layer never fired `load` because no tiles were
+        // actually fetched. The spinner counter then stayed at 1 forever. invalidateSize
+        // here (post-Angular-render, so layout is settled) makes Leaflet remeasure and
+        // re-fetch tiles for the correct viewport, which lets the `load` event fire and
+        // the spinner clear without requiring a stray user click.
+        this.map.invalidateSize(false);
+        if (this.boundingBox) {
+            this.map.fitBounds(
+                [
+                    [this.boundingBox.Bottom, this.boundingBox.Left],
+                    [this.boundingBox.Top, this.boundingBox.Right],
+                ],
+                null
+            );
         }
 
         this.hasEmittedMapLoad = true;


### PR DESCRIPTION
## Summary
- Pages that gate `<neptune-map>` behind a second `@if (...$ | async)` (Record Observations, Review and Finalize, Assessment Detail via `observations-map`) showed the spinner spinning forever until a stray click "fixed" it.
- Root cause: Leaflet measured the container at 0x0 during `ngAfterViewInit` because the parent's data-resolve `@if` had only just flipped — the browser hadn't laid out the freshly-revealed container yet. `fitBounds` picked the wrong zoom and the WMS base tile layer never fired `load` (no tiles were actually fetched), so the loading counter stayed pinned at 1. A click triggered a CD pass which re-ran the `LoadingDirective` input setter, which animated the container, which Leaflet's resize tracking finally noticed.
- Fix: call `map.invalidateSize()` + re-`fitBounds()` inside the existing `afterNextRender` callback in `emitMapLoadOnce`, just before emitting `onMapLoad`. Layout is settled by then, so Leaflet measures correctly and tiles fetch on the first render.
- Also reverts the previous round's `toSignal` binding. The app still has `zone.js` in polyfills with no zone provider, so it's zone-based — the signal indirection was harmless but unnecessary, and reverting keeps the binding simple.

## Test plan
- [ ] Open Review and Finalize on a finalized OVTA — map and tiles render on first paint, no spinner stuck. No click required.
- [ ] Open OVTA Assessment Detail — same.
- [ ] Open Record Observations on a fresh OVTA (no observations yet) — same.
- [ ] Working pages still work: Add/Remove Parcels, Treatment BMP map, WQMP boundary editor — no regression in initial framing or zoom.
- [ ] Spinner still appears briefly during slow tile fetches (not permanently suppressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)