### PR TITLE
NPT-1038: Address PO rework — grid refresh, options inline-edit, mode…

### DIFF
--- a/Neptune.API/Controllers/CustomAttributeTypeController.cs
+++ b/Neptune.API/Controllers/CustomAttributeTypeController.cs
@@ -51,6 +51,15 @@ public class CustomAttributeTypeController(
     [AdminFeature]
     public async Task<ActionResult<CustomAttributeTypeDto>> Create([FromBody] CustomAttributeTypeUpsertDto dto)
     {
+        // NPT-1038 rework: reject Modeling-purpose creates server-side. The SPA filters
+        // the Purpose dropdown to hide Modeling on create — this is defense in depth so
+        // a future direct-API call can't slip a phantom modeling attribute past us.
+        var validationError = CustomAttributeTypes.ValidateForCreate(dto);
+        if (validationError != null)
+        {
+            return BadRequest(validationError);
+        }
+
         var created = await CustomAttributeTypes.CreateAsync(DbContext, dto);
         return Ok(created);
     }

--- a/Neptune.EFModels/Entities/CustomAttributeTypes.cs
+++ b/Neptune.EFModels/Entities/CustomAttributeTypes.cs
@@ -143,6 +143,23 @@ namespace Neptune.EFModels.Entities
                 .ToList();
         }
 
