### PR TITLE
NPT-1049: Improve QuickBMPs extraction prompt + cleanup

### DIFF
--- a/Neptune.API/Services/AI/PromptTemplateService.cs
+++ b/Neptune.API/Services/AI/PromptTemplateService.cs
@@ -27,7 +27,10 @@ public sealed class PromptTemplateService : IPromptTemplateService
     // callers can still pass an explicit version to override for A/B testing.
     private static readonly Dictionary<PromptTemplate, string> ActiveVersion = new()
     {
+        [PromptTemplate.ExtractWqmpFields] = "v2",
+        [PromptTemplate.ExtractParcels] = "v2",
         [PromptTemplate.ExtractQuickBMPs] = "v3",
+        [PromptTemplate.ExtractSourceControlBMPs] = "v2",
     };
 
     private readonly string _promptsDirectory;

--- a/Neptune.API/Services/AI/PromptTemplateService.cs
+++ b/Neptune.API/Services/AI/PromptTemplateService.cs
@@ -27,7 +27,7 @@ public sealed class PromptTemplateService : IPromptTemplateService
     // callers can still pass an explicit version to override for A/B testing.
     private static readonly Dictionary<PromptTemplate, string> ActiveVersion = new()
     {
-        [PromptTemplate.ExtractQuickBMPs] = "v2",
+        [PromptTemplate.ExtractQuickBMPs] = "v3",
     };
 
     private readonly string _promptsDirectory;

--- a/Neptune.API/Services/AI/PromptTemplateService.cs
+++ b/Neptune.API/Services/AI/PromptTemplateService.cs
@@ -16,12 +16,20 @@ public enum PromptTemplate
 
 public interface IPromptTemplateService
 {
-    string Render(PromptTemplate template, object model, string version = "v1");
-    string? GetRawTemplate(PromptTemplate template, string version = "v1");
+    string Render(PromptTemplate template, object model, string? version = null);
+    string? GetRawTemplate(PromptTemplate template, string? version = null);
 }
 
 public sealed class PromptTemplateService : IPromptTemplateService
 {
+    // Active prompt version per template. Templates not listed here default to "v1".
+    // Bump an entry here (and add the corresponding _vN.md file) to roll out a new prompt;
+    // callers can still pass an explicit version to override for A/B testing.
+    private static readonly Dictionary<PromptTemplate, string> ActiveVersion = new()
+    {
+        [PromptTemplate.ExtractQuickBMPs] = "v2",
+    };
+
     private readonly string _promptsDirectory;
     private readonly ConcurrentDictionary<string, string> _templateCache = new();
     private static readonly Regex PlaceholderRegex = new(@"\{\{(\w+)\}\}", RegexOptions.Compiled);
@@ -32,8 +40,9 @@ public sealed class PromptTemplateService : IPromptTemplateService
             ?? Path.Combine(AppContext.BaseDirectory, "Services", "AI", "Prompts");
     }
 
-    public string Render(PromptTemplate template, object model, string version = "v1")
+    public string Render(PromptTemplate template, object model, string? version = null)
     {
+        version ??= ActiveVersion.GetValueOrDefault(template, "v1");
         var templateContent = GetRawTemplate(template, version)
             ?? throw new InvalidOperationException($"Prompt template '{template}_{version}' not found at {_promptsDirectory}.");
 
@@ -45,8 +54,9 @@ public sealed class PromptTemplateService : IPromptTemplateService
         });
     }
 
