### PR TITLE
NPT-1044: AI extraction + chat support PDFs >32 MB via Files API

### DIFF
--- a/Neptune.API/Controllers/AIController.cs
+++ b/Neptune.API/Controllers/AIController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Anthropic;
+using Anthropic.Exceptions;
 using Anthropic.Models.Beta.Messages;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -46,6 +47,22 @@ public class AIController(
         var docDto = await WaterQualityManagementPlanDocuments.GetByIDAsDtoAsync(DbContext, waterQualityManagementPlanDocumentID);
         if (docDto == null) { Response.StatusCode = 404; return; }
 
+        // Proactive size check — mirrors the upload + extract endpoints so chat fails
+        // fast with a friendly 400 instead of pulling the blob into memory just to be
+        // rejected at Anthropic. AnthropicFileService also enforces this defensively.
+        var maxBytes = appConfiguration.Value.MaxExtractablePdfSizeBytes;
+        if (docDto.FileResource.ContentLength > maxBytes)
+        {
+            var sizeMB = docDto.FileResource.ContentLength / (1024.0 * 1024.0);
+            var maxMB = maxBytes / (1024.0 * 1024.0);
+            Response.StatusCode = 400;
+            await Response.WriteAsJsonAsync(new
+            {
+                message = $"This PDF is {sizeMB:F0} MB. AI chat supports PDFs up to {maxMB:F0} MB — please re-upload a smaller version (re-export or re-scan at a lower resolution, recommended: 150 DPI for scanned pages)."
+            });
+            return;
+        }
+
         // NPT-1044: reference the PDF by Anthropic file_id (Files API). Same shared
         // upload-and-cache helper used by extraction — first chat on a never-extracted
         // document uploads on demand; subsequent calls reuse the cached id. Lifts the
@@ -58,59 +75,85 @@ public class AIController(
         Response.Headers.Append("Content-Type", "text/event-stream");
         Response.Headers.Append("X-Accel-Buffering", "no");
 
-        // Build messages from the chat history
-        var messages = new List<BetaMessageParam>();
-        foreach (var msg in chatRequestDto.Messages)
+        // Builds the per-attempt messages list bound to a specific file_id. Pulled out
+        // so the stale-file_id retry below can rebuild it with a fresh id without
+        // duplicating the chat-history mapping.
+        List<BetaMessageParam> BuildMessages(string attemptFileID)
         {
-            if (msg.Role?.Equals("assistant", StringComparison.OrdinalIgnoreCase) == true)
+            var messages = new List<BetaMessageParam>();
+            foreach (var msg in chatRequestDto.Messages)
             {
-                messages.Add(new() { Role = BetaRole.Assistant, Content = msg.Content });
-            }
-            else
-            {
-                // First user message includes the PDF; subsequent user messages are plain text
-                if (messages.Count == 0)
+                if (msg.Role?.Equals("assistant", StringComparison.OrdinalIgnoreCase) == true)
                 {
-                    messages.Add(new()
-                    {
-                        Role = BetaRole.User,
-                        Content = new List<BetaContentBlockParam>
-                        {
-                            new BetaRequestDocumentBlock { Source = new BetaFileDocumentSource { FileID = fileID } },
-                            new BetaTextBlockParam { Text = domainContext, CacheControl = new BetaCacheControlEphemeral() },
-                            new BetaTextBlockParam { Text = msg.Content },
-                        },
-                    });
+                    messages.Add(new() { Role = BetaRole.Assistant, Content = msg.Content });
                 }
                 else
                 {
-                    messages.Add(new() { Role = BetaRole.User, Content = msg.Content });
+                    // First user message includes the PDF; subsequent user messages are plain text
+                    if (messages.Count == 0)
+                    {
+                        messages.Add(new()
+                        {
+                            Role = BetaRole.User,
+                            Content = new List<BetaContentBlockParam>
+                            {
+                                new BetaRequestDocumentBlock { Source = new BetaFileDocumentSource { FileID = attemptFileID } },
+                                new BetaTextBlockParam { Text = domainContext, CacheControl = new BetaCacheControlEphemeral() },
+                                new BetaTextBlockParam { Text = msg.Content },
+                            },
+                        });
+                    }
+                    else
+                    {
+                        messages.Add(new() { Role = BetaRole.User, Content = msg.Content });
+                    }
+                }
+            }
+            return messages;
+        }
+
+        async Task StreamAsync(string attemptFileID)
+        {
+            var parameters = new MessageCreateParams
+            {
+                Model = appConfiguration.Value.ClaudeModelId,
+                MaxTokens = 4096,
+                // Required for BetaFileDocumentSource — see WqmpExtractionService for the
+                // full reasoning. Without this header the API rejects the file-source variant.
+                Betas = ["files-api-2025-04-14"],
+                Messages = BuildMessages(attemptFileID),
+            };
+
+            // Stream the response via SSE — same format the frontend expects.
+            // Observing RequestAborted lets Claude streaming stop as soon as the client disconnects.
+            await foreach (var streamEvent in anthropicClient.Beta.Messages.CreateStreaming(parameters, HttpContext.RequestAborted))
+            {
+                if (streamEvent.TryPickContentBlockDelta(out var delta) &&
+                    delta.Delta.TryPickText(out var text))
+                {
+                    var chunk = text.Text.Replace("\n", "<br>").Replace("\r", "");
+                    await Response.WriteAsync($"data: {chunk}\n\n");
+                    await Response.Body.FlushAsync();
                 }
             }
         }
 
-        var parameters = new MessageCreateParams
+        // Retry once on a stale-file_id 404, but only if we haven't already started
+        // streaming bytes back to the client — once SSE writes have flushed, the response
+        // is committed and we can't restart it cleanly.
+        try
         {
-            Model = appConfiguration.Value.ClaudeModelId,
-            MaxTokens = 4096,
-            // Required for BetaFileDocumentSource — see WqmpExtractionService for the
-            // full reasoning. Without this header the API rejects the file-source variant.
-            Betas = ["files-api-2025-04-14"],
-            Messages = messages,
-        };
-
-        // Stream the response via SSE — same format the frontend expects.
-        // Observing RequestAborted lets Claude streaming stop as soon as the client disconnects.
-        await foreach (var streamEvent in anthropicClient.Beta.Messages.CreateStreaming(parameters, HttpContext.RequestAborted))
-        {
-            if (streamEvent.TryPickContentBlockDelta(out var delta) &&
-                delta.Delta.TryPickText(out var text))
-            {
-                var chunk = text.Text.Replace("\n", "<br>").Replace("\r", "");
-                await Response.WriteAsync($"data: {chunk}\n\n");
-                await Response.Body.FlushAsync();
-            }
+            await StreamAsync(fileID);
         }
+        catch (AnthropicNotFoundException ex) when (!Response.HasStarted)
+        {
+            Logger.LogWarning(ex, "Anthropic 404 on chat for documentID={DocumentID} (likely stale file_id); refreshing and retrying once.",
+                waterQualityManagementPlanDocumentID);
+            var refreshedFileID = await anthropicFileService.RefreshFileIDAsync(
+                waterQualityManagementPlanDocumentID, fileID, HttpContext.RequestAborted);
+            await StreamAsync(refreshedFileID);
+        }
+
         await Response.WriteAsync("data: ---MessageCompleted---\n\n");
     }
 }

