### PR TITLE
NPT-1031: Defer track$ increment in MapLayerLoadingService

### DIFF
--- a/Neptune.Web/src/app/shared/components/leaflet/map-layer-loading.service.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/map-layer-loading.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { BehaviorSubject, Observable, distinctUntilChanged, finalize, map, shareReplay } from "rxjs";
+import { BehaviorSubject, Observable, defer, distinctUntilChanged, finalize, map, shareReplay } from "rxjs";
 
 @Injectable()
 export class MapLayerLoadingService {
@@ -11,9 +11,17 @@ export class MapLayerLoadingService {
         shareReplay({ bufferSize: 1, refCount: true })
     );
 
+    // defer ensures increment fires on subscribe, not at call-time. Layer components call
+    // track$() synchronously in ngAfterViewInit and assign the result to a field that the
+    // template then subscribes to via async pipe — incrementing eagerly meant the counter
+    // ticked up before subscription, and if the resulting CD pass was delayed (it sometimes
+    // is on prod-optimized builds), the counter sat at 1 until a stray click forced CD,
+    // pinning the map spinner indefinitely.
     public track$<T>(source$: Observable<T>): Observable<T> {
-        this.increment();
-        return source$.pipe(finalize(() => this.decrement()));
+        return defer(() => {
+            this.increment();
+            return source$.pipe(finalize(() => this.decrement()));
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
After PR #459 the spinner is driven only by \`MapLayerLoadingService.track\$()\`, but users on QA still see "spins forever until I click" on Review and Finalize / Assessment Detail / fresh-OVTA Record Observations.

Root cause: \`track\$()\` was incrementing the counter at **call-time**, not on subscribe.

\`\`\`ts
public track\$<T>(source\$: Observable<T>): Observable<T> {
    this.increment();   // ← runs immediately when track\$ is called
    return source\$.pipe(finalize(() => this.decrement()));
}
\`\`\`

Layer components (\`ovta-area-layer\`, \`transect-line-layer\`) call \`trackLayerRequest\$()\` synchronously in \`ngAfterViewInit\` and assign the result to a field. The layer's own template then subscribes via \`@if (featureCollection\$ | async)\` — but template re-evaluation with the new field reference requires another CD pass. On prod-optimized QA builds that next CD pass is sometimes delayed, leaving the counter pinned at 1 (incremented at call-time, never decremented because nothing subscribed yet). A click forces CD, async pipe finally subscribes, HTTP fires, \`finalize\` runs, decrement happens — exactly the symptom reported.

## Fix
Wrap the body in \`defer()\` so both \`increment()\` and the source subscription happen together when something subscribes, and \`decrement()\` runs via \`finalize\` on tear-down. Increment/decrement now properly paired with subscription lifecycle.

## Test plan
- [ ] Open Review and Finalize on a finalized OVTA on QA — map renders, no stuck spinner. No click required.
- [ ] Open OVTA Assessment Detail on QA — same.
- [ ] Open Record Observations on a fresh OVTA on QA — same.
- [ ] Spinner still appears briefly during real API calls (\`ovta-area-layer\`/\`transect-line-layer\` HTTP).
- [ ] No regression on Add/Remove Parcels, Treatment BMP map, WQMP boundary editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)