+        /// <summary>
+        /// NPT-1038: validates the create-time payload. Modeling-purpose attributes are
+        /// system-managed (delivered by application data + scaffolding) and must not be
+        /// added through the admin editor — the SPA filters the Purpose dropdown to hide
+        /// Modeling on create, and this is the backend belt-and-suspenders. Returns null
+        /// on success or an error string suitable for a BadRequest body.
+        /// </summary>
+        public static string? ValidateForCreate(CustomAttributeTypeUpsertDto? dto)
+        {
+            if (dto == null) return "Custom Attribute Type payload was empty.";
+            if (dto.CustomAttributeTypePurposeID == (int)CustomAttributeTypePurposeEnum.Modeling)
+            {
+                return "Custom Attribute Types with the Modeling purpose are system-managed and cannot be created via this admin editor.";
+            }
+            return null;
+        }
+
         public static async Task<CustomAttributeTypeDto> CreateAsync(NeptuneDbContext dbContext, CustomAttributeTypeUpsertDto dto)
         {
             var entity = new CustomAttributeType

--- a/Neptune.Tests/CustomAttributeTypesValidateForCreateTests.cs
+++ b/Neptune.Tests/CustomAttributeTypesValidateForCreateTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.EFModels.Entities;
+using Neptune.Models.DataTransferObjects;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// Covers the NPT-1038 rework guard that blocks creation of Modeling-purpose
+    /// Custom Attribute Types via the admin editor. The SPA filters the Purpose
+    /// dropdown to hide Modeling on create, and this validator is the backend
+    /// belt-and-suspenders.
+    /// </summary>
+    [TestClass]
+    public class CustomAttributeTypesValidateForCreateTests
+    {
+        [TestMethod]
+        public void Validate_NullDto_ReturnsError()
+        {
+            var result = CustomAttributeTypes.ValidateForCreate(null);
+            Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
+        public void Validate_ModelingPurpose_ReturnsError()
+        {
+            var dto = new CustomAttributeTypeUpsertDto
+            {
+                CustomAttributeTypePurposeID = (int)CustomAttributeTypePurposeEnum.Modeling,
+            };
+
+            var result = CustomAttributeTypes.ValidateForCreate(dto);
+
+            Assert.IsNotNull(result);
+            StringAssert.Contains(result, "Modeling");
+        }
+
+        [TestMethod]
+        public void Validate_OtherDesignPurpose_Succeeds()
+        {
+            var dto = new CustomAttributeTypeUpsertDto
+            {
+                CustomAttributeTypePurposeID = (int)CustomAttributeTypePurposeEnum.OtherDesignAttributes,
+            };
+
+            Assert.IsNull(CustomAttributeTypes.ValidateForCreate(dto));
+        }
+
+        [TestMethod]
+        public void Validate_MaintenancePurpose_Succeeds()
+        {
+            var dto = new CustomAttributeTypeUpsertDto
+            {
+                CustomAttributeTypePurposeID = (int)CustomAttributeTypePurposeEnum.Maintenance,
+            };
+
+            Assert.IsNull(CustomAttributeTypes.ValidateForCreate(dto));
+        }
+    }
+}

--- a/Neptune.Web/src/app/app.routes.ts
+++ b/Neptune.Web/src/app/app.routes.ts
@@ -565,6 +565,11 @@ export const routes: Routes = [
                 loadComponent: () => import("./pages/manage/custom-attributes.component").then((m) => m.CustomAttributesComponent),
             },
             {
+                path: "manage/custom-attributes/:customAttributeTypeID",
+                title: "Custom Attribute Type Detail",
+                loadComponent: () => import("./pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component").then((m) => m.CustomAttributeTypeDetailComponent),
+            },
+            {
                 path: "manage/observation-types",
                 title: "Observation Types",
                 loadComponent: () => import("./pages/manage/observation-types-manage.component").then((m) => m.ObservationTypesManageComponent),

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component.html
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component.html
@@ -1,0 +1,91 @@
+@if (attribute$ | async; as attribute) {
+    <page-header [pageTitle]="attribute.CustomAttributeTypeName ?? ''" [templateAbove]="templateAbove" [templateRight]="templateRight">
+        <ng-template #templateAbove>
+            <div class="back">
+                <a [routerLink]="['/manage/custom-attributes']" class="back__link">Back to Custom Attribute Types</a>
+            </div>
+        </ng-template>
+        <ng-template #templateRight>
+            <button class="btn btn-primary-outline" (click)="openEditModal(attribute)">
+                <i class="fa fa-pencil"></i> Edit
+            </button>
+            @if (attribute.CustomAttributeTypePurposeID !== CustomAttributeTypePurposeEnum.Modeling) {
+                <button class="btn btn-danger-outline ml-2" (click)="confirmDelete(attribute)">
+                    <i class="fa fa-trash"></i> Delete
+                </button>
+            }
+        </ng-template>
+    </page-header>
+
+    <app-alert-display></app-alert-display>
+
+    <div class="grid-12">
+        <div class="card g-col-12">
+            <div class="card-header">
+                <span class="card-title">Attribute Details</span>
+            </div>
+            <div class="card-body">
+                <dl class="grid-12">
+                    <dt class="g-col-4">Name</dt>
+                    <dd class="g-col-8">{{ attribute.CustomAttributeTypeName }}</dd>
+
+                    <dt class="g-col-4">Description</dt>
+                    <dd class="g-col-8">{{ attribute.CustomAttributeTypeDescription || "—" }}</dd>
+
+                    <dt class="g-col-4">Data Type</dt>
+                    <dd class="g-col-8">{{ attribute.DataTypeDisplayName ?? "—" }}</dd>
+
+                    <dt class="g-col-4">Purpose</dt>
+                    <dd class="g-col-8">{{ attribute.Purpose ?? "—" }}</dd>
+
+                    <dt class="g-col-4">Measurement Unit</dt>
+                    <dd class="g-col-8">{{ attribute.MeasurementUnitDisplayName || "—" }}</dd>
+
+                    <dt class="g-col-4">Is Required</dt>
+                    <dd class="g-col-8">{{ attribute.IsRequired ? "Yes" : "No" }}</dd>
+
+                    <dt class="g-col-4">Default Value</dt>
+                    <dd class="g-col-8">{{ attribute.CustomAttributeTypeDefaultValue || "—" }}</dd>
+                </dl>
+            </div>
+        </div>
+
+        @if (isOptionsType(attribute.CustomAttributeDataTypeID)) {
+            <div class="card g-col-12 mt-3">
+                <div class="card-header">
+                    <span class="card-title">Options</span>
+                </div>
+                <div class="card-body">
+                    @if (parseOptions(attribute.CustomAttributeTypeOptionsSchema).length) {
+                        <ul>
+                            @for (opt of parseOptions(attribute.CustomAttributeTypeOptionsSchema); track $index) {
+                                <li>{{ opt }}</li>
+                            }
+                        </ul>
+                    } @else {
+                        <p class="system-text">No options defined.</p>
+                    }
+                </div>
+            </div>
+        }
+
+        <div class="card g-col-12 mt-3">
+            <div class="card-header">
+                <span class="card-title">Used by Treatment BMP Types</span>
+            </div>
+            <div class="card-body">
+                @if (attribute.TreatmentBMPTypeNames?.length) {
+                    <ul>
+                        @for (name of attribute.TreatmentBMPTypeNames; track $index) {
+                            <li>{{ name }}</li>
+                        }
+                    </ul>
+                } @else {
+                    <p class="system-text">This attribute is not assigned to any Treatment BMP Types.</p>
+                }
+            </div>
+        </div>
+    </div>
+} @else {
+    <div [loadingSpinner]="{ isLoading: isLoading, loadingHeight: 400 }"></div>
+}

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component.html
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component.html
@@ -51,14 +51,15 @@
         </div>
 
         @if (isOptionsType(attribute.CustomAttributeDataTypeID)) {
+            @let options = parseOptions(attribute.CustomAttributeTypeOptionsSchema);
             <div class="card g-col-12 mt-3">
                 <div class="card-header">
                     <span class="card-title">Options</span>
                 </div>
                 <div class="card-body">
-                    @if (parseOptions(attribute.CustomAttributeTypeOptionsSchema).length) {
+                    @if (options.length) {
                         <ul>
-                            @for (opt of parseOptions(attribute.CustomAttributeTypeOptionsSchema); track $index) {
+                            @for (opt of options; track $index) {
                                 <li>{{ opt }}</li>
                             }
                         </ul>

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component.scss
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component.scss
@@ -1,0 +1,6 @@
+@use "/src/scss/abstracts" as *;
+
+// Match the spacing pattern from other detail pages (e.g. verification-detail).
+:host {
+    display: block;
+}

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component.ts
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, Input, OnInit } from "@angular/core";
 import { AsyncPipe } from "@angular/common";
 import { Router, RouterLink } from "@angular/router";
-import { BehaviorSubject, Observable, switchMap } from "rxjs";
+import { BehaviorSubject, catchError, EMPTY, Observable, shareReplay, switchMap, tap } from "rxjs";
 import { DialogService } from "@ngneat/dialog";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
@@ -47,12 +47,22 @@ export class CustomAttributeTypeDetailComponent implements OnInit {
     public CustomAttributeTypePurposeEnum = CustomAttributeTypePurposeEnum;
 
     ngOnInit(): void {
+        // Single subscription via the async pipe — isLoading and error handling are
+        // baked into the pipeline so no second subscribe is needed (a separate
+        // .subscribe would have fired a duplicate HTTP call on every reload).
+        // shareReplay caches the latest emission for any future subscriber.
         this.attribute$ = this.reload$.pipe(
-            switchMap(() => this.customAttributeTypeService.getCustomAttributeType(this.customAttributeTypeID)),
+            tap(() => (this.isLoading = true)),
+            switchMap(() => this.customAttributeTypeService.getCustomAttributeType(this.customAttributeTypeID).pipe(
+                tap(() => (this.isLoading = false)),
+                catchError(() => {
+                    this.isLoading = false;
+                    this.alertService.pushAlert(new Alert("Failed to load custom attribute type.", AlertContext.Danger));
+                    return EMPTY;
+                }),
+            )),
+            shareReplay(1),
         );
-        // Async-pipe handles the data; spinner only shows in the @else branch of the
-        // template (no data resolved yet). isLoading is the spinner's input there.
-        this.attribute$.subscribe(() => (this.isLoading = false));
     }
 
     isOptionsType(dataTypeID: number | undefined): boolean {

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component.ts
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-detail/custom-attribute-type-detail.component.ts
@@ -1,0 +1,119 @@
+import { Component, inject, Input, OnInit } from "@angular/core";
+import { AsyncPipe } from "@angular/common";
+import { Router, RouterLink } from "@angular/router";
+import { BehaviorSubject, Observable, switchMap } from "rxjs";
+import { DialogService } from "@ngneat/dialog";
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
+import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
+import { LoadingDirective } from "src/app/shared/directives/loading.directive";
+import { AlertService } from "src/app/shared/services/alert.service";
+import { Alert } from "src/app/shared/models/alert";
+import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
+import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
+import { CustomAttributeTypeService } from "src/app/shared/generated/api/custom-attribute-type.service";
+import { CustomAttributeTypeDto } from "src/app/shared/generated/model/custom-attribute-type-dto";
+import { CustomAttributeTypePurposeEnum } from "src/app/shared/generated/enum/custom-attribute-type-purpose-enum";
+import { CustomAttributeDataTypeEnum } from "src/app/shared/generated/enum/custom-attribute-data-type-enum";
+import { CustomAttributeTypeModalComponent } from "src/app/pages/manage/custom-attribute-type-modal/custom-attribute-type-modal.component";
+
+/**
+ * NPT-1038 rework: read-only detail page for a single Custom Attribute Type.
+ * Reachable from the Name link / View action on the index grid. Renders the
+ * same fields the edit modal shows (Name, Description, Data Type, Purpose,
+ * Unit, Required, Default Value, Options) plus the "Used by Treatment BMP
+ * Types" list that previously cluttered the edit modal. Edit and Delete
+ * buttons live at the bottom (Delete gated to non-modeling).
+ */
+@Component({
+    selector: "custom-attribute-type-detail",
+    standalone: true,
+    imports: [AsyncPipe, RouterLink, PageHeaderComponent, AlertDisplayComponent, LoadingDirective],
+    templateUrl: "./custom-attribute-type-detail.component.html",
+    styleUrl: "./custom-attribute-type-detail.component.scss",
+})
+export class CustomAttributeTypeDetailComponent implements OnInit {
+    @Input() customAttributeTypeID!: number;
+
+    private customAttributeTypeService = inject(CustomAttributeTypeService);
+    private alertService = inject(AlertService);
+    private confirmService = inject(ConfirmService);
+    private dialogService = inject(DialogService);
+    private router = inject(Router);
+
+    private reload$ = new BehaviorSubject<void>(undefined);
+    public attribute$: Observable<CustomAttributeTypeDto>;
+    public isLoading = true;
+
+    public CustomAttributeTypePurposeEnum = CustomAttributeTypePurposeEnum;
+
+    ngOnInit(): void {
+        this.attribute$ = this.reload$.pipe(
+            switchMap(() => this.customAttributeTypeService.getCustomAttributeType(this.customAttributeTypeID)),
+        );
+        // Async-pipe handles the data; spinner only shows in the @else branch of the
+        // template (no data resolved yet). isLoading is the spinner's input there.
+        this.attribute$.subscribe(() => (this.isLoading = false));
+    }
+
+    isOptionsType(dataTypeID: number | undefined): boolean {
+        return dataTypeID === CustomAttributeDataTypeEnum.PickFromList || dataTypeID === CustomAttributeDataTypeEnum.MultiSelect;
+    }
+
+    parseOptions(schema: string | null | undefined): string[] {
+        if (!schema) return [];
+        try {
+            const parsed = JSON.parse(schema);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch {
+            return [];
+        }
+    }
+
+    openEditModal(attribute: CustomAttributeTypeDto): void {
+        const dialogRef = this.dialogService.open(CustomAttributeTypeModalComponent, {
+            data: { mode: "edit", customAttributeType: attribute },
+            width: "700px",
+        });
+        dialogRef.afterClosed$.subscribe((result) => {
+            if (result) {
+                this.alertService.pushAlert(new Alert("Custom attribute type updated.", AlertContext.Success));
+                this.reload$.next();
+            }
+        });
+    }
+
+    confirmDelete(attribute: CustomAttributeTypeDto): void {
+        const name = this.escapeHtml(attribute.CustomAttributeTypeName ?? "this attribute");
+        this.confirmService
+            .confirm({
+                title: "Delete Custom Attribute Type",
+                message: `<p>You are about to delete <strong>${name}</strong>.</p>` +
+                    `<p>Any values stored on Treatment BMPs or Maintenance Records using this attribute, plus its associations to BMP types, will be removed too. This cannot be undone.</p>` +
+                    `<p>Are you sure you wish to proceed?</p>`,
+                buttonClassYes: "btn btn-danger",
+                buttonTextYes: "Delete",
+                buttonTextNo: "Cancel",
+            })
+            .then((confirmed) => {
+                if (!confirmed) return;
+                this.customAttributeTypeService.deleteCustomAttributeType(attribute.CustomAttributeTypeID!).subscribe({
+                    next: () => {
+                        this.alertService.pushAlert(new Alert("Custom attribute type deleted.", AlertContext.Success));
+                        this.router.navigate(["/manage/custom-attributes"]);
+                    },
+                    error: () => {
+                        this.alertService.pushAlert(new Alert("An error occurred while deleting the custom attribute type.", AlertContext.Danger));
+                    },
+                });
+            });
+    }
+
+    private escapeHtml(s: string): string {
+        return s
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
+}

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-modal/custom-attribute-type-modal.component.html
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-modal/custom-attribute-type-modal.component.html
@@ -40,14 +40,32 @@
 
         @if (showOptionsEditor) {
             <h4 class="mt-3">Options</h4>
-            <p class="system-text">Add the available options for this pick-list or multi-select attribute.</p>
+            <p class="system-text">Add the available options for this pick-list or multi-select attribute. Click an option to edit its text.</p>
             <div class="options-editor">
                 @for (option of optionsList(); track $index) {
                     <div class="options-editor__item">
-                        <span>{{ option }}</span>
-                        <button type="button" class="btn btn-sm btn-danger-outline" (click)="removeOption($index)">
-                            <i class="fa fa-trash"></i>
-                        </button>
+                        @if (editingOptionIndex() === $index) {
+                            <!-- NPT-1038 rework: inline-edit affordance. Replaces the prior delete-and-re-add
+                                 dance for fixing typos. Enter saves, Escape cancels. -->
+                            <input #editInput type="text" class="form-control form-control-sm options-editor__edit-input"
+                                [value]="option"
+                                (keydown.enter)="saveOptionEdit($index, editInput.value); $event.preventDefault()"
+                                (keydown.escape)="cancelOptionEdit(); $event.preventDefault()">
+                            <button type="button" class="btn btn-sm btn-primary" (click)="saveOptionEdit($index, editInput.value)" title="Save">
+                                <i class="fa fa-check"></i>
+                            </button>
+                            <button type="button" class="btn btn-sm btn-secondary-outline" (click)="cancelOptionEdit()" title="Cancel">
+                                <i class="fa fa-times"></i>
+                            </button>
+                        } @else {
+                            <span class="options-editor__text" (click)="startEditOption($index)" title="Click to edit">{{ option }}</span>
+                            <button type="button" class="btn btn-sm btn-secondary-outline" (click)="startEditOption($index)" title="Edit">
+                                <i class="fa fa-pencil"></i>
+                            </button>
+                            <button type="button" class="btn btn-sm btn-danger-outline" (click)="removeOption($index)" title="Delete">
+                                <i class="fa fa-trash"></i>
+                            </button>
+                        }
                     </div>
                 }
                 <div class="options-editor__add">
@@ -61,14 +79,9 @@
             </div>
         }
 
-        @if (isEdit && bmpTypeNames().length) {
-            <h4 class="mt-3">Used by Treatment BMP Types</h4>
-            <ul>
-                @for (name of bmpTypeNames(); track $index) {
-                    <li>{{ name }}</li>
-                }
-            </ul>
-        }
+        <!-- NPT-1038 rework: "Used by Treatment BMP Types" moved out of this modal
+             to the dedicated /manage/custom-attributes/:id detail page so the modal
+             stays focused on edit. -->
     </form>
 </div>
 <div class="modal-footer">

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-modal/custom-attribute-type-modal.component.html
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-modal/custom-attribute-type-modal.component.html
@@ -58,11 +58,14 @@
                                 <i class="fa fa-times"></i>
                             </button>
                         } @else {
-                            <span class="options-editor__text" (click)="startEditOption($index)" title="Click to edit">{{ option }}</span>
-                            <button type="button" class="btn btn-sm btn-secondary-outline" (click)="startEditOption($index)" title="Edit">
+                            <!-- Plain text + a separate Edit button. The pencil <button> is the
+                                 canonical edit trigger so keyboard / screen-reader users get the
+                                 same affordance as mouse users — no <span (click)> shortcut. -->
+                            <span class="options-editor__text">{{ option }}</span>
+                            <button type="button" class="btn btn-sm btn-secondary-outline" (click)="startEditOption($index)" [attr.aria-label]="'Edit option ' + option" title="Edit">
                                 <i class="fa fa-pencil"></i>
                             </button>
-                            <button type="button" class="btn btn-sm btn-danger-outline" (click)="removeOption($index)" title="Delete">
+                            <button type="button" class="btn btn-sm btn-danger-outline" (click)="removeOption($index)" [attr.aria-label]="'Delete option ' + option" title="Delete">
                                 <i class="fa fa-trash"></i>
                             </button>
                         }

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-modal/custom-attribute-type-modal.component.ts
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-modal/custom-attribute-type-modal.component.ts
@@ -127,8 +127,15 @@ export class CustomAttributeTypeModalComponent implements OnInit {
 
     removeOption(index: number): void {
         this.optionsList.update((list) => list.filter((_, i) => i !== index));
-        if (this.editingOptionIndex() === index) {
+        // Keep editingOptionIndex in sync with the post-delete array. Deleting the
+        // currently-edited row clears the edit; deleting an earlier row shifts the
+        // edited index left by one; deleting a later row leaves it alone.
+        const editing = this.editingOptionIndex();
+        if (editing === null) return;
+        if (editing === index) {
             this.editingOptionIndex.set(null);
+        } else if (editing > index) {
+            this.editingOptionIndex.set(editing - 1);
         }
     }
 

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-modal/custom-attribute-type-modal.component.ts
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-modal/custom-attribute-type-modal.component.ts
@@ -50,12 +50,23 @@ export class CustomAttributeTypeModalComponent implements OnInit {
 
     public optionsList = signal<string[]>([]);
     public newOptionText = signal("");
-    public bmpTypeNames = signal<string[]>([]);
+    // NPT-1038: inline-edit support for PickFromList/MultiSelect option text. Tracks
+    // which option row is currently being edited (or null when nothing is edited).
+    public editingOptionIndex = signal<number | null>(null);
 
     ngOnInit(): void {
         this.alertService.clearAlerts();
         this.mode = this.ref.data.mode;
         this.isEdit = this.mode === "edit";
+
+        // NPT-1038 rework: hide the Modeling purpose on create. Modeling-purpose
+        // attributes are system-managed, and the backend ValidateForCreate also
+        // rejects them — this is the friendlier UI gate.
+        if (!this.isEdit) {
+            this.purposeOptions = CustomAttributeTypePurposesAsSelectDropdownOptions.filter(
+                (o) => (o.Value as number) !== CustomAttributeTypePurposeEnum.Modeling
+            );
+        }
 
         if (this.isEdit && this.ref.data.customAttributeType) {
             const cat = this.ref.data.customAttributeType;
@@ -68,11 +79,6 @@ export class CustomAttributeTypeModalComponent implements OnInit {
                 CustomAttributeTypeDescription: cat.CustomAttributeTypeDescription,
                 CustomAttributeTypeDefaultValue: cat.CustomAttributeTypeDefaultValue,
             });
-
-            // Show related BMP types
-            if (cat.TreatmentBMPTypeNames?.length) {
-                this.bmpTypeNames.set(cat.TreatmentBMPTypeNames);
-            }
 
             // Parse existing options schema
             if (cat.CustomAttributeTypeOptionsSchema) {
@@ -121,6 +127,37 @@ export class CustomAttributeTypeModalComponent implements OnInit {
 
     removeOption(index: number): void {
         this.optionsList.update((list) => list.filter((_, i) => i !== index));
+        if (this.editingOptionIndex() === index) {
+            this.editingOptionIndex.set(null);
+        }
+    }
+
+    // NPT-1038 rework: enter edit-in-place for the option at `index`. Mutually
+    // exclusive — only one option can be edited at a time.
+    startEditOption(index: number): void {
+        this.editingOptionIndex.set(index);
+    }
+
+    // Persist the edited text back into the options array. No-ops if the new value
+    // is empty (treat as cancel) or duplicates another option (silent reject —
+    // the UI already shows the current text in the input so the user sees their typo).
+    saveOptionEdit(index: number, newText: string): void {
+        const trimmed = (newText ?? "").trim();
+        if (!trimmed) {
+            this.editingOptionIndex.set(null);
+            return;
+        }
+        const current = this.optionsList();
+        if (current.some((opt, i) => i !== index && opt === trimmed)) {
+            this.editingOptionIndex.set(null);
+            return;
+        }
+        this.optionsList.update((list) => list.map((opt, i) => (i === index ? trimmed : opt)));
+        this.editingOptionIndex.set(null);
+    }
+
+    cancelOptionEdit(): void {
+        this.editingOptionIndex.set(null);
     }
 
     save(): void {

--- a/Neptune.Web/src/app/pages/manage/custom-attributes.component.ts
+++ b/Neptune.Web/src/app/pages/manage/custom-attributes.component.ts
@@ -1,7 +1,8 @@
 import { Component, inject, OnInit } from "@angular/core";
 import { AsyncPipe } from "@angular/common";
+import { Router } from "@angular/router";
 import { ColDef } from "ag-grid-community";
-import { Observable, shareReplay, tap } from "rxjs";
+import { BehaviorSubject, Observable, shareReplay, switchMap } from "rxjs";
 import { DialogService } from "@ngneat/dialog";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
@@ -10,8 +11,11 @@ import { UtilityFunctionsService } from "src/app/services/utility-functions.serv
 import { AlertService } from "src/app/shared/services/alert.service";
 import { Alert } from "src/app/shared/models/alert";
 import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
+import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
 import { CustomAttributeTypeService } from "src/app/shared/generated/api/custom-attribute-type.service";
 import { CustomAttributeTypeDto } from "src/app/shared/generated/model/custom-attribute-type-dto";
+import { CustomAttributeTypePurposeEnum } from "src/app/shared/generated/enum/custom-attribute-type-purpose-enum";
+import { NeptunePageTypeEnum } from "src/app/shared/generated/enum/neptune-page-type-enum";
 import { CustomAttributeTypeModalComponent } from "src/app/pages/manage/custom-attribute-type-modal/custom-attribute-type-modal.component";
 
 @Component({
@@ -19,7 +23,7 @@ import { CustomAttributeTypeModalComponent } from "src/app/pages/manage/custom-a
     standalone: true,
     imports: [PageHeaderComponent, AlertDisplayComponent, NeptuneGridComponent, AsyncPipe],
     template: `
-        <page-header pageTitle="Custom Attribute Types" [templateRight]="addButton"></page-header>
+        <page-header pageTitle="Custom Attribute Types" [templateRight]="addButton" [customRichTextTypeID]="NeptunePageTypeEnum.ManageCustomAttributeTypesList"></page-header>
         <ng-template #addButton>
             <button class="btn btn-primary" (click)="openAddModal()">
                 <i class="fa fa-plus"></i> Add Custom Attribute Type
@@ -35,9 +39,7 @@ import { CustomAttributeTypeModalComponent } from "src/app/pages/manage/custom-a
                     [columnDefs]="columnDefs"
                     [pagination]="true"
                     [height]="'600px'"
-                    [downloadFileName]="'CustomAttributeTypes'"
-                    rowSelection="single"
-                    (selectionChanged)="onRowSelected($event)">
+                    [downloadFileName]="'CustomAttributeTypes'">
                 </neptune-grid>
             }
         </div>
@@ -48,22 +50,59 @@ export class CustomAttributesComponent implements OnInit {
     private utilityFunctionsService = inject(UtilityFunctionsService);
     private dialogService = inject(DialogService);
     private alertService = inject(AlertService);
+    private confirmService = inject(ConfirmService);
+    private router = inject(Router);
 
-    public customAttributeTypes$: Observable<CustomAttributeTypeDto[]>;
+    // NPT-1038 rework: drives grid refresh after edits/deletes. Replaces the previous
+    // shareReplay-on-reassign pattern, which left the grid bound to a stale subscription
+    // after loadData() rebuilt the observable — edits only showed up after a manual
+    // page reload.
+    private reload$ = new BehaviorSubject<void>(undefined);
+    public customAttributeTypes$: Observable<CustomAttributeTypeDto[]> = this.reload$.pipe(
+        switchMap(() => this.customAttributeTypeService.listCustomAttributeType()),
+        shareReplay(1),
+    );
     public columnDefs: ColDef[];
+    public NeptunePageTypeEnum = NeptunePageTypeEnum;
 
     ngOnInit(): void {
         this.buildColumnDefs();
-        this.loadData();
-    }
-
-    private loadData(): void {
-        this.customAttributeTypes$ = this.customAttributeTypeService.listCustomAttributeType().pipe(shareReplay(1));
     }
 
     private buildColumnDefs(): void {
         this.columnDefs = [
-            this.utilityFunctionsService.createBasicColumnDef("Name", "CustomAttributeTypeName"),
+            // NPT-1038: Row actions (View / Edit / Delete). Delete is gated to
+            // non-modeling attributes — modeling rows are system-managed and the
+            // backend refuses to remove them.
+            this.utilityFunctionsService.createActionsColumnDef((params: any) => {
+                const row = params.data as CustomAttributeTypeDto;
+                const id = row.CustomAttributeTypeID;
+                const isModeling = row.CustomAttributeTypePurposeID === CustomAttributeTypePurposeEnum.Modeling;
+                const actions: any[] = [
+                    {
+                        ActionName: "View",
+                        ActionHandler: () => this.router.navigate(["/manage/custom-attributes", id]),
+                    },
+                    {
+                        ActionName: "Edit",
+                        ActionIcon: "fas fa-edit",
+                        ActionHandler: () => this.openEditModal(row),
+                    },
+                ];
+                if (!isModeling) {
+                    actions.push({
+                        ActionName: "Delete",
+                        ActionIcon: "fa fa-trash text-danger",
+                        ActionHandler: () => this.confirmDelete(row),
+                    });
+                }
+                return actions;
+            }),
+            // NPT-1038: Name column is now a router-link to the detail page so it's
+            // visually obvious clicking it does something.
+            this.utilityFunctionsService.createLinkColumnDef("Name", "CustomAttributeTypeName", "CustomAttributeTypeID", {
+                InRouterLink: "/manage/custom-attributes/",
+            }),
             this.utilityFunctionsService.createBasicColumnDef("Data Type", "DataTypeDisplayName", { UseCustomDropdownFilter: true }),
             this.utilityFunctionsService.createBasicColumnDef("Purpose", "Purpose", { UseCustomDropdownFilter: true }),
             this.utilityFunctionsService.createBasicColumnDef("Is Required", "IsRequired", {
@@ -83,25 +122,59 @@ export class CustomAttributesComponent implements OnInit {
         dialogRef.afterClosed$.subscribe((result) => {
             if (result) {
                 this.alertService.pushAlert(new Alert("Custom attribute type created.", AlertContext.Success));
-                this.loadData();
+                this.reload$.next();
             }
         });
     }
 
-    onRowSelected(event: any): void {
-        const selectedRows = event.api.getSelectedRows();
-        if (!selectedRows?.length) return;
-        const selected = selectedRows[0] as CustomAttributeTypeDto;
-
+    private openEditModal(row: CustomAttributeTypeDto): void {
         const dialogRef = this.dialogService.open(CustomAttributeTypeModalComponent, {
-            data: { mode: "edit", customAttributeType: selected },
+            data: { mode: "edit", customAttributeType: row },
             width: "700px",
         });
         dialogRef.afterClosed$.subscribe((result) => {
             if (result) {
                 this.alertService.pushAlert(new Alert("Custom attribute type updated.", AlertContext.Success));
-                this.loadData();
+                this.reload$.next();
             }
         });
+    }
+
+    private confirmDelete(row: CustomAttributeTypeDto): void {
+        const name = this.escapeHtml(row.CustomAttributeTypeName ?? "this attribute");
+        this.confirmService
+            .confirm({
+                title: "Delete Custom Attribute Type",
+                message: `<p>You are about to delete <strong>${name}</strong>.</p>` +
+                    `<p>Any values stored on Treatment BMPs or Maintenance Records using this attribute, plus its associations to BMP types, will be removed too. This cannot be undone.</p>` +
+                    `<p>Are you sure you wish to proceed?</p>`,
+                buttonClassYes: "btn btn-danger",
+                buttonTextYes: "Delete",
+                buttonTextNo: "Cancel",
+            })
+            .then((confirmed) => {
+                if (!confirmed) return;
+                this.customAttributeTypeService.deleteCustomAttributeType(row.CustomAttributeTypeID!).subscribe({
+                    next: () => {
+                        this.alertService.pushAlert(new Alert("Custom attribute type deleted.", AlertContext.Success));
+                        this.reload$.next();
+                    },
+                    error: () => {
+                        this.alertService.pushAlert(new Alert("An error occurred while deleting the custom attribute type.", AlertContext.Danger));
+                    },
+                });
+            });
+    }
+
+    // ConfirmModalComponent renders message via [innerHtml] + bypassSecurityTrustHtml,
+    // so any user-controlled string interpolated into the template must be HTML-escaped
+    // first. Custom attribute names come from admin input — treated as untrusted.
+    private escapeHtml(s: string): string {
+        return s
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
     }
 }


### PR DESCRIPTION
…ling gate, delete, detail page, RTE

Six items flagged on 4/29/26 PO testing — all addressed in one slice.

Grid refresh after save (#1):
- custom-attributes.component.ts: dropped the shareReplay-on-reassign pattern that left the grid bound to a stale subscription. Replaced with a BehaviorSubject reload trigger; modal save and delete fire reload$.next() so the grid re-renders without a manual page reload.

Inline-edit option text (#2):
- custom-attribute-type-modal: each PickFromList/MultiSelect option row now toggles to an edit-in-place input (pencil icon → input, Enter saves, Escape cancels). New editingOptionIndex signal + startEditOption/saveOptionEdit/cancelOptionEdit methods. Replaces the prior delete-and-re-add dance for typo fixes.

Modeling-purpose create gate (#3):
- Backend: new CustomAttributeTypes.ValidateForCreate returns an error when CustomAttributeTypePurposeID == Modeling; controller calls it before CreateAsync and returns 400 on rejection.
- Frontend: modal filters Modeling out of the Purpose dropdown when isCreate. Edit mode keeps the full list so existing modeling attributes still render correctly.
- 4 new CustomAttributeTypesValidateForCreateTests cover null payload, Modeling rejected, OtherDesignAttributes accepted, Maintenance accepted.

Delete affordance (#4):
- Backend Delete endpoint already existed at CustomAttributeTypeController.cs:66-72 with full cascade — only the UI was missing. Added Delete in two spots per PO:
  - Grid row actions menu (View / Edit / Delete kebab), gated to non-modeling rows
  - Detail page footer button, also gated
- Both call ConfirmService with a cascade warning. Names are HTML-escaped before interpolation since ConfirmModal renders via bypassSecurityTrustHtml.

Name link + separated detail view (#5):
- Name column swapped from createBasicColumnDef to createLinkColumnDef, routing to /manage/custom-attributes/:id.
- New CustomAttributeTypeDetailComponent under manage/custom-attribute-type-detail/ — read-only field summary (Name, Description, Data Type, Purpose, Unit, Required, Default Value, Options) plus the "Used by Treatment BMP Types" list that previously cluttered the edit modal. Edit + Delete buttons in the page header.
- Edit modal stripped of the "Used by" section and the now-unused bmpTypeNames signal.

Page-level RTE blurb (#6):
- Wired <page-header [customRichTextTypeID]> to the existing NeptunePageTypeEnum.ManageCustomAttributeTypesList enum value (carried over from the legacy MVC site — no schema migration needed). Admin pastes the PO-supplied wording (Performance/Modeling / Other Design / Maintenance bullet list with the BMP Types link) via the existing CustomRichText edit flow.