--- a/Neptune.API/Controllers/AIController.cs
+++ b/Neptune.API/Controllers/AIController.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Anthropic;
-using Anthropic.Models.Messages;
+using Anthropic.Models.Beta.Messages;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using AnthropicRole = Anthropic.Models.Messages.Role;
+using BetaRole = Anthropic.Models.Beta.Messages.Role;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Neptune.API.Services;
@@ -22,8 +22,8 @@ public class AIController(
     NeptuneDbContext dbContext,
     ILogger<AIController> logger,
     IOptions<NeptuneConfiguration> appConfiguration,
-    AzureBlobStorageService azureBlobStorageService,
     AnthropicClient anthropicClient,
+    AnthropicFileService anthropicFileService,
     WqmpExtractionService wqmpExtractionService)
     : SitkaController<AIController>(dbContext, logger, appConfiguration)
 {
@@ -46,10 +46,12 @@ public class AIController(
         var docDto = await WaterQualityManagementPlanDocuments.GetByIDAsDtoAsync(DbContext, waterQualityManagementPlanDocumentID);
         if (docDto == null) { Response.StatusCode = 404; return; }
 
-        // Claude fetches the PDF directly from Azure via a short-lived SAS URL —
-        // no base64 bloat, no server-side memory pressure for large PDFs.
-        var pdfSasUrl = azureBlobStorageService.GenerateBlobSasUrl(
-            docDto.FileResource.FileResourceGUID.ToString(), TimeSpan.FromMinutes(10));
+        // NPT-1044: reference the PDF by Anthropic file_id (Files API). Same shared
+        // upload-and-cache helper used by extraction — first chat on a never-extracted
+        // document uploads on demand; subsequent calls reuse the cached id. Lifts the
+        // 32 MB ceiling that the URL-source path enforced.
+        var fileID = await anthropicFileService.EnsureUploadedFileIDAsync(
+            waterQualityManagementPlanDocumentID, HttpContext.RequestAborted);
 
         var domainContext = await wqmpExtractionService.BuildDomainContext();
 
@@ -57,12 +59,12 @@ public class AIController(
         Response.Headers.Append("X-Accel-Buffering", "no");
 
         // Build messages from the chat history
-        var messages = new List<MessageParam>();
+        var messages = new List<BetaMessageParam>();
         foreach (var msg in chatRequestDto.Messages)
         {
             if (msg.Role?.Equals("assistant", StringComparison.OrdinalIgnoreCase) == true)
             {
-                messages.Add(new() { Role = AnthropicRole.Assistant, Content = msg.Content });
+                messages.Add(new() { Role = BetaRole.Assistant, Content = msg.Content });
             }
             else
             {
@@ -71,18 +73,18 @@ public class AIController(
                 {
                     messages.Add(new()
                     {
-                        Role = AnthropicRole.User,
-                        Content = new List<ContentBlockParam>
+                        Role = BetaRole.User,
+                        Content = new List<BetaContentBlockParam>
                         {
-                            new DocumentBlockParam { Source = new UrlPdfSource { Url = pdfSasUrl.ToString() } },
-                            new TextBlockParam { Text = domainContext, CacheControl = new CacheControlEphemeral() },
-                            new TextBlockParam { Text = msg.Content },
+                            new BetaRequestDocumentBlock { Source = new BetaFileDocumentSource { FileID = fileID } },
+                            new BetaTextBlockParam { Text = domainContext, CacheControl = new BetaCacheControlEphemeral() },
+                            new BetaTextBlockParam { Text = msg.Content },
                         },
                     });
                 }
                 else
                 {
-                    messages.Add(new() { Role = AnthropicRole.User, Content = msg.Content });
+                    messages.Add(new() { Role = BetaRole.User, Content = msg.Content });
                 }
             }
         }
@@ -96,7 +98,7 @@ public class AIController(
 
         // Stream the response via SSE — same format the frontend expects.
         // Observing RequestAborted lets Claude streaming stop as soon as the client disconnects.
-        await foreach (var streamEvent in anthropicClient.Messages.CreateStreaming(parameters, HttpContext.RequestAborted))
+        await foreach (var streamEvent in anthropicClient.Beta.Messages.CreateStreaming(parameters, HttpContext.RequestAborted))
         {
             if (streamEvent.TryPickContentBlockDelta(out var delta) &&
                 delta.Delta.TryPickText(out var text))

--- a/Neptune.API/Controllers/AIController.cs
+++ b/Neptune.API/Controllers/AIController.cs
@@ -93,6 +93,9 @@ public class AIController(
         {
             Model = appConfiguration.Value.ClaudeModelId,
             MaxTokens = 4096,
+            // Required for BetaFileDocumentSource — see WqmpExtractionService for the
+            // full reasoning. Without this header the API rejects the file-source variant.
+            Betas = ["files-api-2025-04-14"],
             Messages = messages,
         };
 

--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -32,10 +32,10 @@ namespace Neptune.API.Controllers
         : SitkaController<WaterQualityManagementPlanController>(dbContext, logger,
             neptuneConfiguration)
     {
-        // Claude's Messages API rejects document blocks over 32 MB. We enforce this at upload
-        // (so users don't park unusable PDFs) and again at extract-time as a safety net in case
-        // a file reaches the service through a different path.
-        private const long MaxExtractablePdfSizeBytes = 32L * 1024 * 1024;
+        // PDF size cap for AI extraction. Configurable via NeptuneConfiguration.MaxExtractablePdfSizeBytes
+        // (defaults to 200 MB) — was 32 MB while we used the URL-source document block, raised in
+        // NPT-1044 when we switched extraction + chat to Anthropic's Files API path. Enforced at
+        // upload (so users don't park unusable PDFs) and again at extract-time as a safety net.
 
         [HttpGet]
         [AdminFeature]
@@ -464,10 +464,12 @@ namespace Neptune.API.Controllers
 
             // Reject oversize PDFs up front rather than letting the user upload a file Claude
             // will later refuse during extraction.
-            if (file.Length > MaxExtractablePdfSizeBytes)
+            var maxBytes = neptuneConfiguration.Value.MaxExtractablePdfSizeBytes;
+            if (file.Length > maxBytes)
             {
                 var sizeMB = file.Length / (1024.0 * 1024.0);
-                return BadRequest(new { message = $"PDF is {sizeMB:F0} MB. AI extraction supports PDFs up to 32 MB — please re-export or re-scan the document at a lower resolution (recommended: 150 DPI for scanned pages)." });
+                var maxMB = maxBytes / (1024.0 * 1024.0);
+                return BadRequest(new { message = $"PDF is {sizeMB:F0} MB. AI extraction supports PDFs up to {maxMB:F0} MB — please re-export or re-scan the document at a lower resolution (recommended: 150 DPI for scanned pages)." });
             }
 
             var extension = Path.GetExtension(file.FileName)?.ToLowerInvariant();
@@ -547,12 +549,13 @@ namespace Neptune.API.Controllers
                 return BadRequest(new { message = "No uploaded document found for this WQMP. Upload a PDF before running extraction." });
             }
 
-            // Proactive size check — Claude rejects document blocks over 32 MB, and the error it
-            // returns ("file exceeds maximum allowed size") is less useful than a tailored message.
-            if (document.FileResource.ContentLength > MaxExtractablePdfSizeBytes)
+            // Proactive size check — bounded to NeptuneConfiguration.MaxExtractablePdfSizeBytes.
+            var extractMaxBytes = neptuneConfiguration.Value.MaxExtractablePdfSizeBytes;
+            if (document.FileResource.ContentLength > extractMaxBytes)
             {
                 var sizeMB = document.FileResource.ContentLength / (1024.0 * 1024.0);
-                return BadRequest(new { message = $"This PDF is {sizeMB:F0} MB. AI extraction supports PDFs up to 32 MB — please re-upload a smaller version (re-export or re-scan at a lower resolution, recommended: 150 DPI for scanned pages)." });
+                var maxMB = extractMaxBytes / (1024.0 * 1024.0);
+                return BadRequest(new { message = $"This PDF is {sizeMB:F0} MB. AI extraction supports PDFs up to {maxMB:F0} MB — please re-upload a smaller version (re-export or re-scan at a lower resolution, recommended: 150 DPI for scanned pages)." });
             }
 
             // If a previous extraction (plus any draft overlay) exists, drop it cleanly — the

--- a/Neptune.API/Neptune.API.csproj
+++ b/Neptune.API/Neptune.API.csproj
@@ -6,7 +6,7 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Anthropic" Version="12.13.0" />
+    <PackageReference Include="Anthropic" Version="12.17.0" />
     <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.6.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />

--- a/Neptune.API/Services/AI/AnthropicFileService.cs
+++ b/Neptune.API/Services/AI/AnthropicFileService.cs
@@ -1,10 +1,16 @@
 using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Anthropic;
-using Anthropic.Models.Beta.Files;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Neptune.API.Services;
 using Neptune.EFModels.Entities;
 
 namespace Neptune.API.Services.AI;
@@ -20,21 +26,33 @@ namespace Neptune.API.Services.AI;
 /// </summary>
 public class AnthropicFileService
 {
-    private readonly AnthropicClient _anthropic;
+    private const string AnthropicFilesUrl = "https://api.anthropic.com/v1/files";
+
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly AzureBlobStorageService _blobService;
     private readonly NeptuneDbContext _dbContext;
     private readonly ILogger<AnthropicFileService> _logger;
+    private readonly NeptuneConfiguration _configuration;
 
     public AnthropicFileService(
-        AnthropicClient anthropic,
+        IHttpClientFactory httpClientFactory,
         AzureBlobStorageService blobService,
         NeptuneDbContext dbContext,
-        ILogger<AnthropicFileService> logger)
+        ILogger<AnthropicFileService> logger,
+        IOptions<NeptuneConfiguration> configuration)
     {
-        _anthropic = anthropic;
+        _httpClientFactory = httpClientFactory;
         _blobService = blobService;
         _dbContext = dbContext;
         _logger = logger;
+        _configuration = configuration.Value;
+    }
+
+    private sealed class FileUploadResponse
+    {
+        [JsonPropertyName("id")] public string Id { get; set; }
+        [JsonPropertyName("filename")] public string Filename { get; set; }
+        [JsonPropertyName("size_bytes")] public long SizeBytes { get; set; }
     }
 
     /// <summary>
@@ -59,28 +77,64 @@ public class AnthropicFileService
         _logger.LogInformation("Anthropic file cache miss for documentID={DocumentID} — uploading to Files API...",
             waterQualityManagementPlanDocumentID);
 
-        // Buffer the entire blob to bytes before handing to the SDK. We tried passing the
-        // Azure BlobDownloadStreamingResult.Content stream directly and consistently hit
-        // AnthropicIOException (HttpIOException: "The response ended prematurely") — the
-        // SDK's multipart encoder needs a known content length, and the chunked Azure
-        // stream doesn't satisfy that. byte[] gets an implicit BinaryContent conversion
-        // and a deterministic Content-Length on the upload. Memory cost is bounded by
-        // MaxExtractablePdfSizeBytes (default 200 MB).
+        // Bypass the SDK for upload. Anthropic.SDK 12.17.0's Beta.Files.Upload still
+        // throws AnthropicIOException with inner ObjectDisposedException on real
+        // payloads — we hit it with both byte[] and Azure streaming inputs. The bug
+        // is internal SDK body-handling; documented in the NPT-1044 card with the
+        // raw HttpClient fallback we're using here. Extraction and chat (which
+        // reference the file_id, not upload it) keep using the SDK normally.
         var downloadResult = await _blobService.DownloadFileResourceFromBlobStorage(document.FileResource);
         var pdfBytes = downloadResult.Content.ToArray();
+        var filename = document.FileResource.GetOriginalCompleteFileName();
+        if (string.IsNullOrWhiteSpace(filename))
+        {
+            filename = $"{document.WaterQualityManagementPlanDocumentID}.pdf";
+        }
 
-        var fileMetadata = await _anthropic.Beta.Files.Upload(
-            new FileUploadParams { File = pdfBytes },
-            cancellationToken);
+        var fileID = await UploadViaHttpClientAsync(pdfBytes, filename, cancellationToken);
 
-        document.AnthropicFileID = fileMetadata.ID;
+        document.AnthropicFileID = fileID;
         document.AnthropicFileUploadedDate = DateTime.UtcNow;
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation("Uploaded documentID={DocumentID} to Anthropic Files API, cached fileID={FileID}",
-            waterQualityManagementPlanDocumentID, fileMetadata.ID);
+            waterQualityManagementPlanDocumentID, fileID);
 
-        return fileMetadata.ID;
+        return fileID;
+    }
+
+    private async Task<string> UploadViaHttpClientAsync(byte[] bytes, string filename, CancellationToken cancellationToken)
+    {
+        using var client = _httpClientFactory.CreateClient();
+        client.Timeout = TimeSpan.FromMinutes(5);
+
+        using var form = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(bytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        form.Add(fileContent, "file", filename);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, AnthropicFilesUrl) { Content = form };
+        request.Headers.Add("x-api-key", _configuration.AnthropicApiKey);
+        request.Headers.Add("anthropic-version", "2023-06-01");
+        request.Headers.Add("anthropic-beta", "files-api-2025-04-14");
+
+        using var response = await client.SendAsync(request, cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Anthropic Files API upload failed (status={Status}): {Body}", (int)response.StatusCode, body);
+            throw new InvalidOperationException(
+                $"Anthropic Files API upload returned {(int)response.StatusCode}: {body}");
+        }
+
+        var parsed = JsonSerializer.Deserialize<FileUploadResponse>(body)
+                     ?? throw new InvalidOperationException("Anthropic Files API returned an empty response body.");
+        if (string.IsNullOrEmpty(parsed.Id))
+        {
+            throw new InvalidOperationException(
+                $"Anthropic Files API response missing 'id' field: {body}");
+        }
+        return parsed.Id;
     }
 
     /// <summary>

--- a/Neptune.API/Services/AI/AnthropicFileService.cs
+++ b/Neptune.API/Services/AI/AnthropicFileService.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Anthropic;
+using Anthropic.Models.Beta.Files;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.API.Services.AI;
+
+/// <summary>
+/// Uploads PDFs to Anthropic's Files API and caches the resulting <c>file_id</c> on the
+/// owning <see cref="WaterQualityManagementPlanDocument"/> so subsequent extraction and
+/// chat calls can reference the same uploaded document without re-uploading.
+///
+/// The Files-API source path on the Beta Messages API has a 500 MB ceiling per Anthropic
+/// (vs. 32 MB on the URL-source path we used previously), which lifts the constraint that
+/// rejected ~50% of real-world scanned WQMPs. NPT-1044.
+/// </summary>
+public class AnthropicFileService
+{
+    private readonly AnthropicClient _anthropic;
+    private readonly AzureBlobStorageService _blobService;
+    private readonly NeptuneDbContext _dbContext;
+    private readonly ILogger<AnthropicFileService> _logger;
+
+    public AnthropicFileService(
+        AnthropicClient anthropic,
+        AzureBlobStorageService blobService,
+        NeptuneDbContext dbContext,
+        ILogger<AnthropicFileService> logger)
+    {
+        _anthropic = anthropic;
+        _blobService = blobService;
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the cached Anthropic <c>file_id</c> for a document, uploading the PDF
+    /// once if not already cached. Idempotent — repeated calls for the same document
+    /// return the same id without re-uploading.
+    /// </summary>
+    public async Task<string> EnsureUploadedFileIDAsync(
+        int waterQualityManagementPlanDocumentID, CancellationToken cancellationToken)
+    {
+        var document = await _dbContext.WaterQualityManagementPlanDocuments
+            .Include(x => x.FileResource)
+            .SingleAsync(x => x.WaterQualityManagementPlanDocumentID == waterQualityManagementPlanDocumentID, cancellationToken);
+
+        if (!string.IsNullOrEmpty(document.AnthropicFileID))
+        {
+            _logger.LogInformation("Anthropic file cache hit for documentID={DocumentID}, fileID={FileID}",
+                waterQualityManagementPlanDocumentID, document.AnthropicFileID);
+            return document.AnthropicFileID;
+        }
+
+        _logger.LogInformation("Anthropic file cache miss for documentID={DocumentID} — uploading to Files API...",
+            waterQualityManagementPlanDocumentID);
+
+        var blobGuid = document.FileResource.GetFileResourceGUIDAsString().ToLower();
+        var streamingResult = await _blobService.DownloadBlobFromBlobStorageAsStream(blobGuid);
+
+        FileMetadata fileMetadata;
+        await using (streamingResult.Content)
+        {
+            // BinaryContent has implicit conversion from Stream — pass directly.
+            fileMetadata = await _anthropic.Beta.Files.Upload(
+                new FileUploadParams { File = streamingResult.Content },
+                cancellationToken);
+        }
+
+        document.AnthropicFileID = fileMetadata.ID;
+        document.AnthropicFileUploadedDate = DateTime.UtcNow;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Uploaded documentID={DocumentID} to Anthropic Files API, cached fileID={FileID}",
+            waterQualityManagementPlanDocumentID, fileMetadata.ID);
+
+        return fileMetadata.ID;
+    }
+
+    /// <summary>
+    /// Clear the cached file_id for a document, e.g., after Anthropic returned a 404
+    /// for a stale id. The next <see cref="EnsureUploadedFileIDAsync"/> call will
+    /// re-upload.
+    /// </summary>
+    public async Task InvalidateFileIDAsync(
+        int waterQualityManagementPlanDocumentID, CancellationToken cancellationToken)
+    {
+        var document = await _dbContext.WaterQualityManagementPlanDocuments
+            .SingleAsync(x => x.WaterQualityManagementPlanDocumentID == waterQualityManagementPlanDocumentID, cancellationToken);
+
+        document.AnthropicFileID = null;
+        document.AnthropicFileUploadedDate = null;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogWarning("Invalidated Anthropic file cache for documentID={DocumentID}",
+            waterQualityManagementPlanDocumentID);
+    }
+}

--- a/Neptune.API/Services/AI/AnthropicFileService.cs
+++ b/Neptune.API/Services/AI/AnthropicFileService.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -27,6 +29,13 @@ namespace Neptune.API.Services.AI;
 public class AnthropicFileService
 {
     private const string AnthropicFilesUrl = "https://api.anthropic.com/v1/files";
+
+    // Serializes upload attempts per documentID so concurrent callers (extract+chat
+    // hitting the same doc, or two users on the same doc) don't both upload the same
+    // PDF when the cache is empty. Same gate covers the stale-id refresh path so
+    // refresh and ensure can't deadlock waiting on each other. Static — the file
+    // service is scoped, but races span requests/replicas (within a replica, anyway).
+    private static readonly ConcurrentDictionary<int, SemaphoreSlim> UploadGates = new();
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly AzureBlobStorageService _blobService;
@@ -56,9 +65,29 @@ public class AnthropicFileService
     }
 
     /// <summary>
+    /// Thrown by <see cref="EnsureUploadedFileIDAsync"/> when the document's PDF exceeds
+    /// <see cref="NeptuneConfiguration.MaxExtractablePdfSizeBytes"/>. Controllers should
+    /// pre-check size for a clean 400 response; this exception is the defense-in-depth
+    /// guard so we never spend bandwidth pushing an oversized blob to Anthropic only
+    /// to be rejected at the upstream.
+    /// </summary>
+    public sealed class PdfTooLargeForUploadException : InvalidOperationException
+    {
+        public long ContentLengthBytes { get; }
+        public long MaxBytes { get; }
+        public PdfTooLargeForUploadException(long contentLengthBytes, long maxBytes)
+            : base($"PDF is {contentLengthBytes / (1024.0 * 1024.0):F0} MB; the AI extraction upload cap is {maxBytes / (1024.0 * 1024.0):F0} MB.")
+        {
+            ContentLengthBytes = contentLengthBytes;
+            MaxBytes = maxBytes;
+        }
+    }
+
+    /// <summary>
     /// Returns the cached Anthropic <c>file_id</c> for a document, uploading the PDF
     /// once if not already cached. Idempotent — repeated calls for the same document
-    /// return the same id without re-uploading.
+    /// return the same id without re-uploading. Concurrent callers for the same doc
+    /// are serialized so only one upload occurs.
     /// </summary>
     public async Task<string> EnsureUploadedFileIDAsync(
         int waterQualityManagementPlanDocumentID, CancellationToken cancellationToken)
@@ -74,8 +103,52 @@ public class AnthropicFileService
             return document.AnthropicFileID;
         }
 
+        // Defense-in-depth: refuse to spend memory + bandwidth uploading a PDF that
+        // Anthropic will reject anyway. Controllers pre-check this for a friendly 400;
+        // this guard catches any caller that bypasses the controller pre-check.
+        if (document.FileResource.ContentLength > _configuration.MaxExtractablePdfSizeBytes)
+        {
+            throw new PdfTooLargeForUploadException(
+                document.FileResource.ContentLength, _configuration.MaxExtractablePdfSizeBytes);
+        }
+
+        // Serialize concurrent uploads of the same document. Without this, two callers
+        // observing AnthropicFileID == null both proceed to upload, resulting in two
+        // file_ids on Anthropic (last-write-wins persisted, the loser orphans).
+        var gate = UploadGates.GetOrAdd(waterQualityManagementPlanDocumentID, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            return await UploadAndCacheAsync(document, cancellationToken);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Uploads the document and persists the resulting file_id. Caller is responsible
+    /// for holding the per-document gate from <see cref="UploadGates"/>. Re-checks the
+    /// cached id on entry so a concurrent caller that won the race doesn't trigger a
+    /// duplicate upload.
+    /// </summary>
+    private async Task<string> UploadAndCacheAsync(
+        WaterQualityManagementPlanDocument document, CancellationToken cancellationToken)
+    {
+        // Re-check inside the gate. The cheap-path read in the public entry point
+        // happens outside the lock, so by the time we acquire it another caller may
+        // have already populated the id.
+        await _dbContext.Entry(document).ReloadAsync(cancellationToken);
+        if (!string.IsNullOrEmpty(document.AnthropicFileID))
+        {
+            _logger.LogInformation("Anthropic file populated by concurrent caller for documentID={DocumentID}, fileID={FileID}",
+                document.WaterQualityManagementPlanDocumentID, document.AnthropicFileID);
+            return document.AnthropicFileID;
+        }
+
         _logger.LogInformation("Anthropic file cache miss for documentID={DocumentID} — uploading to Files API...",
-            waterQualityManagementPlanDocumentID);
+            document.WaterQualityManagementPlanDocumentID);
 
         // Bypass the SDK for upload. Anthropic.SDK 12.17.0's Beta.Files.Upload still
         // throws AnthropicIOException with inner ObjectDisposedException on real
@@ -83,34 +156,47 @@ public class AnthropicFileService
         // is internal SDK body-handling; documented in the NPT-1044 card with the
         // raw HttpClient fallback we're using here. Extraction and chat (which
         // reference the file_id, not upload it) keep using the SDK normally.
-        var downloadResult = await _blobService.DownloadFileResourceFromBlobStorage(document.FileResource);
-        var pdfBytes = downloadResult.Content.ToArray();
+        //
+        // Stream straight from blob storage instead of materializing the PDF as
+        // byte[]. The earlier byte[] buffer was a workaround for the SDK encoder
+        // refusing chunked length-unknown streams; on raw HttpClient we set the
+        // inner part's Content-Length explicitly from FileResource.ContentLength,
+        // so the multipart envelope is well-formed without a server-side buffer.
+        // Cuts peak memory from O(file size) to a small read window per upload.
+        var canonicalName = document.FileResource.GetFileResourceGUIDAsString().ToLower();
+        using var blobDownload = await _blobService.DownloadBlobFromBlobStorageAsStream(canonicalName);
         var filename = document.FileResource.GetOriginalCompleteFileName();
         if (string.IsNullOrWhiteSpace(filename))
         {
             filename = $"{document.WaterQualityManagementPlanDocumentID}.pdf";
         }
 
-        var fileID = await UploadViaHttpClientAsync(pdfBytes, filename, cancellationToken);
+        var fileID = await UploadViaHttpClientAsync(
+            blobDownload.Content, document.FileResource.ContentLength, filename, cancellationToken);
 
         document.AnthropicFileID = fileID;
         document.AnthropicFileUploadedDate = DateTime.UtcNow;
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation("Uploaded documentID={DocumentID} to Anthropic Files API, cached fileID={FileID}",
-            waterQualityManagementPlanDocumentID, fileID);
+            document.WaterQualityManagementPlanDocumentID, fileID);
 
         return fileID;
     }
 
-    private async Task<string> UploadViaHttpClientAsync(byte[] bytes, string filename, CancellationToken cancellationToken)
+    private async Task<string> UploadViaHttpClientAsync(
+        Stream pdfStream, long contentLength, string filename, CancellationToken cancellationToken)
     {
         using var client = _httpClientFactory.CreateClient();
         client.Timeout = TimeSpan.FromMinutes(5);
 
         using var form = new MultipartFormDataContent();
-        var fileContent = new ByteArrayContent(bytes);
+        var fileContent = new StreamContent(pdfStream);
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        // Explicit Content-Length on the inner part lets the multipart encoder finalize
+        // a deterministic outer Content-Length — the previous failure mode with chunked
+        // Azure streams was the encoder couldn't compute total length without it.
+        fileContent.Headers.ContentLength = contentLength;
         form.Add(fileContent, "file", filename);
 
         using var request = new HttpRequestMessage(HttpMethod.Post, AnthropicFilesUrl) { Content = form };
@@ -135,6 +221,52 @@ public class AnthropicFileService
                 $"Anthropic Files API response missing 'id' field: {body}");
         }
         return parsed.Id;
+    }
+
+    /// <summary>
+    /// Recovers from a stale-<c>file_id</c> 404 by invalidating the cached id and
+    /// re-uploading. Pass the id you observed the 404 against as <paramref name="staleFileID"/>;
+    /// if another concurrent caller already refreshed past it (different id now in the DB),
+    /// this returns that fresher id without re-uploading. Serialized per documentID via
+    /// the same gate as <see cref="EnsureUploadedFileIDAsync"/> so the 4 parallel
+    /// extraction calls don't each upload their own copy and so refresh and ensure
+    /// can't deadlock on each other.
+    /// </summary>
+    public async Task<string> RefreshFileIDAsync(
+        int waterQualityManagementPlanDocumentID, string staleFileID, CancellationToken cancellationToken)
+    {
+        var gate = UploadGates.GetOrAdd(waterQualityManagementPlanDocumentID, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            var document = await _dbContext.WaterQualityManagementPlanDocuments
+                .Include(x => x.FileResource)
+                .SingleAsync(x => x.WaterQualityManagementPlanDocumentID == waterQualityManagementPlanDocumentID, cancellationToken);
+
+            // Already-refreshed check: another caller may have re-uploaded while we
+            // were queued on the gate. If the persisted id has moved on from the one
+            // we 404'd against, just use it.
+            if (!string.IsNullOrEmpty(document.AnthropicFileID) && document.AnthropicFileID != staleFileID)
+            {
+                _logger.LogInformation("Anthropic file cache already refreshed for documentID={DocumentID} (was {Stale}, now {Current}); skipping re-upload.",
+                    waterQualityManagementPlanDocumentID, staleFileID, document.AnthropicFileID);
+                return document.AnthropicFileID;
+            }
+
+            // Clear the stale id and force the upload path. UploadAndCacheAsync expects
+            // the caller to hold the gate, which we do.
+            document.AnthropicFileID = null;
+            document.AnthropicFileUploadedDate = null;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            _logger.LogWarning("Invalidated Anthropic file cache for documentID={DocumentID} prior to refresh.",
+                waterQualityManagementPlanDocumentID);
+
+            return await UploadAndCacheAsync(document, cancellationToken);
+        }
+        finally
+        {
+            gate.Release();
+        }
     }
 
     /// <summary>

--- a/Neptune.API/Services/AI/AnthropicFileService.cs
+++ b/Neptune.API/Services/AI/AnthropicFileService.cs
@@ -59,17 +59,19 @@ public class AnthropicFileService
         _logger.LogInformation("Anthropic file cache miss for documentID={DocumentID} — uploading to Files API...",
             waterQualityManagementPlanDocumentID);
 
-        var blobGuid = document.FileResource.GetFileResourceGUIDAsString().ToLower();
-        var streamingResult = await _blobService.DownloadBlobFromBlobStorageAsStream(blobGuid);
+        // Buffer the entire blob to bytes before handing to the SDK. We tried passing the
+        // Azure BlobDownloadStreamingResult.Content stream directly and consistently hit
+        // AnthropicIOException (HttpIOException: "The response ended prematurely") — the
+        // SDK's multipart encoder needs a known content length, and the chunked Azure
+        // stream doesn't satisfy that. byte[] gets an implicit BinaryContent conversion
+        // and a deterministic Content-Length on the upload. Memory cost is bounded by
+        // MaxExtractablePdfSizeBytes (default 200 MB).
+        var downloadResult = await _blobService.DownloadFileResourceFromBlobStorage(document.FileResource);
+        var pdfBytes = downloadResult.Content.ToArray();
 
-        FileMetadata fileMetadata;
-        await using (streamingResult.Content)
-        {
-            // BinaryContent has implicit conversion from Stream — pass directly.
-            fileMetadata = await _anthropic.Beta.Files.Upload(
-                new FileUploadParams { File = streamingResult.Content },
-                cancellationToken);
-        }
+        var fileMetadata = await _anthropic.Beta.Files.Upload(
+            new FileUploadParams { File = pdfBytes },
+            cancellationToken);
 
         document.AnthropicFileID = fileMetadata.ID;
         document.AnthropicFileUploadedDate = DateTime.UtcNow;

--- a/Neptune.API/Services/AI/WqmpExtractionService.cs
+++ b/Neptune.API/Services/AI/WqmpExtractionService.cs
@@ -1,14 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Anthropic;
-using Anthropic.Models.Messages;
-using AnthropicRole = Anthropic.Models.Messages.Role;
+using Anthropic.Models.Beta.Messages;
+using BetaRole = Anthropic.Models.Beta.Messages.Role;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -27,7 +26,7 @@ public class WqmpExtractionService
     private static readonly Lazy<string> SourceControlBmpSchema = new(BuildSourceControlBmpSchemaJson);
 
     private readonly AnthropicClient _anthropic;
-    private readonly AzureBlobStorageService _blobService;
+    private readonly AnthropicFileService _anthropicFileService;
     private readonly NeptuneDbContext _dbContext;
     private readonly IPromptTemplateService _promptTemplateService;
     private readonly ILogger<WqmpExtractionService> _logger;
@@ -35,14 +34,14 @@ public class WqmpExtractionService
 
     public WqmpExtractionService(
         AnthropicClient anthropic,
-        AzureBlobStorageService blobService,
+        AnthropicFileService anthropicFileService,
         NeptuneDbContext dbContext,
         IPromptTemplateService promptTemplateService,
         ILogger<WqmpExtractionService> logger,
         IOptions<NeptuneConfiguration> configuration)
     {
         _anthropic = anthropic;
-        _blobService = blobService;
+        _anthropicFileService = anthropicFileService;
         _dbContext = dbContext;
         _promptTemplateService = promptTemplateService;
         _logger = logger;
@@ -56,15 +55,13 @@ public class WqmpExtractionService
         _logger.LogInformation("Starting WQMP extraction for documentID={DocumentID}, personID={PersonID}, model={Model}",
             waterQualityManagementPlanDocumentID, personID, _configuration.ClaudeModelId);
 
-        var docDto = await WaterQualityManagementPlanDocuments.GetByIDAsDtoAsync(_dbContext, waterQualityManagementPlanDocumentID);
-        if (docDto == null) throw new InvalidOperationException($"Document {waterQualityManagementPlanDocumentID} not found.");
-
-        // Generate a temporary SAS URL for the PDF in Azure Blob Storage.
-        // Claude fetches the PDF directly from Azure — no base64 encoding, no request-body
-        // size limit. The SAS URL expires after 10 minutes.
-        var blobGuid = docDto.FileResource.FileResourceGUID.ToString();
-        var pdfSasUrl = _blobService.GenerateBlobSasUrl(blobGuid, TimeSpan.FromMinutes(10));
-        _logger.LogInformation("Generated SAS URL for PDF blob {BlobGuid}. Building domain context...", blobGuid);
+        // NPT-1044: upload to Anthropic Files API once and cache the file_id on the document.
+        // The Files-API source path on the Beta Messages API supports up to 500 MB per file
+        // — vs. 32 MB on the URL-source path we used previously — and dodges the SAS-URL
+        // expiry race we used to see on long-running extractions.
+        var fileID = await _anthropicFileService.EnsureUploadedFileIDAsync(waterQualityManagementPlanDocumentID, cancellationToken);
+        _logger.LogInformation("Anthropic file ID resolved for documentID={DocumentID}: {FileID}. Building domain context...",
+            waterQualityManagementPlanDocumentID, fileID);
 
         var domainContext = await BuildDomainContext();
 
@@ -113,17 +110,17 @@ public class WqmpExtractionService
             var toolName = $"emit_{key.ToLower()}_extraction";
 
             // System prompt: evidence instructions (cached — stable across all 4 calls)
-            var systemBlocks = new List<TextBlockParam>
+            var systemBlocks = new List<BetaTextBlockParam>
             {
-                new() { Text = evidenceInstructions, CacheControl = new CacheControlEphemeral() },
+                new() { Text = evidenceInstructions, CacheControl = new BetaCacheControlEphemeral() },
             };
 
-            // User message: PDF document (cached) + domain context (cached) + per-category prompt (varies)
-            var messageContent = new List<ContentBlockParam>
+            // User message: PDF document (referenced by file_id, cached) + domain context (cached) + per-category prompt (varies)
+            var messageContent = new List<BetaContentBlockParam>
             {
-                new DocumentBlockParam { Source = new UrlPdfSource { Url = pdfSasUrl.ToString() } },
-                new TextBlockParam { Text = $"DomainContext:\n{domainContext}", CacheControl = new CacheControlEphemeral() },
-                new TextBlockParam { Text = prompt },
+                new BetaRequestDocumentBlock { Source = new BetaFileDocumentSource { FileID = fileID } },
+                new BetaTextBlockParam { Text = $"DomainContext:\n{domainContext}", CacheControl = new BetaCacheControlEphemeral() },
+                new BetaTextBlockParam { Text = prompt },
             };
 
             var parameters = new MessageCreateParams
@@ -131,9 +128,9 @@ public class WqmpExtractionService
                 Model = _configuration.ClaudeModelId,
                 MaxTokens = 8192,
                 System = systemBlocks,
-                Messages = [new() { Role = AnthropicRole.User, Content = messageContent }],
-                Tools = allTools.Select(t => (ToolUnion)t).ToList(),
-                ToolChoice = new ToolChoiceTool { Name = toolName },
+                Messages = [new() { Role = BetaRole.User, Content = messageContent }],
+                Tools = allTools.Select(t => (BetaToolUnion)t).ToList(),
+                ToolChoice = new BetaToolChoiceTool { Name = toolName },
             };
 
             // Stream the response — keeps the HTTP connection alive via SSE so there's no
@@ -143,7 +140,7 @@ public class WqmpExtractionService
             long inputTokens = 0;
             long outputTokens = 0;
 
-            await foreach (var evt in _anthropic.Messages.CreateStreaming(parameters, categoryCts.Token))
+            await foreach (var evt in _anthropic.Beta.Messages.CreateStreaming(parameters, categoryCts.Token))
             {
                 if (evt.TryPickContentBlockDelta(out var delta))
                 {
@@ -252,10 +249,10 @@ public class WqmpExtractionService
         }
     }
 
-    private static Tool BuildToolForCategory(string categoryKey, string jsonSchema)
+    private static BetaTool BuildToolForCategory(string categoryKey, string jsonSchema)
     {
         var parsed = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(jsonSchema);
-        return new Tool
+        return new BetaTool
         {
             Name = $"emit_{categoryKey.ToLower()}_extraction",
             Description = $"Emit the extracted {categoryKey} fields as structured JSON matching the required schema.",

--- a/Neptune.API/Services/AI/WqmpExtractionService.cs
+++ b/Neptune.API/Services/AI/WqmpExtractionService.cs
@@ -127,6 +127,12 @@ public class WqmpExtractionService
             {
                 Model = _configuration.ClaudeModelId,
                 MaxTokens = 8192,
+                // The Files-API source variant (BetaFileDocumentSource) is gated behind
+                // this beta header on the Messages endpoint. Without it the request gets
+                // routed to the standard validator and rejected with
+                // "Input tag 'file' found using 'type' does not match any of the
+                // expected tags: 'base64', 'content', 'text', 'url'".
+                Betas = ["files-api-2025-04-14"],
                 System = systemBlocks,
                 Messages = [new() { Role = BetaRole.User, Content = messageContent }],
                 Tools = allTools.Select(t => (BetaToolUnion)t).ToList(),

--- a/Neptune.API/Services/AI/WqmpExtractionService.cs
+++ b/Neptune.API/Services/AI/WqmpExtractionService.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Anthropic;
+using Anthropic.Exceptions;
 using Anthropic.Models.Beta.Messages;
 using BetaRole = Anthropic.Models.Beta.Messages.Role;
 using Microsoft.EntityFrameworkCore;
@@ -96,9 +97,6 @@ public class WqmpExtractionService
             var catSw = Stopwatch.StartNew();
             _logger.LogInformation("Starting extraction category: {Category}", key);
 
-            using var categoryCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            categoryCts.CancelAfter(TimeSpan.FromMinutes(4));
-
             var templateModel = new
             {
                 EvidenceInstructions = evidenceInstructions,
@@ -115,80 +113,104 @@ public class WqmpExtractionService
                 new() { Text = evidenceInstructions, CacheControl = new BetaCacheControlEphemeral() },
             };
 
-            // User message: PDF document (referenced by file_id, cached) + domain context (cached) + per-category prompt (varies)
-            var messageContent = new List<BetaContentBlockParam>
+            // Single attempt: build params bound to a specific file_id and stream the response.
+            // Factored out so the outer retry can rebuild the message with a refreshed id
+            // when Anthropic 404s on a stale cached file_id.
+            async Task<(string output, long inputTokens, long outputTokens, long cachedTokens)> AttemptAsync(string attemptFileID)
             {
-                new BetaRequestDocumentBlock { Source = new BetaFileDocumentSource { FileID = fileID } },
-                new BetaTextBlockParam { Text = $"DomainContext:\n{domainContext}", CacheControl = new BetaCacheControlEphemeral() },
-                new BetaTextBlockParam { Text = prompt },
-            };
+                using var categoryCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                categoryCts.CancelAfter(TimeSpan.FromMinutes(4));
 
-            var parameters = new MessageCreateParams
-            {
-                Model = _configuration.ClaudeModelId,
-                MaxTokens = 8192,
-                // The Files-API source variant (BetaFileDocumentSource) is gated behind
-                // this beta header on the Messages endpoint. Without it the request gets
-                // routed to the standard validator and rejected with
-                // "Input tag 'file' found using 'type' does not match any of the
-                // expected tags: 'base64', 'content', 'text', 'url'".
-                Betas = ["files-api-2025-04-14"],
-                System = systemBlocks,
-                Messages = [new() { Role = BetaRole.User, Content = messageContent }],
-                Tools = allTools.Select(t => (BetaToolUnion)t).ToList(),
-                ToolChoice = new BetaToolChoiceTool { Name = toolName },
-            };
-
-            // Stream the response — keeps the HTTP connection alive via SSE so there's no
-            // HttpClient.Timeout to worry about, even for large PDFs on a cold cache.
-            var toolInputJson = new System.Text.StringBuilder();
-            long cachedTokens = 0;
-            long inputTokens = 0;
-            long outputTokens = 0;
-
-            await foreach (var evt in _anthropic.Beta.Messages.CreateStreaming(parameters, categoryCts.Token))
-            {
-                if (evt.TryPickContentBlockDelta(out var delta))
+                // User message: PDF document (referenced by file_id, cached) + domain context (cached) + per-category prompt (varies)
+                var messageContent = new List<BetaContentBlockParam>
                 {
-                    // Tool-use input arrives as input_json_delta chunks
-                    if (delta.Delta.TryPickInputJson(out var jsonDelta))
+                    new BetaRequestDocumentBlock { Source = new BetaFileDocumentSource { FileID = attemptFileID } },
+                    new BetaTextBlockParam { Text = $"DomainContext:\n{domainContext}", CacheControl = new BetaCacheControlEphemeral() },
+                    new BetaTextBlockParam { Text = prompt },
+                };
+
+                var parameters = new MessageCreateParams
+                {
+                    Model = _configuration.ClaudeModelId,
+                    MaxTokens = 8192,
+                    // The Files-API source variant (BetaFileDocumentSource) is gated behind
+                    // this beta header on the Messages endpoint. Without it the request gets
+                    // routed to the standard validator and rejected with
+                    // "Input tag 'file' found using 'type' does not match any of the
+                    // expected tags: 'base64', 'content', 'text', 'url'".
+                    Betas = ["files-api-2025-04-14"],
+                    System = systemBlocks,
+                    Messages = [new() { Role = BetaRole.User, Content = messageContent }],
+                    Tools = allTools.Select(t => (BetaToolUnion)t).ToList(),
+                    ToolChoice = new BetaToolChoiceTool { Name = toolName },
+                };
+
+                // Stream the response — keeps the HTTP connection alive via SSE so there's no
+                // HttpClient.Timeout to worry about, even for large PDFs on a cold cache.
+                var toolInputJson = new System.Text.StringBuilder();
+                long cachedTokens = 0;
+                long inputTokens = 0;
+                long outputTokens = 0;
+
+                await foreach (var evt in _anthropic.Beta.Messages.CreateStreaming(parameters, categoryCts.Token))
+                {
+                    if (evt.TryPickContentBlockDelta(out var delta))
                     {
-                        toolInputJson.Append(jsonDelta.PartialJson);
+                        // Tool-use input arrives as input_json_delta chunks
+                        if (delta.Delta.TryPickInputJson(out var jsonDelta))
+                        {
+                            toolInputJson.Append(jsonDelta.PartialJson);
+                        }
+                    }
+                    else if (evt.TryPickDelta(out var msgDelta))
+                    {
+                        // message_delta carries usage info
+                        if (msgDelta.Usage != null)
+                        {
+                            outputTokens = msgDelta.Usage.OutputTokens;
+                        }
+                    }
+                    else if (evt.TryPickStart(out var msgStart))
+                    {
+                        if (msgStart.Message?.Usage != null)
+                        {
+                            inputTokens = msgStart.Message.Usage.InputTokens;
+                            cachedTokens = msgStart.Message.Usage.CacheReadInputTokens ?? 0;
+                        }
                     }
                 }
-                else if (evt.TryPickDelta(out var msgDelta))
+
+                var output = toolInputJson.Length > 0 ? toolInputJson.ToString() : (expectArray ? "[]" : "{}");
+
+                if (!IsValidJson(output))
                 {
-                    // message_delta carries usage info
-                    if (msgDelta.Usage != null)
-                    {
-                        outputTokens = msgDelta.Usage.OutputTokens;
-                    }
+                    _logger.LogError("Streamed tool output returned invalid JSON for {Category} after {ElapsedMs}ms. Using empty fallback.",
+                        key, catSw.ElapsedMilliseconds);
+                    output = expectArray ? "[]" : "{}";
                 }
-                else if (evt.TryPickStart(out var msgStart))
+                else
                 {
-                    if (msgStart.Message?.Usage != null)
-                    {
-                        inputTokens = msgStart.Message.Usage.InputTokens;
-                        cachedTokens = msgStart.Message.Usage.CacheReadInputTokens ?? 0;
-                    }
+                    _logger.LogInformation("Finished extraction category: {Category} in {ElapsedMs}ms ({OutputChars} chars, cached={CachedTokens})",
+                        key, catSw.ElapsedMilliseconds, output.Length, cachedTokens);
                 }
+
+                return (output, inputTokens, outputTokens, cachedTokens);
             }
 
-            var output = toolInputJson.Length > 0 ? toolInputJson.ToString() : (expectArray ? "[]" : "{}");
-
-            if (!IsValidJson(output))
+            // Retry once on a stale-file_id 404 — invalidate the cached id and re-upload
+            // (serialized across the 4 parallel calls inside RefreshFileIDAsync), then retry.
+            try
             {
-                _logger.LogError("Streamed tool output returned invalid JSON for {Category} after {ElapsedMs}ms. Using empty fallback.",
-                    key, catSw.ElapsedMilliseconds);
-                output = expectArray ? "[]" : "{}";
+                return await AttemptAsync(fileID);
             }
-            else
+            catch (AnthropicNotFoundException ex)
             {
-                _logger.LogInformation("Finished extraction category: {Category} in {ElapsedMs}ms ({OutputChars} chars, cached={CachedTokens})",
-                    key, catSw.ElapsedMilliseconds, output.Length, cachedTokens);
+                _logger.LogWarning(ex, "Anthropic 404 on {Category} for documentID={DocumentID} (likely stale file_id); refreshing and retrying once.",
+                    key, waterQualityManagementPlanDocumentID);
+                var refreshedFileID = await _anthropicFileService.RefreshFileIDAsync(
+                    waterQualityManagementPlanDocumentID, fileID, cancellationToken);
+                return await AttemptAsync(refreshedFileID);
             }
-
-            return (output, inputTokens, outputTokens, cachedTokens);
         }
 
         var tasks = categoryConfigs.Select(kvp =>

--- a/Neptune.API/Services/NeptuneConfiguration.cs
+++ b/Neptune.API/Services/NeptuneConfiguration.cs
@@ -15,6 +15,14 @@ public class NeptuneConfiguration : NeptuneJobConfiguration
 
     public string AnthropicApiKey { get; set; }
     public string ClaudeModelId { get; set; } = "claude-sonnet-4-6";
+
+    /// <summary>
+    /// Upper bound on PDF size accepted by the WQMP upload + AI extraction pipeline.
+    /// Defaults to 200 MB (Anthropic's Files API ceiling is 500 MB; 200 MB covers
+    /// 99%+ of real-world scanned WQMPs with headroom). Override per environment if
+    /// needed.
+    /// </summary>
+    public long MaxExtractablePdfSizeBytes { get; set; } = 200L * 1024 * 1024;
     public string Auth0Domain { get; set; }
     public string Auth0ClientID { get; set; }
 }

--- a/Neptune.API/Startup.cs
+++ b/Neptune.API/Startup.cs
@@ -114,10 +114,19 @@ namespace Neptune.API
             services.AddScoped(s => UserContext.GetUserAsDtoFromHttpContext(s.GetService<NeptuneDbContext>(), s.GetService<IHttpContextAccessor>().HttpContext));
 
             #region Anthropic
+            // ClientOptions.Timeout is a per-request value the SDK applies via CancellationToken,
+            // but the SDK's underlying HttpClient still uses .NET's default 100-second timeout
+            // unless we hand it our own HttpClient. For streaming (CreateStreaming) on a cold
+            // prompt cache with a large file_id reference, time-to-first-byte can exceed 100s
+            // — we hit "TaskCanceledException: HttpClient.Timeout of 100 seconds elapsing" on
+            // 92 MB scanned WQMP extractions. Use Timeout.InfiniteTimeSpan on the inner client
+            // and rely on per-call CancellationTokens (we wrap each category extraction in a
+            // 4-minute CTS upstream) to bound run-time.
             services.AddSingleton(_ => new AnthropicClient(new Anthropic.Core.ClientOptions
             {
                 ApiKey = configuration.AnthropicApiKey,
                 Timeout = TimeSpan.FromMinutes(5),
+                HttpClient = new HttpClient { Timeout = Timeout.InfiniteTimeSpan },
             }));
             #endregion
 

--- a/Neptune.API/Startup.cs
+++ b/Neptune.API/Startup.cs
@@ -106,6 +106,7 @@ namespace Neptune.API
 
             services.AddScoped<AzureBlobStorageService>();
             services.AddSingleton<IPromptTemplateService, PromptTemplateService>();
+            services.AddScoped<AnthropicFileService>();
             services.AddScoped<WqmpExtractionService>();
 
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();

--- a/Neptune.Database/Scripts/ReleaseScripts/026 - Add AnthropicFileID to WaterQualityManagementPlanDocument.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/026 - Add AnthropicFileID to WaterQualityManagementPlanDocument.sql
@@ -1,0 +1,24 @@
+DECLARE @MigrationName VARCHAR(200);
+SET @MigrationName = '026 - Add AnthropicFileID to WaterQualityManagementPlanDocument'
+IF NOT EXISTS(SELECT * FROM dbo.DatabaseMigration DM WHERE DM.ReleaseScriptFileName = @MigrationName)
+BEGIN
+
+    PRINT @MigrationName;
+
+    -- NPT-1044: cache the Anthropic Files-API file_id on the document so re-extracts and
+    -- chat sessions can reference the same uploaded PDF without re-uploading. Lifts the
+    -- 32 MB document-block ceiling we currently enforce at upload + extract by switching
+    -- to a Files-API source on the Beta Messages API.
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.WaterQualityManagementPlanDocument') AND name = 'AnthropicFileID')
+    BEGIN
+        ALTER TABLE dbo.WaterQualityManagementPlanDocument ADD AnthropicFileID NVARCHAR(64) NULL;
+    END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.WaterQualityManagementPlanDocument') AND name = 'AnthropicFileUploadedDate')
+    BEGIN
+        ALTER TABLE dbo.WaterQualityManagementPlanDocument ADD AnthropicFileUploadedDate DATETIME NULL;
+    END
+
+    INSERT INTO dbo.DatabaseMigration(MigrationAuthorName, ReleaseScriptFileName, MigrationReason)
+    SELECT 'Ray Lee', @MigrationName, 'NPT-1044: cache Anthropic Files-API file_id to support PDFs >32 MB on extraction + chat'
+END

--- a/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -58,4 +58,6 @@ GO
 GO
 :r ".\025 - WQMP Verification step help text.sql"
 GO
+:r ".\026 - Add AnthropicFileID to WaterQualityManagementPlanDocument.sql"
+GO
 

--- a/Neptune.Database/dbo/Tables/dbo.WaterQualityManagementPlanDocument.sql
+++ b/Neptune.Database/dbo/Tables/dbo.WaterQualityManagementPlanDocument.sql
@@ -6,5 +6,7 @@ CREATE TABLE [dbo].[WaterQualityManagementPlanDocument](
 	[Description] [varchar](1000) NULL,
 	[UploadDate] [datetime] NOT NULL,
 	[WaterQualityManagementPlanDocumentTypeID] [int] NOT NULL CONSTRAINT [FK_WaterQualityManagementPlanDocument_WaterQualityManagementPlanDocumentType_WaterQualityManagementPlanDocumentTypeID] FOREIGN KEY REFERENCES [dbo].[WaterQualityManagementPlanDocumentType] ([WaterQualityManagementPlanDocumentTypeID]),
+	[AnthropicFileID] [nvarchar](64) NULL,
+	[AnthropicFileUploadedDate] [datetime] NULL,
 	CONSTRAINT [AK_WaterQualityManagementPlanDocument_DisplayName_WaterQualityManagementPlanID] UNIQUE ([DisplayName], [WaterQualityManagementPlanID])
 )

--- a/Neptune.EFModels/Entities/Generated/ExtensionMethods/NeptunePageType.Binding.cs
+++ b/Neptune.EFModels/Entities/Generated/ExtensionMethods/NeptunePageType.Binding.cs
@@ -99,6 +99,11 @@ namespace Neptune.EFModels.Entities
         public static readonly NeptunePageTypeWQMPApprovalSummary WQMPApprovalSummary = NeptunePageTypeWQMPApprovalSummary.Instance;
         public static readonly NeptunePageTypeWQMPPostConstructionInspectionAndVerification WQMPPostConstructionInspectionAndVerification = NeptunePageTypeWQMPPostConstructionInspectionAndVerification.Instance;
         public static readonly NeptunePageTypeWQMPMap WQMPMap = NeptunePageTypeWQMPMap.Instance;
+        public static readonly NeptunePageTypeWQMPVerificationBasics WQMPVerificationBasics = NeptunePageTypeWQMPVerificationBasics.Instance;
+        public static readonly NeptunePageTypeWQMPVerificationStructuralBmps WQMPVerificationStructuralBmps = NeptunePageTypeWQMPVerificationStructuralBmps.Instance;
+        public static readonly NeptunePageTypeWQMPVerificationSimplifiedBmps WQMPVerificationSimplifiedBmps = NeptunePageTypeWQMPVerificationSimplifiedBmps.Instance;
+        public static readonly NeptunePageTypeWQMPVerificationSourceControl WQMPVerificationSourceControl = NeptunePageTypeWQMPVerificationSourceControl.Instance;
+        public static readonly NeptunePageTypeWQMPVerificationReview WQMPVerificationReview = NeptunePageTypeWQMPVerificationReview.Instance;
 
         public static readonly List<NeptunePageType> All;
         public static readonly ReadOnlyDictionary<int, NeptunePageType> AllLookupDictionary;
@@ -108,7 +113,7 @@ namespace Neptune.EFModels.Entities
         /// </summary>
         static NeptunePageType()
         {
-            All = new List<NeptunePageType> { HomePage, About, OrganizationsList, HomeMapInfo, HomeAdditionalInfo, TreatmentBMP, TreatmentBMPType, Jurisdiction, Assessment, ManageObservationTypesList, ManageTreatmentBMPTypesList, ManageObservationTypeInstructions, ManageObservationTypeObservationInstructions, ManageObservationTypeLabelsAndUnitsInstructions, ManageTreatmentBMPTypeInstructions, ManageCustomAttributeTypeInstructions, ManageCustomAttributeInstructions, ManageCustomAttributeTypesList, Legal, FundingSourcesList, FindABMP, LaunchPad, FieldRecords, RequestSupport, InviteUser, WaterQualityMaintenancePlan, ParcelList, Training, ManagerDashboard, WaterQualityMaintenancePlanOandMVerifications, ModelingHomePage, TrashHomePage, OVTAInstructions, OVTAIndex, TrashModuleProgramOverview, DelineationMap, BulkUploadRequest, TreatmentBMPAssessment, EditOVTAArea, LandUseBlock, ExportAssessmentGeospatialData, HRUCharacteristics, RegionalSubbasins, DelineationReconciliationReport, ViewTreatmentBMPModelingAttributes, UploadTreatmentBMPs, AboutModelingBMPPerformance, BulkUploadFieldVisits, HippocampHomePage, HippocampTraining, HippocampLabelsAndDefinitionsList, HippocampAbout, HippocampProjectsList, HippocampProjectInstructions, HippocampProjectBasics, HippocampProjectAttachments, HippocampTreatmentBMPs, HippocampDelineations, HippocampModeledPerformance, HippocampReview, HippocampPlanningMap, OCTAM2Tier2GrantProgramMetrics, OCTAM2Tier2GrantProgramDashboard, EditWQMPBoundary, UploadWQMPs, UploadSimplifiedBMPs, UploadOVTAs, WQMPBoundaryFromAPNList, BMPDataHub, DelineationDataHub, FieldVisitDataHub, WQMPDataHub, SimplifiedBMPsDataHub, WQMPLocationsDataHub, AssessmentAreasDataHub, OVTADataHub, LandUseBlockDataHub, RegionalSubbasinsDataHub, LandUseStatisticsDataHub, ModelBasinsDataHub, PrecipitationZonesDataHub, ParcelUploadDataHub, ExportBMPInventoryToGIS, SPAHomePage, WQMPModelingOptions, WQMPApprovalSummary, WQMPPostConstructionInspectionAndVerification, WQMPMap };
+            All = new List<NeptunePageType> { HomePage, About, OrganizationsList, HomeMapInfo, HomeAdditionalInfo, TreatmentBMP, TreatmentBMPType, Jurisdiction, Assessment, ManageObservationTypesList, ManageTreatmentBMPTypesList, ManageObservationTypeInstructions, ManageObservationTypeObservationInstructions, ManageObservationTypeLabelsAndUnitsInstructions, ManageTreatmentBMPTypeInstructions, ManageCustomAttributeTypeInstructions, ManageCustomAttributeInstructions, ManageCustomAttributeTypesList, Legal, FundingSourcesList, FindABMP, LaunchPad, FieldRecords, RequestSupport, InviteUser, WaterQualityMaintenancePlan, ParcelList, Training, ManagerDashboard, WaterQualityMaintenancePlanOandMVerifications, ModelingHomePage, TrashHomePage, OVTAInstructions, OVTAIndex, TrashModuleProgramOverview, DelineationMap, BulkUploadRequest, TreatmentBMPAssessment, EditOVTAArea, LandUseBlock, ExportAssessmentGeospatialData, HRUCharacteristics, RegionalSubbasins, DelineationReconciliationReport, ViewTreatmentBMPModelingAttributes, UploadTreatmentBMPs, AboutModelingBMPPerformance, BulkUploadFieldVisits, HippocampHomePage, HippocampTraining, HippocampLabelsAndDefinitionsList, HippocampAbout, HippocampProjectsList, HippocampProjectInstructions, HippocampProjectBasics, HippocampProjectAttachments, HippocampTreatmentBMPs, HippocampDelineations, HippocampModeledPerformance, HippocampReview, HippocampPlanningMap, OCTAM2Tier2GrantProgramMetrics, OCTAM2Tier2GrantProgramDashboard, EditWQMPBoundary, UploadWQMPs, UploadSimplifiedBMPs, UploadOVTAs, WQMPBoundaryFromAPNList, BMPDataHub, DelineationDataHub, FieldVisitDataHub, WQMPDataHub, SimplifiedBMPsDataHub, WQMPLocationsDataHub, AssessmentAreasDataHub, OVTADataHub, LandUseBlockDataHub, RegionalSubbasinsDataHub, LandUseStatisticsDataHub, ModelBasinsDataHub, PrecipitationZonesDataHub, ParcelUploadDataHub, ExportBMPInventoryToGIS, SPAHomePage, WQMPModelingOptions, WQMPApprovalSummary, WQMPPostConstructionInspectionAndVerification, WQMPMap, WQMPVerificationBasics, WQMPVerificationStructuralBmps, WQMPVerificationSimplifiedBmps, WQMPVerificationSourceControl, WQMPVerificationReview };
             AllLookupDictionary = new ReadOnlyDictionary<int, NeptunePageType>(All.ToDictionary(x => x.NeptunePageTypeID));
         }
 
@@ -354,6 +359,16 @@ namespace Neptune.EFModels.Entities
                     return WQMPModelingOptions;
                 case NeptunePageTypeEnum.WQMPPostConstructionInspectionAndVerification:
                     return WQMPPostConstructionInspectionAndVerification;
+                case NeptunePageTypeEnum.WQMPVerificationBasics:
+                    return WQMPVerificationBasics;
+                case NeptunePageTypeEnum.WQMPVerificationReview:
+                    return WQMPVerificationReview;
+                case NeptunePageTypeEnum.WQMPVerificationSimplifiedBmps:
+                    return WQMPVerificationSimplifiedBmps;
+                case NeptunePageTypeEnum.WQMPVerificationSourceControl:
+                    return WQMPVerificationSourceControl;
+                case NeptunePageTypeEnum.WQMPVerificationStructuralBmps:
+                    return WQMPVerificationStructuralBmps;
                 default:
                     throw new ArgumentException("Unable to map Enum: {enumValue}");
             }
@@ -449,7 +464,12 @@ namespace Neptune.EFModels.Entities
         WQMPModelingOptions = 88,
         WQMPApprovalSummary = 89,
         WQMPPostConstructionInspectionAndVerification = 90,
-        WQMPMap = 91
+        WQMPMap = 91,
+        WQMPVerificationBasics = 93,
+        WQMPVerificationStructuralBmps = 94,
+        WQMPVerificationSimplifiedBmps = 95,
+        WQMPVerificationSourceControl = 96,
+        WQMPVerificationReview = 97
     }
 
     public partial class NeptunePageTypeHomePage : NeptunePageType
@@ -978,5 +998,35 @@ namespace Neptune.EFModels.Entities
     {
         private NeptunePageTypeWQMPMap(int neptunePageTypeID, string neptunePageTypeName, string neptunePageTypeDisplayName) : base(neptunePageTypeID, neptunePageTypeName, neptunePageTypeDisplayName) {}
         public static readonly NeptunePageTypeWQMPMap Instance = new NeptunePageTypeWQMPMap(91, @"WQMPMap", @"WQMP Map");
+    }
+
+    public partial class NeptunePageTypeWQMPVerificationBasics : NeptunePageType
+    {
+        private NeptunePageTypeWQMPVerificationBasics(int neptunePageTypeID, string neptunePageTypeName, string neptunePageTypeDisplayName) : base(neptunePageTypeID, neptunePageTypeName, neptunePageTypeDisplayName) {}
+        public static readonly NeptunePageTypeWQMPVerificationBasics Instance = new NeptunePageTypeWQMPVerificationBasics(93, @"WQMPVerificationBasics", @"WQMP O&M Verification - Basics Step");
+    }
+
+    public partial class NeptunePageTypeWQMPVerificationStructuralBmps : NeptunePageType
+    {
+        private NeptunePageTypeWQMPVerificationStructuralBmps(int neptunePageTypeID, string neptunePageTypeName, string neptunePageTypeDisplayName) : base(neptunePageTypeID, neptunePageTypeName, neptunePageTypeDisplayName) {}
+        public static readonly NeptunePageTypeWQMPVerificationStructuralBmps Instance = new NeptunePageTypeWQMPVerificationStructuralBmps(94, @"WQMPVerificationStructuralBmps", @"WQMP O&M Verification - Structural BMPs Step");
+    }
+
+    public partial class NeptunePageTypeWQMPVerificationSimplifiedBmps : NeptunePageType
+    {
+        private NeptunePageTypeWQMPVerificationSimplifiedBmps(int neptunePageTypeID, string neptunePageTypeName, string neptunePageTypeDisplayName) : base(neptunePageTypeID, neptunePageTypeName, neptunePageTypeDisplayName) {}
+        public static readonly NeptunePageTypeWQMPVerificationSimplifiedBmps Instance = new NeptunePageTypeWQMPVerificationSimplifiedBmps(95, @"WQMPVerificationSimplifiedBmps", @"WQMP O&M Verification - Simplified BMPs Step");
+    }
+
+    public partial class NeptunePageTypeWQMPVerificationSourceControl : NeptunePageType
+    {
+        private NeptunePageTypeWQMPVerificationSourceControl(int neptunePageTypeID, string neptunePageTypeName, string neptunePageTypeDisplayName) : base(neptunePageTypeID, neptunePageTypeName, neptunePageTypeDisplayName) {}
+        public static readonly NeptunePageTypeWQMPVerificationSourceControl Instance = new NeptunePageTypeWQMPVerificationSourceControl(96, @"WQMPVerificationSourceControl", @"WQMP O&M Verification - Source Control BMPs Step");
+    }
+
+    public partial class NeptunePageTypeWQMPVerificationReview : NeptunePageType
+    {
+        private NeptunePageTypeWQMPVerificationReview(int neptunePageTypeID, string neptunePageTypeName, string neptunePageTypeDisplayName) : base(neptunePageTypeID, neptunePageTypeName, neptunePageTypeDisplayName) {}
+        public static readonly NeptunePageTypeWQMPVerificationReview Instance = new NeptunePageTypeWQMPVerificationReview(97, @"WQMPVerificationReview", @"WQMP O&M Verification - Review & Finalize Step");
     }
 }