-    public string? GetRawTemplate(PromptTemplate template, string version = "v1")
+    public string? GetRawTemplate(PromptTemplate template, string? version = null)
     {
+        version ??= ActiveVersion.GetValueOrDefault(template, "v1");
         var cacheKey = $"{template}_{version}";
         var result = _templateCache.GetOrAdd(cacheKey, _ => LoadTemplate(template.ToString(), version));
         return string.IsNullOrEmpty(result) ? null : result;

--- a/Neptune.API/Services/AI/Prompts/ExtractParcels_v2.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractParcels_v2.md
@@ -1,0 +1,12 @@
+{{EvidenceInstructions}}
+
+<task>
+Extract all Parcels (APNs / Assessor Parcel Numbers) from the uploaded Water Quality Management Plan PDF (Orange County, CA). APNs commonly appear on the cover page, the title block, the project-description section, or in a parcel-listing table near the front of the document. Format is typically `XXX-XX-XXX` or `XXX-XXX-XX`.
+</task>
+
+When you cannot determine a value from the document, set the field's `Value`, `ExtractionEvidence`, `DocumentSource`, and `BoundingBox` to null. Do not infer.
+
+The schema for each emitted item:
+{{Schema}}
+
+Return a JSON object containing an `"items"` array (empty if no parcels are listed in this document).

--- a/Neptune.API/Services/AI/Prompts/ExtractQuickBMPs_v2.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractQuickBMPs_v2.md
@@ -1,0 +1,93 @@
+You are part of an automated workflow and must return only JSON. No narrative, no follow-up suggestions.
+You are helping a stormwater technician extract data from a Water Quality Management Plan (WQMP) used in Orange County California.
+If an attribute is not found output null for all of its child fields. Do not hallucinate.
+
+{{EvidenceInstructions}}
+
+Extract all **Simplified Structural BMPs (a.k.a. "Simple BMPs" or "QuickBMPs")** described in the uploaded PDF document.
+
+A QuickBMP is a stormwater control measure called out in the WQMP itself. It is **not** the same as the global Treatment BMP inventory: scope each extraction to the BMPs specifically described in this document for this site.
+
+## Where to look
+
+The OC WQMP form has two stylistic regions for BMP listings, and you must read both:
+
+**1. Pre-printed checkbox forms in Sections IV.3.1 – IV.3.6 (and IV.3.8, IV.3.9 when present).**
+These are LID / source-control / infiltration / biotreatment / hydromod BMP menus with a fixed list of BMP names and an "Included?" column (or equivalent). Selection is signaled by a **graphical checkmark, ☑, ✓, X, filled circle, or other mark next to the BMP name** — there is often no underlying text saying "selected." A marked box is **positive selection evidence on equal footing with a free-form table row.** Treat each checked row as a BMP to extract. An unchecked / blank row is NOT a selection and must be ignored.
+
+Important: **Section IV.3.5 (Hydromodification Control BMPs) is also a BMP source.** Underground detention systems, flow-duration control tanks, CMP detention pipes, and similar are typically described here, not in IV.3.7. Do not skip IV.3.5.
+
+**2. Free-form tables in Section IV.3.7 (Treatment Control BMPs) and similar narrative subsections.**
+Two-column "BMP Name | BMP Description" tables typed in by the engineer, often with vendor names, model numbers, and sizing. Extract one BMP per row. If IV.3.7 says something like *"See Proprietary Biotreatment BMP table above"*, follow the cross-reference back to the IV.3.4 table and extract from there instead of emitting nothing. If the same BMP appears in both IV.3.4 and IV.3.7, emit it **once** (de-dupe).
+
+Footnotes attached to a BMP table count as part of that table's content — extract BMPs mentioned only in a footnote (e.g. trash-capture pipe screens listed under a biotreatment table footnote).
+
+The "North OC Priority WQMP Template August 2011" variant has IV.3.1 – IV.3.5 but no IV.3.7 — structural treatment BMPs are described directly in IV.3.4. Do not assume IV.3.7 exists.
+
+Other supporting evidence sources: BMP fact sheets / cut-sheets in WQMP appendices, sizing calculation pages, treatment train diagrams, Section V (Operation & Maintenance) narratives that enumerate the project's BMPs.
+
+## Positive-selection rule (do not emit catalog items)
+
+Some WQMPs include catalog or reference tables listing BMP types that are **not** selected for this project — every row may be marked "N/A" or left blank. Do **not** extract these.
+
+Emit a BMP only when at least one of the following positive signals is present for that specific row/instance:
+- A checked / marked / X'd / filled box next to the BMP name in a Section IV.3.x form.
+- An explicit "Selected: Yes" / "Included" / "Provided" mark.
+- An assigned `% Site Treated`, drainage area assignment, or sizing calculation for this site.
+- A project-specific fact sheet, sizing page, or O&M narrative naming this BMP as installed on the project.
+
+If a row is marked "N/A", left blank, or appears in a generic reference appendix without any of the above, do NOT extract it.
+
+## Vendor → canonical type aliases
+
+Engineers commonly write vendor product names rather than the canonical TreatmentBMPType. Map vendor names to the canonical type when populating `TreatmentBMPType` (use a name from DomainContext's TreatmentBMPType list when available). Keep the vendor name in `QuickBMPName`.
+
+| Vendor name in document | Canonical TreatmentBMPType |
+|---|---|
+| Modular Wetlands / Modular Wetland System / MWS / MWS-L-* | Proprietary Biotreatment |
+| UrbanGreen Biofilter | Proprietary Biotreatment |
+| Filterra (any model, incl. Roofdrain System) | Proprietary Biotreatment |
+| Contech StormFilter | Proprietary Biotreatment |
+| Americast (Filterra is an Americast product) | Proprietary Biotreatment |
+| Bioclean Modular Connector / Connector Pipe Screen | Inlet/Pipe Screen |
+| Bioclean Grate Inlet Filter | Catch Basin Insert |
+| FloGard (catch basin filter insert) | Catch Basin Insert |
+| Kristar | Catch Basin Insert (context-dependent — verify in document) |
+| CMP Underground Detention / corrugated metal pipe detention | Underground Detention / Hydrodynamic / Detention Basin |
+| Stormwater Planter Box (with or without underdrains) | Bioretention |
+| Bioswale | Vegetated Swale |
+| Hydrodynamic Separator | Hydrodynamic Separator |
+
+When the document text is close to a name in DomainContext's TreatmentBMPType list, prefer that — staff can correct via dropdown if not.
+
+## Field guidance
+
+For each Simple BMP found, emit one object containing the following ExtractedValue fields:
+
+| Field | Guidance |
+|---|---|
+| QuickBMPName | The name as written in the WQMP (e.g. "Bioretention Area #1", "MWS DMA D1 (MWS-L-6-8 Unit A)", "4x4 Filterra Roofdrain System"). Keep vendor names, numbering, and DMA/subarea identifiers if shown. |
+| TreatmentBMPType | The canonical BMP type/category. Apply the vendor-alias table above. Prefer a name that matches one of the TreatmentBMPTypes in DomainContext. |
+| NumberOfIndividualBMPs | Integer count of physical units this row represents. **Defer to nearby quantity language** ("two planter boxes", "three 4'x6' units", "the 4 MWSs and 2 bioswales") rather than guessing. Only default to "1" if the document gives no count signal at all. |
+| PercentOfSiteTreated | Numeric percent (0–100) of the WQMP site area this BMP treats. Often shown in BMP sizing tables or treatment train diagrams. |
+| PercentCaptured | Numeric percent (0–100) of the design storm captured/intercepted by this BMP. |
+| PercentRetained | Numeric percent (0–100) retained on-site (infiltrated, evapotranspired, harvested). MUST be ≤ PercentCaptured — anything captured but not retained is treated and discharged. |
+| QuickBMPNote | Free-form note (≤200 chars) — sizing rationale, model number, drainage area assignment, or qualifiers like *"Supplemental Only. Not part of the Design Volume"*. |
+
+## Edge cases
+
+- If the document discusses BMPs in the abstract (e.g. a list of "could be used" measures) without committing to specific instances on this site, do NOT extract them.
+- If a single BMP type covers multiple instances enumerable as one row (e.g. "10 catch basin inserts at the perimeter"), emit one object with NumberOfIndividualBMPs="10".
+- If individual instances are distinguished by drainage area or model (e.g. "MWS 1 in DA 1", "MWS 2 in DA 2"), emit one object per instance — these are distinct BMPs even if the type is the same.
+- If a percent is given as a range (e.g. "80–90% capture"), emit the higher value.
+- If retained > captured in the source document (data quality issue), still extract both verbatim — staff will reconcile during review.
+- A BMP marked "Supplemental Only" or "Not part of Design Volume" should still be extracted; surface the qualifier in QuickBMPNote.
+- If the same BMP is described in both IV.3.4 and IV.3.7 (or any two sections), emit it once.
+
+Each attribute must be an object matching ExtractedValueSchema:
+{{ExtractedValueSchema}}
+
+QuickBmpSchema:
+{{Schema}}
+
+Return a JSON object containing an "items" array of objects matching QuickBmpSchema (empty array if no Simple BMPs are described in this document).

--- a/Neptune.API/Services/AI/Prompts/ExtractQuickBMPs_v3.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractQuickBMPs_v3.md
@@ -1,0 +1,123 @@
+{{EvidenceInstructions}}
+
+<task>
+Extract all **Simplified Structural BMPs** (a.k.a. "Simple BMPs" or "QuickBMPs") that this Water Quality Management Plan (WQMP) describes — stormwater control measures that this specific Orange County, CA project has committed to. This is **not** the global Treatment BMP inventory; scope each extraction to the BMPs in this document for this site.
+</task>
+
+<where_to_look>
+The OC WQMP form has two stylistic regions for BMP listings. You must read both. **Section numbers below reflect the standard OC template** — older variants and non-standard documents may use different numbering or omit sections. **Anchor your reading on the content / intent of each section, not on the literal section number.** If you see a section described by content that fits one of the categories below, treat it as that category regardless of how it's numbered.
+
+**Pre-printed checkbox forms** — typically Sections IV.3.1 through IV.3.6 (sometimes also IV.3.8, IV.3.9). Recognize by structure: a fixed list of BMP names with an "Included?" column, where selection is signaled by a graphical mark (☑, ✓, X, filled circle, or similar) next to the name. There is often no underlying text saying "selected." A marked box is positive selection evidence on equal footing with a free-form table row. Skip blank / unchecked rows.
+
+What the checkbox sections typically cover, in standard OC order — match by intent, not number:
+
+- **Hydrologic Source Controls (HSCs):** site-design measures — permeable pavement, planter boxes, green roofs, etc. (typically IV.3.1)
+- **Infiltration BMPs:** basins, drywells, trenches (typically IV.3.2)
+- **Harvest-and-Use BMPs:** cisterns, rain barrels (typically IV.3.3)
+- **Biotreatment BMPs:** bioretention, biofilters, vegetated swales, and most proprietary biotreatment products (typically IV.3.4)
+- **Hydromodification Control BMPs:** flow-duration control tanks, underground detention, CMP detention pipes — these BMPs typically *do not* appear in the free-form table; they are selected here (typically IV.3.5)
+- **Source Control BMPs (operational/non-structural):** covered by a separate extraction — ignore for QuickBMPs (typically IV.3.6)
+
+**Free-form treatment-control tables** — typically Section IV.3.7. Recognize by structure: two-column "BMP Name | BMP Description" tables filled in by the engineer, often with vendor names, model numbers, and sizing. Extract one BMP per row.
+
+If a free-form table cross-references a checkbox section (e.g. *"See Proprietary Biotreatment BMP table above"*), follow the cross-reference and extract from the referenced content. If the same BMP appears in both a checkbox form and a free-form table, emit it **once** (de-dupe).
+
+Footnotes attached to a BMP table count as part of that table's content — extract BMPs mentioned only in a footnote (e.g. trash-capture pipe screens listed under a biotreatment table footnote).
+
+**Variant templates exist.** The "North OC Priority WQMP Template August 2011" omits the free-form treatment-control table and describes structural treatment BMPs directly in the Biotreatment section. Some other templates use entirely custom numbering or merge categories. In any layout, prioritize content semantics — *is this site committing to this BMP?* — over the document's organizational scheme.
+
+**Non-standard or unrecognized BMPs.** If the document selects a BMP that doesn't fit any vendor alias or canonical category cleanly, extract it anyway: put the document's name verbatim in `QuickBMPName`, put your best canonical guess (or the document's own type label if it gave one) in `TreatmentBMPType`, and leave staff to remap during review. Do not skip a BMP because it doesn't fit the template — a missed BMP is worse than a mis-typed one.
+
+Other supporting evidence: BMP fact sheets / cut-sheets in WQMP appendices, sizing calculation pages, treatment train diagrams, Section V (Operation & Maintenance) narratives that enumerate the project's BMPs. These often disambiguate which checkboxes were marked when a scanned page is unclear.
+</where_to_look>
+
+<positive_selection_rule>
+Some WQMPs include catalog or reference tables listing BMP types that are **not** selected for this project — every row may be marked "N/A" or left blank. Do **not** extract these.
+
+Emit a BMP only when at least one of the following positive signals is present for that specific row/instance:
+
+- A checked / marked / X'd / filled box next to the BMP name in a Section IV.3.x form.
+- An explicit "Selected: Yes" / "Included" / "Provided" mark.
+- An assigned `% Site Treated`, drainage area assignment, or sizing calculation for this site.
+- A project-specific fact sheet, sizing page, or O&M narrative naming this BMP as installed on the project.
+
+If a row is marked "N/A", left blank, or appears in a generic reference appendix without any of the above, do **not** extract it.
+</positive_selection_rule>
+
+<vendor_aliases>
+Engineers commonly write vendor product names rather than the canonical `TreatmentBMPType`. Map vendor names to the canonical type when populating the `TreatmentBMPType` field — use a name from DomainContext's `TreatmentBMPTypes` list when available. Keep the vendor name in `QuickBMPName`.
+
+| Vendor name in document | Canonical `TreatmentBMPType` |
+|---|---|
+| Modular Wetlands / Modular Wetland System / MWS / MWS-L-* | Proprietary Biotreatment |
+| UrbanGreen Biofilter | Proprietary Biotreatment |
+| Filterra (any model, incl. Roofdrain System) | Proprietary Biotreatment |
+| Contech StormFilter | Proprietary Biotreatment |
+| Americast (vendor of Filterra) | Proprietary Biotreatment |
+| Bioclean Modular Connector / Connector Pipe Screen | Inlet and Pipe Screens |
+| Bioclean Grate Inlet Filter | Catch Basin / Inlet (unscreened) |
+| FloGard (catch basin filter insert) | Catch Basin / Inlet (unscreened) |
+| Kristar | Catch Basin / Inlet (unscreened) — verify in document |
+| CMP Underground Detention / corrugated metal pipe detention | Flow Duration Control Tank |
+| Stormwater Planter Box (with or without underdrains) | Bioinfiltration (bioretention with underdrain) |
+| Bioswale | Vegetated Swale |
+| Hydrodynamic Separator | Hydrodynamic Separator |
+
+<example>
+Document text:
+"1) 4x4 Filterra Roofdrain System: LAT: 33°38'51.42"; LONG: 117° 44'07.38""
+
+Correct extraction (vendor name in QuickBMPName, canonical type in TreatmentBMPType):
+
+```
+{
+  "QuickBMPName":     "4x4 Filterra Roofdrain System",
+  "TreatmentBMPType": "Proprietary Biotreatment"
+}
+```
+
+Wrong: leaving `TreatmentBMPType` as "Filterra Roof Drain System" (a vendor name — does not match any canonical `TreatmentBMPType` and will fail dropdown bind during staff review).
+</example>
+
+<example>
+Document mentions two distinct Bioclean products:
+
+- "Bioclean Modular Connector Pipe Screens" — trash-capture screens at storm-drain pipe inlets
+- "Bioclean Grate Inlet Filter" — filter insert that sits inside a catch basin grate
+
+Correct extraction (two separate items, different canonical types — same vendor, different BMP categories):
+
+```
+[
+  { "QuickBMPName": "Bioclean Modular Connector Pipe Screen", "TreatmentBMPType": "Inlet and Pipe Screens" },
+  { "QuickBMPName": "Bioclean Grate Inlet Filter",            "TreatmentBMPType": "Catch Basin / Inlet (unscreened)" }
+]
+```
+</example>
+</vendor_aliases>
+
+<output_fields>
+For each Simple BMP found, emit one object containing the following ExtractedValue fields:
+
+| Field | Guidance |
+|---|---|
+| `QuickBMPName` | The name as written in the WQMP (e.g. "Bioretention Area #1", "MWS DMA D1 (MWS-L-6-8 Unit A)", "4x4 Filterra Roofdrain System"). Keep vendor names, numbering, and DMA/subarea identifiers. If individual instances are distinguished by drainage area or model (e.g. MWS 1 in DA 1, MWS 2 in DA 2), emit one object per instance — these are distinct BMPs. |
+| `TreatmentBMPType` | Canonical BMP type/category. Apply the vendor-alias table above. Prefer a name from DomainContext's `TreatmentBMPTypes` list. |
+| `NumberOfIndividualBMPs` | Integer count of physical units this row represents. **Defer to nearby quantity language** ("two planter boxes", "three 4'x6' units", "the 4 MWSs and 2 bioswales") rather than guessing. Default to 1 only if the document gives no count signal at all. If a single BMP type covers multiple identical instances enumerable as one row (e.g. "10 catch basin inserts at the perimeter"), emit one object with `NumberOfIndividualBMPs=10`. |
+| `PercentOfSiteTreated` | Numeric percent (0–100) of the WQMP site this BMP treats. Often shown in BMP sizing tables or treatment train diagrams. |
+| `PercentCaptured` | Numeric percent (0–100) of the design storm captured/intercepted by this BMP. If given as a range ("80–90% capture"), emit the higher value. |
+| `PercentRetained` | Numeric percent (0–100) retained on-site (infiltrated, evapotranspired, harvested). Must be ≤ `PercentCaptured` — anything captured but not retained is treated and discharged. If the source document violates this constraint, still extract both verbatim — staff will reconcile during review. |
+| `QuickBMPNote` | Free-form note (≤200 chars) — sizing rationale, model number, drainage area assignment, or qualifiers like *"Supplemental Only. Not part of the Design Volume"*. |
+</output_fields>
+
+<edge_cases>
+- If the document discusses BMPs in the abstract — a list of "could be used" measures with no commitment to specific instances on this site — do not extract them.
+- A BMP qualified as "Supplemental Only" or "Not part of Design Volume" should still be extracted; surface the qualifier in `QuickBMPNote`.
+- If the same BMP is described in multiple sections (e.g. IV.3.4 and IV.3.7), emit it once.
+- **When uncertain about a value, set the field's `Value`, `ExtractionEvidence`, `DocumentSource`, and `BoundingBox` to null.** Do not infer plausible values from defaults, general knowledge, or other documents — null is the correct answer when the document does not specify.
+</edge_cases>
+
+The schema for each emitted item:
+{{Schema}}
+
+Return a JSON object containing an `"items"` array (empty if no Simple BMPs are described in this document).

--- a/Neptune.API/Services/AI/Prompts/ExtractSourceControlBMPs_v2.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractSourceControlBMPs_v2.md
@@ -1,0 +1,12 @@
+{{EvidenceInstructions}}
+
+<task>
+Extract all **Source Control BMPs** from the uploaded Water Quality Management Plan PDF (Orange County, CA). Source Control BMPs are **non-structural / operational measures** — for example storm-drain stenciling, trash management practices, employee training, vehicle wash protocols, spill response. They are distinct from the structural treatment BMPs handled by the QuickBMPs extraction. Match each finding's `SourceControlBMPAttribute` value to a name from DomainContext's `SourceControlBMPAttributes` list when a close match exists.
+</task>
+
+When you cannot determine a value from the document, set the field's `Value`, `ExtractionEvidence`, `DocumentSource`, and `BoundingBox` to null. Do not infer.
+
+The schema for each emitted item:
+{{Schema}}
+
+Return a JSON object containing an `"items"` array (empty if no Source Control BMPs are described in this document).

--- a/Neptune.API/Services/AI/Prompts/ExtractWqmpFields_v2.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractWqmpFields_v2.md
@@ -1,0 +1,12 @@
+{{EvidenceInstructions}}
+
+<task>
+Extract root-level WQMP attributes from the uploaded Water Quality Management Plan PDF (Orange County, CA). For fields whose value should match a controlled vocabulary — `Jurisdiction`, `HydrologicSubarea`, `WaterQualityManagementPlanLandUse`, `WaterQualityManagementPlanPriority`, `WaterQualityManagementPlanStatus`, `WaterQualityManagementPlanDevelopmentType`, `WaterQualityManagementPlanPermitTerm`, `TrashCaptureStatusType`, `HydromodificationAppliesType` — match the document's text to the corresponding list in DomainContext when a close match exists.
+</task>
+
+When you cannot determine a field from the document, set its `Value`, `ExtractionEvidence`, `DocumentSource`, and `BoundingBox` to null. Do not infer plausible values from defaults, general knowledge, or related fields — null is the correct answer when the document does not specify.
+
+The schema:
+{{Schema}}
+
+Return a single JSON object matching the schema.


### PR DESCRIPTION
## Summary
- Adds **v2** of `ExtractQuickBMPs` (vendor → canonical `TreatmentBMPType` alias table for Modular Wetlands / UrbanGreen / Filterra / Bioclean / FloGard / etc.) and **v3** (structural cleanup with XML-tagged sections + few-shot examples). v3 is wired as the active version.
- **Hygiene cleanup of the other three extraction prompts** (`WqmpFields`, `Parcels`, `SourceControlBMPs`) shipped as v2: drops the cargo-culted "Do not hallucinate" / persona / "must return JSON" preamble, fixes the misleading "Return a JSON array" instruction (actual schema is `{items: [...]}`), drops the redundant `{{DomainContext}}` substitution from `WqmpFields`.
- New `ActiveVersion` map in `PromptTemplateService` is the single source of truth for which prompt version is live per template; v1 retained on disk for rollback.

## Findings from regression-set scoring
v1, v2, v3 all score **+0.75** on the 4 processable docs (11/12 BMPs, 1 missed + 1 spurious that turn out to be the same regression-set ground-truth labeling artifact). The qualitative win for v2 / v3 is **canonical type binding** — v1 emits `Filterra Roof Drain System` for WQMP 3075, which is not a valid `TreatmentBMPType` and would fail dropdown bind during staff approval; v2 / v3 map it to `Proprietary Biotreatment`. Same outcome on UrbanGreen, MWS, FloGard, Bioclean. See [NPT-1049](https://sitkatech.atlassian.net/browse/NPT-1049) comments for full details.

Patterns 1 (checkbox semantics) and 4 (IV.3.5 hydromod inclusion) turned out to be **not load-bearing for `claude-sonnet-4-6`** — v1 already handles both natively. Kept in v2/v3 as cheap insurance for weaker / future models. The original framing of the card was based on stale runs.

**Side issue worth a separate ticket:** WQMPs 2739 and 2879 fail Anthropic's PDF processing regardless of prompt (400 + 500 errors). Both have partial text layers; production will hit the same wall.

## Test plan
- [ ] Smoke-test extraction on a recent WQMP via the existing approve flow; confirm `TreatmentBMPType` values bind to canonical names in the dropdown without staff remap (verify Filterra / MWS / UrbanGreen / Bioclean cases).
- [ ] Confirm `WqmpFields`, `Parcels`, and `SourceControlBMPs` extractions still produce valid output after the v2 hygiene cleanup (no semantic changes intended; structure-only).
- [ ] Verify token usage in `AITokenUsage` table is in the expected ballpark (~6–7k input per category for cached calls, modest +6% over v1/v2 for QuickBMPs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)