### PR TITLE
NPT-995: Round 3 rework — wizard styling, Begin CTA, grid Delete, det…

### DIFF
--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-detail/verification-detail.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-detail/verification-detail.component.html
@@ -1,17 +1,18 @@
-@if (verification$ | async; as verification) {
-    <page-header pageTitle="O&M Verification" [templateAbove]="templateAbove" [templateRight]="templateRight">
+@if (pageData$ | async; as data) {
+    <page-header [pageTitle]="data.wqmp.WaterQualityManagementPlanName" [templateAbove]="templateAbove" [templateRight]="templateRight">
         <ng-template #templateAbove>
             <div class="back">
                 <a [routerLink]="['/water-quality-management-plans', waterQualityManagementPlanID]" class="back__link">Back to WQMP</a>
             </div>
         </ng-template>
         <ng-template #templateRight>
-            @if (currentPersonCanEdit && verification.IsDraft) {
-                <a class="btn btn-primary" [routerLink]="['/water-quality-management-plans', waterQualityManagementPlanID, 'verifications', verification.WaterQualityManagementPlanVerifyID]">
+            @if (currentPersonCanEdit && data.verification.IsDraft) {
+                <a class="btn btn-primary" [routerLink]="['/water-quality-management-plans', waterQualityManagementPlanID, 'verifications', data.verification.WaterQualityManagementPlanVerifyID]">
                     Edit
                 </a>
             }
         </ng-template>
+        <em class="verification-status">O&amp;M Verification — {{ data.verification.IsDraft ? "Draft" : "Finalized" }}</em>
     </page-header>
 
     <app-alert-display></app-alert-display>
@@ -20,40 +21,39 @@
         <div class="card g-col-12">
             <div class="card-header">
                 <span class="card-title">Verification Basics</span>
-                <span class="card-tag">{{ verification.IsDraft ? "Draft" : "Finalized" }}</span>
             </div>
             <div class="card-body">
                 <dl class="grid-12">
                     <dt class="g-col-4">Verification Date</dt>
-                    <dd class="g-col-8">{{ verification.VerificationDate | date: "MM/dd/yyyy" }}</dd>
+                    <dd class="g-col-8">{{ data.verification.VerificationDate | date: "MM/dd/yyyy" }}</dd>
 
                     <dt class="g-col-4">Verification Type</dt>
-                    <dd class="g-col-8">{{ verification.WaterQualityManagementPlanVerifyTypeDisplayName }}</dd>
+                    <dd class="g-col-8">{{ data.verification.WaterQualityManagementPlanVerifyTypeDisplayName }}</dd>
 
                     <dt class="g-col-4">Visit Status</dt>
-                    <dd class="g-col-8">{{ verification.WaterQualityManagementPlanVisitStatusDisplayName }}</dd>
+                    <dd class="g-col-8">{{ data.verification.WaterQualityManagementPlanVisitStatusDisplayName }}</dd>
 
                     <dt class="g-col-4">Verification Status</dt>
-                    <dd class="g-col-8">{{ verification.WaterQualityManagementPlanVerifyStatusDisplayName ?? "—" }}</dd>
+                    <dd class="g-col-8">{{ data.verification.WaterQualityManagementPlanVerifyStatusDisplayName ?? "—" }}</dd>
 
                     <dt class="g-col-4">Source Control Condition</dt>
-                    <dd class="g-col-8">{{ verification.SourceControlCondition || "—" }}</dd>
+                    <dd class="g-col-8">{{ data.verification.SourceControlCondition || "—" }}</dd>
 
                     <dt class="g-col-4">Enforcement / Follow-up Actions</dt>
-                    <dd class="g-col-8">{{ verification.EnforcementOrFollowupActions || "—" }}</dd>
+                    <dd class="g-col-8">{{ data.verification.EnforcementOrFollowupActions || "—" }}</dd>
 
                     <dt class="g-col-4">Last Edited</dt>
-                    <dd class="g-col-8">{{ verification.LastEditedDate | date: "MM/dd/yyyy" }} by {{ verification.LastEditedByPersonFullName }}</dd>
+                    <dd class="g-col-8">{{ data.verification.LastEditedDate | date: "MM/dd/yyyy" }} by {{ data.verification.LastEditedByPersonFullName }}</dd>
                 </dl>
             </div>
         </div>
 
         <div class="card g-col-12 mt-3">
             <div class="card-header">
-                <span class="card-title">Structural BMPs ({{ verification.TreatmentBMPs?.length ?? 0 }})</span>
+                <span class="card-title">Structural BMPs ({{ data.verification.TreatmentBMPs?.length ?? 0 }})</span>
             </div>
             <div class="card-body">
-                @if (verification.TreatmentBMPs?.length) {
+                @if (data.verification.TreatmentBMPs?.length) {
                     <table class="table table-condensed">
                         <thead>
                             <tr>
@@ -64,7 +64,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @for (bmp of verification.TreatmentBMPs; track bmp.WaterQualityManagementPlanVerifyTreatmentBMPID) {
+                            @for (bmp of data.verification.TreatmentBMPs; track bmp.WaterQualityManagementPlanVerifyTreatmentBMPID) {
                                 <tr>
                                     <td>{{ bmp.TreatmentBMPName }}</td>
                                     <td>{{ bmp.TreatmentBMPType }}</td>
@@ -82,10 +82,10 @@
 
         <div class="card g-col-12 mt-3">
             <div class="card-header">
-                <span class="card-title">Simplified BMPs ({{ verification.QuickBMPs?.length ?? 0 }})</span>
+                <span class="card-title">Simplified BMPs ({{ data.verification.QuickBMPs?.length ?? 0 }})</span>
             </div>
             <div class="card-body">
-                @if (verification.QuickBMPs?.length) {
+                @if (data.verification.QuickBMPs?.length) {
                     <table class="table table-condensed">
                         <thead>
                             <tr>
@@ -96,7 +96,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @for (bmp of verification.QuickBMPs; track bmp.WaterQualityManagementPlanVerifyQuickBMPID) {
+                            @for (bmp of data.verification.QuickBMPs; track bmp.WaterQualityManagementPlanVerifyQuickBMPID) {
                                 <tr>
                                     <td>{{ bmp.QuickBMPName }}</td>
                                     <td>{{ bmp.TreatmentBMPType }}</td>
@@ -117,8 +117,8 @@
                 <span class="card-title">Source Control BMPs</span>
             </div>
             <div class="card-body">
-                @if (verification.SourceControlBMPs?.length) {
-                    @for (group of groupSourceControlsByCategory(verification.SourceControlBMPs); track group.category) {
+                @if (data.verification.SourceControlBMPs?.length) {
+                    @for (group of groupSourceControlsByCategory(data.verification.SourceControlBMPs); track group.category) {
                         <div class="source-control-group">
                             <h4>{{ group.category }}</h4>
                             <dl class="grid-12">

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-detail/verification-detail.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-detail/verification-detail.component.scss
@@ -1,10 +1,13 @@
 @use "/src/scss/abstracts" as *;
 
-.card-tag {
-    margin-left: auto;
-    font-size: $type-size-200;
-    font-weight: 500;
-    text-transform: uppercase;
+// NPT-995 rework: italic subtitle under the page title showing
+// O&M Verification — Draft / Finalized. Replaces the card-tag pill that
+// previously sat in the panel header alongside "Verification Basics".
+.verification-status {
+    display: block;
+    color: $gray-600;
+    font-size: $type-size-300;
+    margin-top: 0.15rem;
 }
 
 .source-control-group {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-detail/verification-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-detail/verification-detail.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input } from "@angular/core";
 import { AsyncPipe, DatePipe } from "@angular/common";
 import { RouterLink } from "@angular/router";
-import { Observable } from "rxjs";
+import { forkJoin, Observable } from "rxjs";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
 import { AuthenticationService } from "src/app/services/authentication.service";
 import { WaterQualityManagementPlanService } from "src/app/shared/generated/api/water-quality-management-plan.service";
+import { WaterQualityManagementPlanDto } from "src/app/shared/generated/model/water-quality-management-plan-dto";
 import { WaterQualityManagementPlanVerifyDetailDto } from "src/app/shared/generated/model/water-quality-management-plan-verify-detail-dto";
 
 @Component({
@@ -19,12 +20,18 @@ export class VerificationDetailComponent {
     @Input() waterQualityManagementPlanID!: number;
     @Input() waterQualityManagementPlanVerifyID!: number;
 
-    public verification$: Observable<WaterQualityManagementPlanVerifyDetailDto>;
+    // NPT-995 rework: page title is the WQMP name with status as an italic subtitle.
+    // The verify-detail DTO doesn't carry the WQMP name, so the page fetches both
+    // resources in parallel and binds them together.
+    public pageData$: Observable<{ wqmp: WaterQualityManagementPlanDto; verification: WaterQualityManagementPlanVerifyDetailDto }>;
 
     constructor(private wqmpService: WaterQualityManagementPlanService, private authenticationService: AuthenticationService) {}
 
     ngOnInit(): void {
-        this.verification$ = this.wqmpService.getVerificationWaterQualityManagementPlan(this.waterQualityManagementPlanID, this.waterQualityManagementPlanVerifyID);
+        this.pageData$ = forkJoin({
+            wqmp: this.wqmpService.getWaterQualityManagementPlan(this.waterQualityManagementPlanID),
+            verification: this.wqmpService.getVerificationWaterQualityManagementPlan(this.waterQualityManagementPlanID, this.waterQualityManagementPlanVerifyID),
+        });
     }
 
     public get currentPersonCanEdit(): boolean {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/verification-wizard.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/verification-wizard.component.html
@@ -37,23 +37,35 @@
                         <dd>{{ verificationDate() | date: "MM/dd/yyyy" }}</dd>
                     </dl>
                 }
-                @if (waterQualityManagementPlanVerifyID && !isFinalized()) {
-                    <button class="btn btn-danger-outline btn-sm wizard-header__delete" (click)="deleteVerification()">
-                        <i class="fa fa-trash"></i> Delete
-                    </button>
-                }
             </div>
 
-            @for (step of steps; track step.number) {
-                <button class="wizard-sidebar__step"
-                    [class.wizard-sidebar__step--active]="currentStep() === step.number"
-                    [class.wizard-sidebar__step--disabled]="isStepDisabled(step.number)"
-                    [disabled]="isStepDisabled(step.number)"
-                    (click)="goToStep(step.number)">
-                    <span class="wizard-sidebar__number">{{ step.number }}</span>
-                    <span class="wizard-sidebar__title">{{ step.title }}</span>
-                </button>
-            }
+            <!-- NPT-995 rework: switched from custom-numbered circles to the shared
+                 workflow-nav pattern (StepComplete / StepIncomplete icons) so this
+                 wizard matches the OVTA + Project workflows visually. The items are
+                 buttons rather than routerLinks because step state is signal-driven,
+                 not route-driven — same icons + classes as workflow-nav-item, just
+                 click-handled inline. -->
+            <workflow-nav>
+                @for (step of steps; track step.number) {
+                    <li class="sidebar-item workflow-sidebar-item">
+                        <button type="button"
+                                class="sidebar-link"
+                                [class.active]="currentStep() === step.number"
+                                [class.disabled]="isStepDisabled(step.number)"
+                                [disabled]="isStepDisabled(step.number)"
+                                (click)="goToStep(step.number)">
+                            <div>
+                                @if (step.number < currentStep()) {
+                                    <icon class="complete" icon="StepComplete"></icon>
+                                } @else {
+                                    <icon class="fade" icon="StepIncomplete"></icon>
+                                }
+                            </div>
+                            <div>{{ step.title }}</div>
+                        </button>
+                    </li>
+                }
+            </workflow-nav>
         </aside>
 
         <!-- Step content -->

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/verification-wizard.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/verification-wizard.component.scss
@@ -89,6 +89,22 @@
             cursor: not-allowed;
         }
     }
+
+    // Replicate the icon coloring from workflow-nav-item.component.scss. That file's
+    // rules are scoped to the workflow-nav-item component (default ViewEncapsulation),
+    // so the inline icon markup we're using here doesn't pick them up — without these
+    // local rules every step icon would render the same default color.
+    .workflow-sidebar-item {
+        button.sidebar-link:hover .complete {
+            color: $white;
+        }
+        .complete {
+            color: $green-default;
+        }
+        .info {
+            color: $teal-default;
+        }
+    }
 }
 
 .wizard-content {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/verification-wizard.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/verification-wizard.component.scss
@@ -75,53 +75,19 @@
     flex-direction: column;
     gap: 0.25rem;
 
-    &__step {
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        padding: 0.625rem 0.75rem;
+    // Step list visual now comes from the shared workflow-nav primitives
+    // (sidebar-link + workflow-sidebar-item). The wizard buttons reuse those
+    // classes; only the click-vs-routerLink distinction remains.
+    button.sidebar-link {
+        width: 100%;
         border: none;
-        border-left: 3px solid transparent;
-        border-radius: 0;
         background: transparent;
-        cursor: pointer;
         text-align: left;
+        cursor: pointer;
 
-        &:hover:not(:disabled) {
-            background: rgba($primary, 0.04);
-        }
-
-        &--active {
-            border-left-color: $primary;
-            font-weight: 600;
-        }
-
-        &--disabled {
-            opacity: 0.45;
+        &[disabled] {
             cursor: not-allowed;
         }
-    }
-
-    &__number {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 28px;
-        height: 28px;
-        border-radius: 50%;
-        background: $gray-100;
-        font-size: $type-size-200;
-        font-weight: 600;
-        flex-shrink: 0;
-
-        .wizard-sidebar__step--active & {
-            background: $primary;
-            color: $white;
-        }
-    }
-
-    &__title {
-        font-size: $type-size-200;
     }
 }
 

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/verification-wizard.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/verification-wizard.component.ts
@@ -22,6 +22,8 @@ import { SimplifiedBmpsStepComponent } from "src/app/pages/wqmps/wqmp-detail/ver
 import { SourceControlStepComponent, SourceControlRow } from "src/app/pages/wqmps/wqmp-detail/verification-wizard/steps/source-control-step.component";
 import { ReviewStepComponent } from "src/app/pages/wqmps/wqmp-detail/verification-wizard/steps/review-step.component";
 import { WorkflowBodyComponent } from "src/app/shared/components/workflow-body/workflow-body.component";
+import { WorkflowNavComponent } from "src/app/shared/components/workflow-nav/workflow-nav.component";
+import { IconComponent } from "src/app/shared/components/icon/icon.component";
 import { NeptunePageTypeEnum } from "src/app/shared/generated/enum/neptune-page-type-enum";
 
 @Component({
@@ -29,6 +31,7 @@ import { NeptunePageTypeEnum } from "src/app/shared/generated/enum/neptune-page-
     standalone: true,
     imports: [
         PageHeaderComponent, AlertDisplayComponent, WorkflowBodyComponent,
+        WorkflowNavComponent, IconComponent,
         VerificationBasicsStepComponent, StructuralBmpsStepComponent,
         SimplifiedBmpsStepComponent, SourceControlStepComponent, ReviewStepComponent,
         RouterLink, AsyncPipe, DatePipe,
@@ -296,16 +299,4 @@ export class VerificationWizardComponent implements OnInit {
         });
     }
 
-    deleteVerification(): void {
-        if (!confirm("Are you sure you want to delete this verification?")) return;
-        this.wqmpService.deleteVerificationWaterQualityManagementPlan(this.waterQualityManagementPlanID, this.waterQualityManagementPlanVerifyID).subscribe({
-            next: () => {
-                this.alertService.pushAlert(new Alert("Verification deleted.", AlertContext.Success));
-                this.router.navigate(["/water-quality-management-plans", this.waterQualityManagementPlanID]);
-            },
-            error: () => {
-                this.alertService.pushAlert(new Alert("An error occurred while deleting.", AlertContext.Danger));
-            },
-        });
-    }
 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
@@ -396,6 +396,12 @@
         <div class="card g-col-12 mt-3">
             <div class="card-header">
                 <span class="card-title">WQMP O&amp;M Verification</span>
+                @if (currentPersonCanEdit) {
+                    <a class="btn btn-primary btn-sm"
+                       [routerLink]="['/water-quality-management-plans', waterQualityManagementPlanID, 'verifications', 'new']">
+                        <i class="fa fa-plus"></i> Begin O&amp;M Verification
+                    </a>
+                }
             </div>
             <div class="card-body">
                 @if (verifications$ | async; as verifications) {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
@@ -20,6 +20,7 @@ import { LoadingDirective } from "src/app/shared/directives/loading.directive";
 import { UtilityFunctionsService } from "src/app/services/utility-functions.service";
 import { AuthenticationService } from "src/app/services/authentication.service";
 import { AlertService } from "src/app/shared/services/alert.service";
+import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
 import { Alert } from "src/app/shared/models/alert";
 import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 import { MarkerHelper } from "src/app/shared/helpers/marker-helper";
@@ -150,6 +151,7 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
         private authenticationService: AuthenticationService,
         private dialogService: DialogService,
         private alertService: AlertService,
+        private confirmService: ConfirmService,
         private groupByPipe: GroupByPipe,
         private sumPipe: SumPipe,
         private router: Router
@@ -350,6 +352,11 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
                         ActionIcon: "fas fa-edit",
                         ActionHandler: () => this.router.navigate(["/water-quality-management-plans", wqmpID, "verifications", verifyID]),
                     });
+                    actions.push({
+                        ActionName: "Delete",
+                        ActionIcon: "fa fa-trash text-danger",
+                        ActionHandler: () => this.confirmDeleteVerification(verifyID, params.data.VerificationDate),
+                    });
                 }
                 return actions;
             }),
@@ -448,5 +455,34 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
         } else {
             this.router.navigate(["/water-quality-management-plans", this.waterQualityManagementPlanID, "verifications", verifyID, "view"]);
         }
+    }
+
+    // NPT-995 rework: Delete moved off the wizard sign-off step into a row action on
+    // the verifications grid. Mirrors the project-list deleteModal pattern. Gated by
+    // the same currentPersonCanEdit + IsDraft conditions as the action column itself,
+    // so finalized verifications can't be removed accidentally.
+    confirmDeleteVerification(verifyID: number, verificationDate: string | null | undefined): void {
+        const dateText = verificationDate ? new Date(verificationDate).toLocaleDateString() : "this draft";
+        this.confirmService
+            .confirm({
+                title: "Delete Verification",
+                message: `<p>You are about to delete the verification from <strong>${dateText}</strong>.</p><p>Are you sure you wish to proceed?</p>`,
+                buttonClassYes: "btn btn-danger",
+                buttonTextYes: "Delete",
+                buttonTextNo: "Cancel",
+            })
+            .then((confirmed) => {
+                if (!confirmed) return;
+                this.wqmpService.deleteVerificationWaterQualityManagementPlan(this.waterQualityManagementPlanID, verifyID).subscribe({
+                    next: () => {
+                        this.alertService.pushAlert(new Alert("Verification deleted.", AlertContext.Success));
+                        // Re-assign the observable so the async pipe re-subscribes and the grid refreshes.
+                        this.verifications$ = this.wqmpService.listVerificationsWaterQualityManagementPlan(this.waterQualityManagementPlanID);
+                    },
+                    error: () => {
+                        this.alertService.pushAlert(new Alert("An error occurred while deleting the verification.", AlertContext.Danger));
+                    },
+                });
+            });
     }
 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-verifications/wqmp-verifications.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-verifications/wqmp-verifications.component.ts
@@ -2,7 +2,7 @@ import { Component } from "@angular/core";
 import { Router } from "@angular/router";
 import { AsyncPipe } from "@angular/common";
 import { ColDef } from "ag-grid-community";
-import { Observable, tap } from "rxjs";
+import { finalize, Observable } from "rxjs";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
 import { NeptuneGridComponent } from "src/app/shared/components/neptune-grid/neptune-grid.component";
@@ -95,7 +95,25 @@ export class WqmpVerificationsComponent {
 
     private refreshVerifications(): void {
         this.isLoading = true;
-        this.verifications$ = this.wqmpVerifyService.listAllAsIndexGridWaterQualityManagementPlanVerify().pipe(tap(() => (this.isLoading = false)));
+        // finalize so the spinner clears on both success and error — a failed list call
+        // (e.g. transient API outage right after a delete) was leaving the page stuck
+        // on the loading overlay.
+        this.verifications$ = this.wqmpVerifyService
+            .listAllAsIndexGridWaterQualityManagementPlanVerify()
+            .pipe(finalize(() => (this.isLoading = false)));
+    }
+
+    // ConfirmModalComponent renders message via [innerHtml] + bypassSecurityTrustHtml,
+    // so any user-controlled string interpolated into the template must be HTML-escaped
+    // first. WQMP names come from API data sourced from external uploads — treat as
+    // untrusted.
+    private escapeHtml(s: string): string {
+        return s
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
     }
 
     // NPT-995 rework: Delete moved off the wizard sign-off step into a row action.
@@ -103,7 +121,7 @@ export class WqmpVerificationsComponent {
     // IsDraft (set on the action push), so finalized verifications stay locked.
     confirmDeleteVerification(wqmpID: number, verifyID: number, wqmpName: string | null | undefined, verificationDate: string | null | undefined): void {
         const dateText = verificationDate ? new Date(verificationDate).toLocaleDateString() : "this draft";
-        const nameText = wqmpName ? ` for <strong>${wqmpName}</strong>` : "";
+        const nameText = wqmpName ? ` for <strong>${this.escapeHtml(wqmpName)}</strong>` : "";
         this.confirmService
             .confirm({
                 title: "Delete Verification",

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-verifications/wqmp-verifications.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-verifications/wqmp-verifications.component.ts
@@ -9,7 +9,12 @@ import { NeptuneGridComponent } from "src/app/shared/components/neptune-grid/nep
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
 import { UtilityFunctionsService } from "src/app/services/utility-functions.service";
 import { AuthenticationService } from "src/app/services/authentication.service";
+import { AlertService } from "src/app/shared/services/alert.service";
+import { Alert } from "src/app/shared/models/alert";
+import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
+import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
 import { WaterQualityManagementPlanVerifyService } from "src/app/shared/generated/api/water-quality-management-plan-verify.service";
+import { WaterQualityManagementPlanService } from "src/app/shared/generated/api/water-quality-management-plan.service";
 import { WaterQualityManagementPlanVerifyIndexGridDto } from "src/app/shared/generated/model/water-quality-management-plan-verify-index-grid-dto";
 
 @Component({
@@ -26,8 +31,11 @@ export class WqmpVerificationsComponent {
 
     constructor(
         private wqmpVerifyService: WaterQualityManagementPlanVerifyService,
+        private wqmpService: WaterQualityManagementPlanService,
         private utilityFunctionsService: UtilityFunctionsService,
         private authenticationService: AuthenticationService,
+        private alertService: AlertService,
+        private confirmService: ConfirmService,
         private router: Router
     ) {}
 
@@ -51,6 +59,11 @@ export class WqmpVerificationsComponent {
                         ActionName: "Edit",
                         ActionIcon: "fas fa-edit",
                         ActionHandler: () => this.router.navigate(["/water-quality-management-plans", wqmpID, "verifications", verifyID]),
+                    });
+                    actions.push({
+                        ActionName: "Delete",
+                        ActionIcon: "fa fa-trash text-danger",
+                        ActionHandler: () => this.confirmDeleteVerification(wqmpID, verifyID, params.data.WaterQualityManagementPlanName, params.data.VerificationDate),
                     });
                 }
                 return actions;
@@ -77,6 +90,39 @@ export class WqmpVerificationsComponent {
             }),
         ];
 
+        this.refreshVerifications();
+    }
+
+    private refreshVerifications(): void {
+        this.isLoading = true;
         this.verifications$ = this.wqmpVerifyService.listAllAsIndexGridWaterQualityManagementPlanVerify().pipe(tap(() => (this.isLoading = false)));
+    }
+
+    // NPT-995 rework: Delete moved off the wizard sign-off step into a row action.
+    // Mirrors the project-list deleteModal pattern. Gated by currentPersonCanEdit +
+    // IsDraft (set on the action push), so finalized verifications stay locked.
+    confirmDeleteVerification(wqmpID: number, verifyID: number, wqmpName: string | null | undefined, verificationDate: string | null | undefined): void {
+        const dateText = verificationDate ? new Date(verificationDate).toLocaleDateString() : "this draft";
+        const nameText = wqmpName ? ` for <strong>${wqmpName}</strong>` : "";
+        this.confirmService
+            .confirm({
+                title: "Delete Verification",
+                message: `<p>You are about to delete the verification${nameText} from <strong>${dateText}</strong>.</p><p>Are you sure you wish to proceed?</p>`,
+                buttonClassYes: "btn btn-danger",
+                buttonTextYes: "Delete",
+                buttonTextNo: "Cancel",
+            })
+            .then((confirmed) => {
+                if (!confirmed) return;
+                this.wqmpService.deleteVerificationWaterQualityManagementPlan(wqmpID, verifyID).subscribe({
+                    next: () => {
+                        this.alertService.pushAlert(new Alert("Verification deleted.", AlertContext.Success));
+                        this.refreshVerifications();
+                    },
+                    error: () => {
+                        this.alertService.pushAlert(new Alert("An error occurred while deleting the verification.", AlertContext.Danger));
+                    },
+                });
+            });
     }
 }


### PR DESCRIPTION
…ail header

Address PO feedback from the 4/28/26 retest pass on the WQMP O&M Verification workflow. Four items, all UI:

Wizard step indicator now matches OVTA + Project workflows:
- Custom 28px numbered circles in the sidebar replaced with the shared workflow-nav primitives (StepComplete / StepIncomplete icons, $green-default + $teal-default coloring).
- WorkflowNavComponent reused as the outer <ul>; items render as buttons rather than routerLinks because step state is signal-driven, not route-driven.
- Old .wizard-sidebar__step / .wizard-sidebar__number SCSS deleted.

Delete moved off the wizard sign-off step into a row action on both verifications grids:
- Wizard's Delete button + deleteVerification() method removed.
- Detail-page grid (wqmp-detail.component.ts) and standalone index grid (wqmp-verifications.component.ts) both grow a Delete action gated on currentPersonCanEdit && IsDraft, modeled on ProjectListComponent.deleteModal: ConfirmService confirm dialog → deleteVerificationWaterQualityManagementPlan → re-assign the source observable so the grid refreshes via async pipe.
- Backend endpoint already existed at WaterQualityManagementPlanController.DeleteVerification — no codegen needed.

Begin O&M Verification CTA inside the panel header on the WQMP detail page, alongside the existing top-right page-header button. Two-spot discoverability per PO direction.

Verification detail page header switched from the static "O&M Verification" title to the WQMP name with an italic "O&M Verification — Draft/Finalized" subtitle below it. The status pill in the Verification Basics card-header is gone (relocated). The component now forkJoins the WQMP and the verification so it has both names.