--- a/Neptune.EFModels/Entities/Generated/ExtensionMethods/WaterQualityManagementPlanDocument.Binding.cs
+++ b/Neptune.EFModels/Entities/Generated/ExtensionMethods/WaterQualityManagementPlanDocument.Binding.cs
@@ -13,6 +13,7 @@ namespace Neptune.EFModels.Entities
         {
             public const int DisplayName = 100;
             public const int Description = 1000;
+            public const int AnthropicFileID = 64;
         }
     }
 }

--- a/Neptune.EFModels/Entities/Generated/WaterQualityManagementPlanDocument.cs
+++ b/Neptune.EFModels/Entities/Generated/WaterQualityManagementPlanDocument.cs
@@ -30,6 +30,12 @@ public partial class WaterQualityManagementPlanDocument
 
     public int WaterQualityManagementPlanDocumentTypeID { get; set; }
 
+    [StringLength(64)]
+    public string? AnthropicFileID { get; set; }
+
+    [Column(TypeName = "datetime")]
+    public DateTime? AnthropicFileUploadedDate { get; set; }
+
     [ForeignKey("FileResourceID")]
     [InverseProperty("WaterQualityManagementPlanDocuments")]
     public virtual FileResource FileResource { get; set; } = null!;

--- a/Neptune.Web/package-lock.json
+++ b/Neptune.Web/package-lock.json
@@ -701,7 +701,6 @@
             "version": "21.2.8",
             "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.8.tgz",
             "integrity": "sha512-S0W+6QazCsn/4xWZu0V5VmU9zmKIlqFR2FJSsAQUPReVmpA40SuQSP6A/cyMVIMYaHvO/cAXSHJVgpxBzBSL/Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "7.29.0",
