### PR TITLE
Fix OVTA Return to Edit — transect line now updates after observation…

### DIFF
--- a/Neptune.API/Controllers/OnlandVisualTrashAssessmentController.cs
+++ b/Neptune.API/Controllers/OnlandVisualTrashAssessmentController.cs
@@ -183,20 +183,6 @@ public class OnlandVisualTrashAssessmentController(
             OnlandVisualTrashAssessments.CalculateProgressScore(onlandVisualTrashAssessments)?
                 .OnlandVisualTrashAssessmentScoreID;
 
-        if (onlandVisualTrashAssessment.IsTransectBackingAssessment)
-        {
-            onlandVisualTrashAssessment.IsTransectBackingAssessment = false;
-            onlandVisualTrashAssessmentArea.TransectLine = null;
-            onlandVisualTrashAssessmentArea.TransectLine4326 = null;
-
-            await DbContext.SaveChangesAsync();
-
-            var transectLine = OnlandVisualTrashAssessmentAreas.RecomputeTransectLine(onlandVisualTrashAssessments);
-            onlandVisualTrashAssessmentArea.TransectLine = transectLine;
-            onlandVisualTrashAssessmentArea.TransectLine4326 = transectLine.ProjectTo4326();
-
-        }
-
         await DbContext.SaveChangesAsync();
         return Ok();
     }


### PR DESCRIPTION
… edits

The Return to Edit path was clearing IsTransectBackingAssessment to false before saving, so the subsequent observation save in OnlandVisualTrashAssessmentObservations.Update always skipped the transect recompute (isBacking = false, wasNeverSet = false). The transect stayed frozen at the geometry from the first finalization.

Fix: stop clearing IsTransectBackingAssessment in EditStatusToAllowEdit. The flag stays true, so when the user saves observations the recompute guard fires and the area's TransectLine reflects the edited points. The re-finalize path in OnlandVisualTrashAssessments.Update also checks the same flag and recomputes again on finalize.

  Body:
  ## Summary
  - `EditStatusToAllowEdit` was clearing `IsTransectBackingAssessment = false` on save, so the observation save path in
  `OnlandVisualTrashAssessmentObservations.Update` always skipped the transect recompute (`isBacking = false`,
  `wasNeverSet = false`)
  - The transect stayed frozen at the geometry from the original finalization regardless of edits
  - Fix: stop clearing `IsTransectBackingAssessment` in the Return to Edit path — the flag stays `true` so the
  observation save guard fires correctly

  ## Test plan
  - [ ] Finalize an OVTA (first assessment for an area) — verify transect line appears
  - [ ] Return to Edit, move/add/remove observation points, save — verify transect line updates to reflect new positions
  - [ ] Re-finalize — verify transect line reflects final observation positions
  - [ ] Verify repeat (non-backing) assessments on the same area do NOT alter the transect