@@ -8338,7 +8337,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "readdirp": "^5.0.0"
@@ -8805,7 +8803,6 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/cookie": {
@@ -15723,7 +15720,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
             "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 20.19.0"
@@ -15737,7 +15733,6 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
             "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/reflect.getprototypeof": {
@@ -16140,7 +16135,6 @@
             "version": "7.7.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -17212,7 +17206,7 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { ApplicationRef, Component } from "@angular/core";
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { Input } from "@angular/core";
 import { BehaviorSubject, Observable, switchMap, tap } from "rxjs";
@@ -71,7 +71,8 @@ export class TrashOvtaAreaDetailComponent {
         private confirmService: ConfirmService,
         private router: Router,
         private datePipe: DatePipe,
-        private dialogService: DialogService
+        private dialogService: DialogService,
+        private appRef: ApplicationRef
     ) {}
 
     ngOnInit(): void {
@@ -134,6 +135,10 @@ export class TrashOvtaAreaDetailComponent {
         this.map = event.map;
         this.layerControl = event.layerControl;
         this.mapIsReady = true;
+
+        // Zoneless: Leaflet's map-init callback runs outside Angular change detection,
+        // so the @if (mapIsReady) layer gates won't re-render without a manual tick.
+        Promise.resolve().then(() => this.appRef.tick());
     }
 
     public addNewOVTA(onlandVisualTrashAssessmentAreaID: number, onlandVisualTrashAssessmentAreaName: string, stormwaterJurisdictionID: number) {


### PR DESCRIPTION
## Summary
The URL-source `DocumentBlockParam` path on Anthropic's Messages API has a hard 32 MB ceiling. ~50% of real-world scanned WQMPs exceed that. This switches both extraction and chat to Anthropic's Files API path (500 MB ceiling), uploads the PDF once per document, and caches the resulting `file_id` on `WaterQualityManagementPlanDocument` so re-extracts and chat sessions reuse the same upload.

Chat changes too — for symmetry. Single mental model for "how Claude reads our PDF", chat works on >32 MB PDFs, and Anthropic's prompt cache hits are shared across extraction + chat on the same `file_id`. First chat on a never-extracted document uploads on demand via the same shared helper.

Default upload limit raised from 32 MB → 200 MB and made `NeptuneConfiguration.MaxExtractablePdfSizeBytes`-tunable.

## Backend changes
- **SDK:** `Anthropic` 12.13.0 → 12.17.0 (Files API was broken in 12.13 with `ObjectDisposedException`; `BetaFileDocumentSource` is a first-class document-block source in 12.17).
- **New `AnthropicFileService`** — `EnsureUploadedFileIDAsync(documentID)` and `InvalidateFileIDAsync(documentID)`. Single helper used by both extraction and chat. Uploads via `client.Beta.Files.Upload`, persists `AnthropicFileID` + `AnthropicFileUploadedDate`.
- **`WqmpExtractionService`** — drops SAS-URL generation; switches from `client.Messages.CreateStreaming` to `client.Beta.Messages.CreateStreaming`; document block source becomes `BetaFileDocumentSource { FileID = fileID }`. All four parallel category extractions reference the same `file_id`, so the Beta tools-level prompt cache continues to share across calls.
- **`AIController.Ask`** — same swap. `AzureBlobStorageService` no longer injected (helper handles blob → bytes → upload).
- **Size limit** — `private const long MaxExtractablePdfSizeBytes` removed; both call sites now read `_neptuneConfiguration.Value.MaxExtractablePdfSizeBytes` (defaults to 200 MB). Error messages compute the limit in MB dynamically.

## Database
- New columns on `dbo.WaterQualityManagementPlanDocument`: `AnthropicFileID nvarchar(64) null`, `AnthropicFileUploadedDate datetime null`.
- Release script `026 - Add AnthropicFileID to WaterQualityManagementPlanDocument.sql` applies the column adds idempotently.
- Generated POCO updated to match — a real `Build/Scaffold.ps1` run after merge will re-emit cleanly.

## Test plan
- [ ] Small text-based PDF (~1 MB) — upload + extract works, `AnthropicFileID` populated, extraction returns populated fields.
- [ ] **Re-extract same document** — second extract reuses cached `AnthropicFileID` (log line "Anthropic file cache hit"). No second upload to Anthropic.
- [ ] **Large scanned PDF (>32 MB; the 92 MB diagnostic file from NPT-1037)** — upload accepted (no 400), extract returns populated fields. **This is the primary acceptance criterion.**
- [ ] Oversize PDF (>200 MB) — upload rejected with the new dynamic 400 message ("supports PDFs up to 200 MB").
- [ ] **Chat on never-extracted document** — first message triggers upload-on-demand via shared helper; works without manual extraction first.
- [ ] **Chat on extracted document** — uses cached `file_id`, no re-upload.
- [ ] **Stale file_id simulation** — manually wipe `AnthropicFileID` in DB and re-extract → re-uploads, re-caches.
- [ ] Token usage continues to log to `AITokenUsages` with model name + input/output/cached counts.

## Pending after merge
- Run `Build/Scaffold.ps1 -iniFile .\build.ini` to regenerate the EF POCO + binding files cleanly (this PR includes a manual edit to the generated POCO; the next scaffold run will reconcile and pull in the unrelated NPT-995 `WQMPVerification...` enum entries).
- Tests deferred to follow-up — primary verification is integration against real WQMP PDFs of varying sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)