### PR TITLE
NPT-984: Field visit workflow UX polish

### DIFF
--- a/Neptune.Web/src/app/app.routes.ts
+++ b/Neptune.Web/src/app/app.routes.ts
@@ -455,12 +455,40 @@ export const routes: Routes = [
                             ),
                     },
                     {
+                        path: "inventory/location",
+                        title: "Inventory — Location",
+                        loadComponent: () =>
+                            import("./pages/field-visits/field-visit-workflow-outlet/inventory-location-step/inventory-location-step.component").then(
+                                (m) => m.FieldVisitInventoryLocationStepComponent
+                            ),
+                    },
+                    {
+                        path: "inventory/photos",
+                        title: "Inventory — Photos",
+                        loadComponent: () =>
+                            import("./pages/field-visits/field-visit-workflow-outlet/inventory-photos-step/inventory-photos-step.component").then(
+                                (m) => m.FieldVisitInventoryPhotosStepComponent
+                            ),
+                    },
+                    {
+                        path: "inventory/attributes",
+                        title: "Inventory — Attributes",
+                        loadComponent: () =>
+                            import("./pages/field-visits/field-visit-workflow-outlet/inventory-attributes-step/inventory-attributes-step.component").then(
+                                (m) => m.FieldVisitInventoryAttributesStepComponent
+                            ),
+                    },
+                    {
                         path: "assessment",
                         title: "Initial Assessment",
                         loadComponent: () =>
                             import("./pages/field-visits/field-visit-workflow-outlet/assessment-step/assessment-step.component").then(
                                 (m) => m.FieldVisitAssessmentStepComponent
                             ),
+                        // withComponentInputBinding() overrides @Input defaults with `undefined` when the route has
+                        // no matching data key — must explicitly set `assessmentTypeID: 1` here so the Initial
+                        // assessment landing page (and observations/photos sub-steps) get the right type.
+                        data: { assessmentTypeID: 1 },
                     },
                     {
                         path: "assessment/observations",
@@ -469,6 +497,7 @@ export const routes: Routes = [
                             import("./pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component").then(
                                 (m) => m.FieldVisitObservationsStepComponent
                             ),
+                        data: { assessmentTypeID: 1 },
                     },
                     {
                         path: "assessment/photos",
@@ -477,6 +506,7 @@ export const routes: Routes = [
                             import("./pages/field-visits/field-visit-workflow-outlet/assessment-photos-step/assessment-photos-step.component").then(
                                 (m) => m.FieldVisitAssessmentPhotosStepComponent
                             ),
+                        data: { assessmentTypeID: 1 },
                     },
                     {
                         path: "maintenance",

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-photos-step/assessment-photos-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-photos-step/assessment-photos-step.component.html
@@ -1,15 +1,15 @@
 @if (workflow$ | async; as workflow) {
-    <h2>{{ headerLabel }}</h2>
+    <page-header [pageTitle]="headerLabel"></page-header>
 
-    @if (isLoading) {
+    @if (isLoading()) {
         <div [loadingSpinner]="{ isLoading: true }"></div>
-    } @else if (!assessment) {
+    } @else if (!assessment()) {
         <p>No assessment exists yet for this field visit. Return to the Assessment landing page to begin one.</p>
     } @else {
         <div class="card">
             <div class="card-body">
                 <image-editor
-                    [images]="photos"
+                    [images]="photos()"
                     [captionControlForm]="captionControlForm"
                     (newImageAdded)="onPhotoUpload($event)"
                     (imageDeleted)="onPhotoDelete($any($event))"

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-photos-step/assessment-photos-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-photos-step/assessment-photos-step.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, Input, OnInit, signal } from "@angular/core";
 import { Router } from "@angular/router";
 import { AsyncPipe } from "@angular/common";
 import { FormGroup } from "@angular/forms";
@@ -6,6 +6,7 @@ import { forkJoin, Observable, of, switchMap, take } from "rxjs";
 
 import { ImageEditorComponent, ImageEditorItem } from "src/app/shared/components/image-editor/image-editor.component";
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 
 import { TreatmentBMPAssessmentByFieldVisitService } from "src/app/shared/generated/api/treatment-bmp-assessment-by-field-visit.service";
 import { TreatmentBMPAssessmentPhotoService } from "src/app/shared/generated/api/treatment-bmp-assessment-photo.service";
@@ -26,7 +27,7 @@ interface AssessmentPhotoEditorItem extends ImageEditorItem {
 @Component({
     selector: "field-visit-assessment-photos-step",
     standalone: true,
-    imports: [AsyncPipe, ImageEditorComponent, LoadingDirective],
+    imports: [AsyncPipe, ImageEditorComponent, LoadingDirective, PageHeaderComponent],
     templateUrl: "./assessment-photos-step.component.html",
     styleUrl: "./assessment-photos-step.component.scss",
 })
@@ -35,10 +36,12 @@ export class FieldVisitAssessmentPhotosStepComponent implements OnInit {
     @Input() assessmentTypeID: number = 1;
 
     public workflow$: Observable<FieldVisitWorkflowDto | null>;
-    public assessment: TreatmentBMPAssessmentDetailDto | null = null;
-    public photos: AssessmentPhotoEditorItem[] = [];
+    // Signals — plain fields don't reliably trigger CD when mutated inside subscribe callbacks
+    // under zoneless behavior, leaving the spinner stuck until a stray click forces a render.
+    public assessment = signal<TreatmentBMPAssessmentDetailDto | null>(null);
+    public photos = signal<AssessmentPhotoEditorItem[]>([]);
     public captionControlForm = new FormGroup({});
-    public isLoading = true;
+    public isLoading = signal(true);
 
     constructor(
         private workflowService: FieldVisitWorkflowService,
@@ -53,7 +56,9 @@ export class FieldVisitAssessmentPhotosStepComponent implements OnInit {
     }
 
     public get headerLabel(): string {
-        return this.isPostMaintenance ? "Post-Maintenance Assessment Photos" : "Initial Assessment Photos";
+        // Single-word page title — the sidebar already says which assessment is active,
+        // so no need to repeat "Initial / Post-Maintenance Assessment" in the page header.
+        return "Photos";
     }
 
     ngOnInit(): void {
@@ -67,21 +72,22 @@ export class FieldVisitAssessmentPhotosStepComponent implements OnInit {
                 })
             )
             .subscribe((assessment) => {
-                this.assessment = assessment;
+                this.assessment.set(assessment);
                 if (assessment) {
                     this.refreshPhotos();
                 } else {
-                    this.isLoading = false;
+                    this.isLoading.set(false);
                 }
             });
     }
 
     private refreshPhotos(): void {
-        if (!this.assessment) return;
-        this.isLoading = true;
-        this.photoService.listTreatmentBMPAssessmentPhoto(this.assessment.TreatmentBMPAssessmentID).subscribe((photos) => {
-            this.photos = photos.map((p) => this.toEditorItem(p));
-            this.isLoading = false;
+        const assessment = this.assessment();
+        if (!assessment) return;
+        this.isLoading.set(true);
+        this.photoService.listTreatmentBMPAssessmentPhoto(assessment.TreatmentBMPAssessmentID).subscribe((photos) => {
+            this.photos.set(photos.map((p) => this.toEditorItem(p)));
+            this.isLoading.set(false);
         });
     }
 
@@ -95,23 +101,26 @@ export class FieldVisitAssessmentPhotosStepComponent implements OnInit {
     }
 
     onPhotoUpload(event: { file: File; caption: string }): void {
-        if (!this.assessment) return;
-        this.photoService.createTreatmentBMPAssessmentPhoto(this.assessment.TreatmentBMPAssessmentID, event.file, event.caption).subscribe(() => {
+        const assessment = this.assessment();
+        if (!assessment) return;
+        this.photoService.createTreatmentBMPAssessmentPhoto(assessment.TreatmentBMPAssessmentID, event.file, event.caption).subscribe(() => {
             this.alertService.pushAlert(new Alert("Photo uploaded.", AlertContext.Success));
             this.refreshPhotos();
         });
     }
 
     onPhotoDelete(item: AssessmentPhotoEditorItem): void {
-        if (!this.assessment || !item.TreatmentBMPAssessmentPhotoID) return;
-        this.photoService.deleteTreatmentBMPAssessmentPhoto(this.assessment.TreatmentBMPAssessmentID, item.TreatmentBMPAssessmentPhotoID).subscribe(() => {
+        const assessment = this.assessment();
+        if (!assessment || !item.TreatmentBMPAssessmentPhotoID) return;
+        this.photoService.deleteTreatmentBMPAssessmentPhoto(assessment.TreatmentBMPAssessmentID, item.TreatmentBMPAssessmentPhotoID).subscribe(() => {
             this.alertService.pushAlert(new Alert("Photo deleted.", AlertContext.Success));
             this.refreshPhotos();
         });
     }
 
     onSaveCaptions(updated: AssessmentPhotoEditorItem[]): void {
-        if (!this.assessment) return;
+        const assessment = this.assessment();
+        if (!assessment) return;
         if (updated.length === 0) {
             this.alertService.pushAlert(new Alert("No caption changes to save.", AlertContext.Info));
             return;
@@ -120,7 +129,7 @@ export class FieldVisitAssessmentPhotosStepComponent implements OnInit {
         const requests = updated
             .filter((item) => item.TreatmentBMPAssessmentPhotoID != null)
             .map((item) =>
-                this.photoService.updateCaptionTreatmentBMPAssessmentPhoto(this.assessment!.TreatmentBMPAssessmentID, item.TreatmentBMPAssessmentPhotoID!, {
+                this.photoService.updateCaptionTreatmentBMPAssessmentPhoto(assessment.TreatmentBMPAssessmentID, item.TreatmentBMPAssessmentPhotoID!, {
                     TreatmentBMPAssessmentPhotoID: item.TreatmentBMPAssessmentPhotoID!,
                     Caption: item.Caption ?? null,
                 })

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-step/assessment-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-step/assessment-step.component.html
@@ -1,44 +1,48 @@
 @if (workflow$ | async; as workflow) {
-    <h2>{{ headerLabel }}</h2>
+    <page-header [pageTitle]="headerLabel"></page-header>
 
-    @if (!hasAssessment(workflow)) {
+    @if (isPostMaintenance) {
         <p>
-            @if (isPostMaintenance) {
-                Begin a Post-Maintenance Assessment to capture observations after the maintenance event, or skip to the visit summary.
-            } @else {
-                Begin an Initial Assessment to capture observations of the BMP's current condition, or skip to the maintenance step.
-            }
+            If maintenance was recently performed on this BMP (e.g. as part of this field visit), you can record a new assessment to quantify the improved condition of the BMP.
         </p>
-
-        <div class="step-footer">
-            <button type="button" class="btn btn-link" (click)="skip(workflow)">
-                Skip to {{ isPostMaintenance ? "Visit Summary" : "Maintenance" }}
-            </button>
-            <button type="button" class="btn btn-primary" (click)="beginAssessment(workflow)">
-                Begin {{ isPostMaintenance ? "Post-Maintenance" : "Initial" }} Assessment
-            </button>
-        </div>
     } @else {
-        <div class="card">
-            <div class="card-header"><span class="card-title">{{ headerLabel }} in progress</span></div>
-            <div class="card-body">
-                <p>Status: <strong>{{ assessmentComplete(workflow) ? "Complete" : "In Progress" }}</strong></p>
-                @if (assessmentScore(workflow) != null) {
-                    <p>Score: <strong>{{ assessmentScore(workflow) | number: "1.1-1" }}</strong></p>
-                }
-            </div>
-        </div>
-
-        <div class="step-footer">
-            <button type="button" class="btn btn-link" (click)="skip(workflow)">
-                Skip to {{ isPostMaintenance ? "Visit Summary" : "Maintenance" }}
-            </button>
-            <button type="button" class="btn btn-secondary" (click)="goToPhotos(workflow)">
-                Edit Photos
-            </button>
-            <button type="button" class="btn btn-primary" (click)="goToObservations(workflow)">
-                Edit Observations
-            </button>
-        </div>
+        <p>
+            The assessment workflow allows input of observations to quantify the BMP's performance. An assessment consists of several rapid observations and/or measurements made at a BMP,
+            which results in a score between 0&ndash;5.
+        </p>
     }
+
+    <p>
+        Use the navigation on the left to view and enter your assessment details. Be sure to click Save on each page. In order to receive an assessment score you are required to enter
+        observations in each section.
+    </p>
+
+    <p>You will see these icons next to the observation pages &mdash; here's what they mean:</p>
+    <ul class="icon-legend">
+        <li>
+            <icon class="legend-icon incomplete" icon="StepIncomplete"></icon>
+            Required information has not been completely provided (section incomplete)
+        </li>
+        <li>
+            <icon class="legend-icon complete" icon="StepComplete"></icon>
+            Required information has been provided (section complete)
+        </li>
+    </ul>
+
+    <div class="step-footer">
+        @if (!isPostMaintenance) {
+            <button type="button" class="btn btn-primary" (click)="skip(workflow)">
+                Skip to Maintenance <i class="fa fa-forward ml-2"></i>
+            </button>
+        }
+        @if (!hasAssessment(workflow)) {
+            <button type="button" class="btn btn-primary" (click)="beginAssessment(workflow)">
+                Begin {{ isPostMaintenance ? "Post-Maintenance" : "Initial" }} Assessment <i class="fa fa-caret-right ml-2"></i>
+            </button>
+        } @else {
+            <button type="button" class="btn btn-primary" (click)="goToObservations(workflow)">
+                Continue {{ isPostMaintenance ? "Post-Maintenance" : "Initial" }} Assessment <i class="fa fa-caret-right ml-2"></i>
+            </button>
+        }
+    </div>
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-step/assessment-step.component.scss
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-step/assessment-step.component.scss
@@ -1,16 +1,28 @@
 @use "/src/scss/abstracts" as *;
 
-.todo {
-    background: $teal-50;
-    border-left: 3px solid $teal-500;
-    padding: $spacing-300;
-    margin-top: $spacing-300;
-}
+.icon-legend {
+    list-style: none;
+    padding-left: 0;
+    margin: 0 0 $spacing-400;
 
-.step-footer {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: $spacing-300;
-    margin-top: $spacing-500;
+    li {
+        display: flex;
+        align-items: center;
+        gap: $spacing-200;
+        margin-bottom: $spacing-200;
+    }
+
+    .legend-icon {
+        display: inline-flex;
+        width: 1rem;
+        flex: 0 0 auto;
+
+        &.complete {
+            color: $green-default;
+        }
+
+        &.incomplete {
+            color: $orange-default;
+        }
+    }
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-step/assessment-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-step/assessment-step.component.ts
@@ -1,10 +1,12 @@
 import { Component, Input, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
-import { AsyncPipe, DecimalPipe } from "@angular/common";
+import { AsyncPipe } from "@angular/common";
 import { Observable } from "rxjs";
 
 import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visit-workflow-dto";
 import { TreatmentBMPAssessmentByFieldVisitService } from "src/app/shared/generated/api/treatment-bmp-assessment-by-field-visit.service";
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
+import { IconComponent } from "src/app/shared/components/icon/icon.component";
 
 import { FieldVisitWorkflowService } from "../../services/field-visit-workflow.service";
 import { AlertService } from "src/app/shared/services/alert.service";
@@ -13,15 +15,17 @@ import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 
 /**
  * AssessmentStepComponent renders both the Initial and Post-Maintenance assessment
- * landing pages — the layout is identical, only the assessment type and the
- * "skip to" target differ. Pass the type via the route data: { assessmentTypeID: 1 | 2 }.
- * It's a decision page (Begin / Skip / continue to existing); the dynamic
- * observations form lives in ObservationsStepComponent.
+ * landing pages — the layout is identical (workflow description, navigation hint,
+ * icon legend explaining sub-step completion icons, and Begin/Continue buttons),
+ * only the assessment type and the skip target differ. Pass the type via route data:
+ * `{ assessmentTypeID: 1 | 2 }` — `withComponentInputBinding()` binds it to the
+ * `assessmentTypeID` @Input. The actual observations form lives in
+ * `ObservationsStepComponent` (the Observations sub-step under each assessment).
  */
 @Component({
     selector: "field-visit-assessment-step",
     standalone: true,
-    imports: [AsyncPipe, DecimalPipe],
+    imports: [AsyncPipe, PageHeaderComponent, IconComponent],
     templateUrl: "./assessment-step.component.html",
     styleUrl: "./assessment-step.component.scss",
 })
@@ -53,14 +57,6 @@ export class FieldVisitAssessmentStepComponent implements OnInit {
         return this.isPostMaintenance ? !!workflow.PostMaintenanceAssessmentID : !!workflow.InitialAssessmentID;
     }
 
-    public assessmentScore(workflow: FieldVisitWorkflowDto): number | null {
-        return (this.isPostMaintenance ? workflow.PostMaintenanceAssessmentScore : workflow.InitialAssessmentScore) ?? null;
-    }
-
-    public assessmentComplete(workflow: FieldVisitWorkflowDto): boolean {
-        return this.isPostMaintenance ? workflow.PostMaintenanceAssessmentComplete : workflow.InitialAssessmentComplete;
-    }
-
     beginAssessment(workflow: FieldVisitWorkflowDto): void {
         this.assessmentByFieldVisitService.createTreatmentBMPAssessmentByFieldVisit(workflow.FieldVisitID, this.assessmentTypeID).subscribe(() => {
             this.alertService.pushAlert(new Alert(`Started ${this.headerLabel}.`, AlertContext.Success));
@@ -73,13 +69,12 @@ export class FieldVisitAssessmentStepComponent implements OnInit {
         this.router.navigate(["/field-visits", workflow.FieldVisitID, branch, "observations"]);
     }
 
-    goToPhotos(workflow: FieldVisitWorkflowDto): void {
-        const branch = this.isPostMaintenance ? "post-maintenance-assessment" : "assessment";
-        this.router.navigate(["/field-visits", workflow.FieldVisitID, branch, "photos"]);
-    }
-
+    /**
+     * Skip to Maintenance — only surfaced for Initial Assessment. The Post-Maintenance
+     * landing page hides the Skip button (matching legacy MVC), so this method is never
+     * called when `isPostMaintenance` is true.
+     */
     skip(workflow: FieldVisitWorkflowDto): void {
-        const next = this.isPostMaintenance ? "summary" : "maintenance";
-        this.router.navigate(["/field-visits", workflow.FieldVisitID, next]);
+        this.router.navigate(["/field-visits", workflow.FieldVisitID, "maintenance"]);
     }
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.html
@@ -11,8 +11,11 @@
                         <p class="bmp-type">{{ workflow.TreatmentBMPTypeName }}</p>
                         <p class="visit-meta">
                             {{ workflow.FieldVisitTypeDisplayName }} &mdash; {{ workflow.VisitDate | date: "MM/dd/yyyy" }}
-                            <button type="button" class="btn-edit-date" (click)="openChangeDateAndTypeModal(workflow)" title="Change visit date or type">
+                            <button type="button" class="btn-icon" (click)="openChangeDateAndTypeModal(workflow)" title="Change visit date or type">
                                 <i class="fa fa-pencil"></i>
+                            </button>
+                            <button type="button" class="btn-icon btn-icon-danger" (click)="deleteVisit(workflow)" title="Delete visit">
+                                <i class="fa fa-trash"></i>
                             </button>
                         </p>
                         <p class="visit-status">Status: {{ workflow.FieldVisitStatusDisplayName }}</p>
@@ -20,26 +23,46 @@
                 </h5>
             </div>
             <workflow-nav>
-                <workflow-nav-item [navRouterLink]="['inventory']" [complete]="workflow.InventoryUpdated" [required]="true">
+                <workflow-nav-item [navRouterLink]="['inventory']" [complete]="workflow.InventoryUpdated" [required]="true" [hasSubNav]="true">
                     Inventory
+                    <ng-container subnav>
+                        <workflow-nav-sub-item [navRouterLink]="['inventory', 'location']">Location</workflow-nav-sub-item>
+                        <workflow-nav-sub-item [navRouterLink]="['inventory', 'photos']">Photos</workflow-nav-sub-item>
+                        <workflow-nav-sub-item [navRouterLink]="['inventory', 'attributes']" [complete]="workflow.RequiredAttributesEntered">Attributes</workflow-nav-sub-item>
+                    </ng-container>
                 </workflow-nav-item>
-                <workflow-nav-item [navRouterLink]="['assessment']" [complete]="workflow.InitialAssessmentComplete" [disabled]="false" [required]="false">
+                <workflow-nav-item [navRouterLink]="['assessment']" [complete]="workflow.InitialAssessmentComplete" [required]="false" [hasSubNav]="!!workflow.InitialAssessmentID">
                     Initial Assessment
+                    <ng-container subnav>
+                        <workflow-nav-sub-item [navRouterLink]="['assessment', 'observations']" [complete]="workflow.InitialAssessmentComplete">Observations</workflow-nav-sub-item>
+                        <workflow-nav-sub-item [navRouterLink]="['assessment', 'photos']">Photos</workflow-nav-sub-item>
+                    </ng-container>
                 </workflow-nav-item>
-                <workflow-nav-item [navRouterLink]="['maintenance']" [complete]="!!workflow.MaintenanceRecordID" [disabled]="false" [required]="false">
+                <workflow-nav-item [navRouterLink]="['maintenance']" [complete]="!!workflow.MaintenanceRecordID" [required]="false">
                     Maintenance
                 </workflow-nav-item>
                 <workflow-nav-item
                     [navRouterLink]="['post-maintenance-assessment']"
                     [complete]="workflow.PostMaintenanceAssessmentComplete"
                     [disabled]="!workflow.MaintenanceRecordID"
-                    [required]="false">
+                    [required]="false"
+                    [hasSubNav]="!!workflow.PostMaintenanceAssessmentID">
                     Post-Maintenance Assessment
+                    <ng-container subnav>
+                        <workflow-nav-sub-item [navRouterLink]="['post-maintenance-assessment', 'observations']" [complete]="workflow.PostMaintenanceAssessmentComplete">
+                            Observations
+                        </workflow-nav-sub-item>
+                        <workflow-nav-sub-item [navRouterLink]="['post-maintenance-assessment', 'photos']">Photos</workflow-nav-sub-item>
+                    </ng-container>
                 </workflow-nav-item>
-                <workflow-nav-item [navRouterLink]="['summary']" [complete]="workflow.IsFieldVisitVerified" [disabled]="false" [required]="false">
+                <workflow-nav-item [navRouterLink]="['summary']" [complete]="workflow.IsFieldVisitVerified" [required]="false">
                     Visit Summary
                 </workflow-nav-item>
             </workflow-nav>
+
+            <div class="sidebar-actions">
+                <button type="button" class="btn btn-primary" (click)="wrapUpVisit(workflow)">Wrap Up Visit</button>
+            </div>
         </aside>
         <main class="main">
             <div class="outlet-container">

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.scss
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.scss
@@ -1,83 +1,59 @@
 @use "/src/scss/abstracts" as *;
 
-.dashboard.workflow {
-    display: flex;
-    align-items: stretch;
-    min-height: 100vh;
-}
+.sidebar-header {
+    .back {
+        display: inline-block;
+        font-size: $type-size-200;
+        margin-bottom: $spacing-200;
+        color: $teal-700;
+        text-decoration: underline;
+        cursor: pointer;
+    }
 
-.sidebar {
-    width: 22rem;
-    flex-shrink: 0;
-    background: $gray-100;
-    border-right: 1px solid $gray-300;
-    padding: $spacing-500 $spacing-400;
+    .bmp-name {
+        font-size: $type-size-400;
+        margin: 0;
+    }
 
-    .sidebar-header {
-        margin-bottom: $spacing-500;
+    .bmp-type {
+        font-size: $type-size-200;
+        color: $gray-600;
+        margin: 0 0 $spacing-200;
+    }
 
-        .back {
-            display: inline-block;
-            font-size: $type-size-200;
-            margin-bottom: $spacing-200;
-        }
+    .visit-meta {
+        font-size: $type-size-200;
+        margin: 0 0 $spacing-100;
+        display: flex;
+        align-items: center;
+        gap: $spacing-200;
+    }
 
-        .bmp-name {
-            font-size: $type-size-400;
-            margin: 0;
-        }
+    .visit-status {
+        font-size: $type-size-200;
+        color: $gray-700;
+        margin: 0;
+    }
 
-        .bmp-type {
-            font-size: $type-size-200;
-            color: $gray-600;
-            margin: 0 0 $spacing-200;
-        }
+    .btn-icon {
+        border: 0;
+        background: transparent;
+        padding: $spacing-100 $spacing-200;
+        color: $primary;
+        cursor: pointer;
 
-        .visit-meta {
-            font-size: $type-size-200;
-            margin: 0 0 $spacing-100;
-            display: flex;
-            align-items: center;
-            gap: $spacing-200;
-        }
-
-        .visit-status {
-            font-size: $type-size-200;
-            color: $gray-700;
-            margin: 0;
-        }
-
-        .btn-edit-date {
-            border: 0;
-            background: transparent;
-            padding: $spacing-100 $spacing-200;
-            color: $primary;
-            cursor: pointer;
+        &.btn-icon-danger {
+            color: $red-default;
         }
     }
 }
 
-.main {
-    flex-grow: 1;
-    padding: $spacing-500 $spacing-600;
+.sidebar-actions {
+    padding: $spacing-400 $spacing-400 0;
+    display: flex;
+    justify-content: center;
 }
 
 .loading-shell {
     min-height: 50vh;
-}
-
-@media (max-width: 768px) {
-    .dashboard.workflow {
-        flex-direction: column;
-    }
-
-    .sidebar {
-        width: 100%;
-        border-right: 0;
-        border-bottom: 1px solid $gray-300;
-    }
-
-    .main {
-        padding: $spacing-400;
-    }
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.ts
@@ -5,6 +5,7 @@ import { Observable, Subscription } from "rxjs";
 
 import { WorkflowNavComponent } from "src/app/shared/components/workflow-nav/workflow-nav.component";
 import { WorkflowNavItemComponent } from "src/app/shared/components/workflow-nav/workflow-nav-item/workflow-nav-item.component";
+import { WorkflowNavSubItemComponent } from "src/app/shared/components/workflow-nav/workflow-nav-sub-item/workflow-nav-sub-item.component";
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
 
@@ -12,14 +13,19 @@ import { DialogService } from "@ngneat/dialog";
 import { ChangeDateAndTypeModalComponent, ChangeDateAndTypeModalContext } from "./change-date-and-type-modal/change-date-and-type-modal.component";
 
 import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visit-workflow-dto";
+import { FieldVisitService } from "src/app/shared/generated/api/field-visit.service";
 import { FieldVisitWorkflowService } from "../services/field-visit-workflow.service";
+import { AlertService } from "src/app/shared/services/alert.service";
+import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
+import { Alert } from "src/app/shared/models/alert";
+import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 
 @Component({
     selector: "field-visit-workflow-outlet",
     standalone: true,
     templateUrl: "./field-visit-workflow-outlet.component.html",
     styleUrl: "./field-visit-workflow-outlet.component.scss",
-    imports: [RouterModule, RouterOutlet, AsyncPipe, DatePipe, WorkflowNavComponent, WorkflowNavItemComponent, LoadingDirective, AlertDisplayComponent],
+    imports: [RouterModule, RouterOutlet, AsyncPipe, DatePipe, WorkflowNavComponent, WorkflowNavItemComponent, WorkflowNavSubItemComponent, LoadingDirective, AlertDisplayComponent],
 })
 export class FieldVisitWorkflowOutletComponent implements OnInit, OnDestroy {
     @Input() fieldVisitID: number | null = null;
@@ -28,7 +34,14 @@ export class FieldVisitWorkflowOutletComponent implements OnInit, OnDestroy {
     public isLoading = true;
     private sub: Subscription | undefined;
 
-    constructor(private workflowService: FieldVisitWorkflowService, private dialogService: DialogService, private router: Router) {}
+    constructor(
+        private workflowService: FieldVisitWorkflowService,
+        private fieldVisitService: FieldVisitService,
+        private dialogService: DialogService,
+        private alertService: AlertService,
+        private confirmService: ConfirmService,
+        private router: Router
+    ) {}
 
     ngOnInit(): void {
         this.workflow$ = this.workflowService.workflow$;
@@ -56,5 +69,43 @@ export class FieldVisitWorkflowOutletComponent implements OnInit, OnDestroy {
 
     backToBMP(workflow: FieldVisitWorkflowDto): void {
         this.router.navigate(["/treatment-bmps", workflow.TreatmentBMPID]);
+    }
+
+    deleteVisit(workflow: FieldVisitWorkflowDto): void {
+        this.confirmService
+            .confirm({
+                title: "Delete Field Visit",
+                message: "Are you sure you want to delete this Field Visit? This will remove the visit, all assessments, and the maintenance record.",
+                buttonClassYes: "btn btn-danger",
+                buttonTextYes: "Delete",
+                buttonTextNo: "Cancel",
+            })
+            .then((confirmed) => {
+                if (!confirmed) return;
+                this.fieldVisitService.deleteFieldVisit(workflow.FieldVisitID).subscribe(() => {
+                    this.alertService.pushAlert(new Alert("Field Visit deleted.", AlertContext.Success));
+                    this.router.navigate(["/treatment-bmps", workflow.TreatmentBMPID]);
+                });
+            });
+    }
+
+    wrapUpVisit(workflow: FieldVisitWorkflowDto): void {
+        this.confirmService
+            .confirm({
+                title: "Wrap Up Visit",
+                message:
+                    "Are you sure you want to wrap up the field visit? Wrapping up will mark the field visit as complete and ready for review by the Jurisdiction Manager. " +
+                    "Any unsaved form changes on the current step will be lost.",
+                buttonClassYes: "btn btn-primary",
+                buttonTextYes: "Continue",
+                buttonTextNo: "Cancel",
+            })
+            .then((confirmed) => {
+                if (!confirmed) return;
+                this.fieldVisitService.finalizeFieldVisit(workflow.FieldVisitID).subscribe(() => {
+                    this.alertService.pushAlert(new Alert("Field Visit marked Complete.", AlertContext.Success));
+                    this.router.navigate(["/treatment-bmps", workflow.TreatmentBMPID]);
+                });
+            });
     }
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-attributes-step/inventory-attributes-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-attributes-step/inventory-attributes-step.component.html
@@ -1,0 +1,8 @@
+@if (workflow$ | async; as workflow) {
+    <page-header pageTitle="Attributes"></page-header>
+    <treatment-bmp-custom-attributes-form
+        [treatmentBMPID]="workflow.TreatmentBMPID"
+        [customAttributePurposeID]="OtherDesignAttributesPurposeID"
+        (saved)="onSaved(workflow)"
+        (cancelled)="onCancelled(workflow)"></treatment-bmp-custom-attributes-form>
+}

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-attributes-step/inventory-attributes-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-attributes-step/inventory-attributes-step.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from "@angular/core";
+import { Router } from "@angular/router";
+import { AsyncPipe } from "@angular/common";
+import { Observable } from "rxjs";
+
+import { TreatmentBmpCustomAttributesFormComponent } from "src/app/shared/components/treatment-bmp-editors/custom-attributes-form/treatment-bmp-custom-attributes-form.component";
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
+
+import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visit-workflow-dto";
+import { CustomAttributeTypePurposeEnum } from "src/app/shared/generated/enum/custom-attribute-type-purpose-enum";
+
+import { FieldVisitWorkflowService } from "../../services/field-visit-workflow.service";
+
+@Component({
+    selector: "field-visit-inventory-attributes-step",
+    standalone: true,
+    imports: [AsyncPipe, PageHeaderComponent, TreatmentBmpCustomAttributesFormComponent],
+    templateUrl: "./inventory-attributes-step.component.html",
+})
+export class FieldVisitInventoryAttributesStepComponent implements OnInit {
+    public workflow$: Observable<FieldVisitWorkflowDto | null>;
+    public OtherDesignAttributesPurposeID = CustomAttributeTypePurposeEnum.OtherDesignAttributes;
+
+    constructor(private workflowService: FieldVisitWorkflowService, private router: Router) {}
+
+    ngOnInit(): void {
+        this.workflow$ = this.workflowService.workflow$;
+    }
+
+    onSaved(workflow: FieldVisitWorkflowDto): void {
+        this.workflowService.markInventoryUpdatedAndRefresh(workflow.FieldVisitID).subscribe(() => {
+            this.router.navigate(["/field-visits", workflow.FieldVisitID, "inventory"]);
+        });
+    }
+
+    onCancelled(workflow: FieldVisitWorkflowDto): void {
+        this.router.navigate(["/field-visits", workflow.FieldVisitID, "inventory"]);
+    }
+}

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-location-step/inventory-location-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-location-step/inventory-location-step.component.html
@@ -1,0 +1,7 @@
+@if (workflow$ | async; as workflow) {
+    <page-header pageTitle="Location"></page-header>
+    <treatment-bmp-location-editor
+        [treatmentBMPID]="workflow.TreatmentBMPID"
+        (saved)="onSaved(workflow)"
+        (cancelled)="onCancelled(workflow)"></treatment-bmp-location-editor>
+}

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-location-step/inventory-location-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-location-step/inventory-location-step.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from "@angular/core";
+import { Router } from "@angular/router";
+import { AsyncPipe } from "@angular/common";
+import { Observable } from "rxjs";
+
+import { TreatmentBmpLocationEditorComponent } from "src/app/shared/components/treatment-bmp-editors/location-editor/treatment-bmp-location-editor.component";
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
+
+import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visit-workflow-dto";
+
+import { FieldVisitWorkflowService } from "../../services/field-visit-workflow.service";
+
+@Component({
+    selector: "field-visit-inventory-location-step",
+    standalone: true,
+    imports: [AsyncPipe, PageHeaderComponent, TreatmentBmpLocationEditorComponent],
+    templateUrl: "./inventory-location-step.component.html",
+})
+export class FieldVisitInventoryLocationStepComponent implements OnInit {
+    public workflow$: Observable<FieldVisitWorkflowDto | null>;
+
+    constructor(private workflowService: FieldVisitWorkflowService, private router: Router) {}
+
+    ngOnInit(): void {
+        this.workflow$ = this.workflowService.workflow$;
+    }
+
+    onSaved(workflow: FieldVisitWorkflowDto): void {
+        this.workflowService.markInventoryUpdatedAndRefresh(workflow.FieldVisitID).subscribe(() => {
+            this.router.navigate(["/field-visits", workflow.FieldVisitID, "inventory", "photos"]);
+        });
+    }
+
+    onCancelled(workflow: FieldVisitWorkflowDto): void {
+        this.router.navigate(["/field-visits", workflow.FieldVisitID, "inventory"]);
+    }
+}

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-photos-step/inventory-photos-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-photos-step/inventory-photos-step.component.html
@@ -1,0 +1,9 @@
+@if (workflow$ | async; as workflow) {
+    <page-header pageTitle="Photos"></page-header>
+    <treatment-bmp-images-editor
+        [treatmentBMPID]="workflow.TreatmentBMPID"
+        (uploaded)="onPhotosChanged(workflow)"
+        (deleted)="onPhotosChanged(workflow)"
+        (saved)="onContinue(workflow)"
+        (cancelled)="onCancelled(workflow)"></treatment-bmp-images-editor>
+}

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-photos-step/inventory-photos-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-photos-step/inventory-photos-step.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnInit } from "@angular/core";
+import { Router } from "@angular/router";
+import { AsyncPipe } from "@angular/common";
+import { Observable } from "rxjs";
+
+import { TreatmentBmpImagesEditorComponent } from "src/app/shared/components/treatment-bmp-editors/images-editor/treatment-bmp-images-editor.component";
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
+
+import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visit-workflow-dto";
+
+import { FieldVisitWorkflowService } from "../../services/field-visit-workflow.service";
+
+@Component({
+    selector: "field-visit-inventory-photos-step",
+    standalone: true,
+    imports: [AsyncPipe, PageHeaderComponent, TreatmentBmpImagesEditorComponent],
+    templateUrl: "./inventory-photos-step.component.html",
+})
+export class FieldVisitInventoryPhotosStepComponent implements OnInit {
+    public workflow$: Observable<FieldVisitWorkflowDto | null>;
+
+    constructor(private workflowService: FieldVisitWorkflowService, private router: Router) {}
+
+    ngOnInit(): void {
+        this.workflow$ = this.workflowService.workflow$;
+    }
+
+    /**
+     * Fired by treatment-bmp-images-editor on every persistence event (upload, delete, captions saved).
+     * Each one counts as an inventory change, so we flip InventoryUpdated even if the user never clicks
+     * the "Save Captions" button — matches legacy MVC where any photos-page submit set the flag.
+     */
+    onPhotosChanged(workflow: FieldVisitWorkflowDto): void {
+        this.workflowService.markInventoryUpdatedAndRefresh(workflow.FieldVisitID).subscribe();
+    }
+
+    onContinue(workflow: FieldVisitWorkflowDto): void {
+        this.workflowService.markInventoryUpdatedAndRefresh(workflow.FieldVisitID).subscribe(() => {
+            this.router.navigate(["/field-visits", workflow.FieldVisitID, "inventory", "attributes"]);
+        });
+    }
+
+    onCancelled(workflow: FieldVisitWorkflowDto): void {
+        this.router.navigate(["/field-visits", workflow.FieldVisitID, "inventory"]);
+    }
+}

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-step/inventory-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-step/inventory-step.component.html
@@ -1,81 +1,26 @@
 @if (workflow$ | async; as workflow) {
-    <h2>Inventory</h2>
+    <page-header pageTitle="Review and Update Inventory?"></page-header>
+
     <p>
-        Confirm that the BMP's location, photos, and required attributes are accurate before performing the assessment. Changes saved here update the
-        Treatment BMP itself. When you're done, mark the inventory complete and continue to the assessment, or skip.
+        You may review the BMP inventory data, including setting the location of the BMP, adding photos, and completing the attributes necessary to track and analyze the BMP's
+        performance.
     </p>
 
-    <div class="card">
-        <div class="card-header">
-            <span class="card-title">Review Inventory</span>
-        </div>
-        <div class="card-body">
-            <ul class="inventory-actions">
-                <li>
-                    <span class="action-label">Location</span>
-                    @if (activePanel === "location") {
-                        <button type="button" class="btn btn-link" (click)="collapsePanel()">Collapse</button>
-                    } @else {
-                        <button type="button" class="btn btn-secondary" (click)="expandPanel('location')">Edit Location</button>
-                    }
-                </li>
-                @if (activePanel === "location") {
-                    <li class="inline-editor">
-                        <treatment-bmp-location-editor
-                            [treatmentBMPID]="workflow.TreatmentBMPID"
-                            (saved)="onLocationSaved()"
-                            (cancelled)="collapsePanel()"></treatment-bmp-location-editor>
-                    </li>
-                }
-                <li>
-                    <span class="action-label">Photos</span>
-                    @if (activePanel === "photos") {
-                        <button type="button" class="btn btn-link" (click)="collapsePanel()">Collapse</button>
-                    } @else {
-                        <button type="button" class="btn btn-secondary" (click)="expandPanel('photos')">Edit Photos</button>
-                    }
-                </li>
-                @if (activePanel === "photos") {
-                    <li class="inline-editor">
-                        <treatment-bmp-images-editor
-                            [treatmentBMPID]="workflow.TreatmentBMPID"
-                            (saved)="onPhotosSaved()"
-                            (cancelled)="collapsePanel()"></treatment-bmp-images-editor>
-                    </li>
-                }
-                <li>
-                    <span class="action-label">Custom Attributes</span>
-                    @if (activePanel === "attributes") {
-                        <button type="button" class="btn btn-link" (click)="collapsePanel()">Collapse</button>
-                    } @else {
-                        <button type="button" class="btn btn-secondary" (click)="expandPanel('attributes')">Other Design Attributes</button>
-                    }
-                </li>
-                @if (activePanel === "attributes") {
-                    <li class="inline-editor">
-                        <treatment-bmp-custom-attributes-form
-                            [treatmentBMPID]="workflow.TreatmentBMPID"
-                            [customAttributePurposeID]="OtherDesignAttributesPurposeID"
-                            (saved)="onAttributesSaved()"
-                            (cancelled)="collapsePanel()"></treatment-bmp-custom-attributes-form>
-                    </li>
-                }
-            </ul>
-
-            @if (workflow.NumberOfRequiredAttributes > 0) {
-                <p class="required-attrs">
-                    Required attributes entered: <strong>{{ workflow.NumberRequiredAttributesEntered }}</strong> of
-                    <strong>{{ workflow.NumberOfRequiredAttributes }}</strong>
-                    @if (!workflow.RequiredAttributesEntered) {
-                        <span class="warn"> &mdash; not all required attributes have values yet.</span>
-                    }
-                </p>
+    @if (workflow.NumberOfRequiredAttributes > 0) {
+        <p class="required-attrs">
+            Required attributes entered: <strong>{{ workflow.NumberRequiredAttributesEntered }}</strong> of <strong>{{ workflow.NumberOfRequiredAttributes }}</strong>
+            @if (!workflow.RequiredAttributesEntered) {
+                <span class="warn"> &mdash; not all required attributes have values yet.</span>
             }
-        </div>
-    </div>
+        </p>
+    }
 
     <div class="step-footer">
-        <button type="button" class="btn btn-link" (click)="skipInventoryAndContinue(workflow)">Skip to Assessment</button>
-        <button type="button" class="btn btn-primary" (click)="markInventoryUpdatedAndContinue(workflow)">Mark Inventory Updated &amp; Continue</button>
+        <button type="button" class="btn btn-primary" (click)="skipToAssessment(workflow)">
+            Skip to Assessment <i class="fa fa-forward ml-2"></i>
+        </button>
+        <button type="button" class="btn btn-primary" (click)="reviewInventory(workflow)">
+            Review Inventory <i class="fa fa-caret-right ml-2"></i>
+        </button>
     </div>
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-step/inventory-step.component.scss
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-step/inventory-step.component.scss
@@ -1,36 +1,5 @@
 @use "/src/scss/abstracts" as *;
 
-.inline-editor {
-    display: block !important;
-    padding: $spacing-400 0;
-    background: $gray-50;
-    margin: $spacing-200 calc(-1 * $spacing-400);
-    padding-left: $spacing-400;
-    padding-right: $spacing-400;
-}
-
-.inventory-actions {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-
-    li {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: $spacing-300 0;
-        border-bottom: 1px solid $gray-200;
-
-        &:last-child {
-            border-bottom: 0;
-        }
-    }
-
-    .action-label {
-        font-weight: 600;
-    }
-}
-
 .required-attrs {
     margin-top: $spacing-400;
     font-size: $type-size-200;
@@ -38,12 +7,4 @@
     .warn {
         color: $danger;
     }
-}
-
-.step-footer {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: $spacing-300;
-    margin-top: $spacing-500;
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-step/inventory-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-step/inventory-step.component.ts
@@ -3,83 +3,33 @@ import { Router } from "@angular/router";
 import { AsyncPipe } from "@angular/common";
 import { Observable } from "rxjs";
 
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
+
 import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visit-workflow-dto";
-import { FieldVisitService } from "src/app/shared/generated/api/field-visit.service";
-import { FieldVisitInventoryUpdatedDto } from "src/app/shared/generated/model/field-visit-inventory-updated-dto";
 
 import { FieldVisitWorkflowService } from "../../services/field-visit-workflow.service";
-import { AlertService } from "src/app/shared/services/alert.service";
-import { Alert } from "src/app/shared/models/alert";
-import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
-import { TreatmentBmpLocationEditorComponent } from "src/app/shared/components/treatment-bmp-editors/location-editor/treatment-bmp-location-editor.component";
-import { TreatmentBmpImagesEditorComponent } from "src/app/shared/components/treatment-bmp-editors/images-editor/treatment-bmp-images-editor.component";
-import { TreatmentBmpCustomAttributesFormComponent } from "src/app/shared/components/treatment-bmp-editors/custom-attributes-form/treatment-bmp-custom-attributes-form.component";
-import { CustomAttributeTypePurposeEnum } from "src/app/shared/generated/enum/custom-attribute-type-purpose-enum";
-
-type InventoryPanel = "location" | "photos" | "attributes" | null;
 
 @Component({
     selector: "field-visit-inventory-step",
     standalone: true,
-    imports: [AsyncPipe, TreatmentBmpLocationEditorComponent, TreatmentBmpImagesEditorComponent, TreatmentBmpCustomAttributesFormComponent],
+    imports: [AsyncPipe, PageHeaderComponent],
     templateUrl: "./inventory-step.component.html",
     styleUrl: "./inventory-step.component.scss",
 })
 export class FieldVisitInventoryStepComponent implements OnInit {
     public workflow$: Observable<FieldVisitWorkflowDto | null>;
-    /** Which inline editor panel is expanded. Null = collapsed list view. */
-    public activePanel: InventoryPanel = null;
 
-    public OtherDesignAttributesPurposeID = CustomAttributeTypePurposeEnum.OtherDesignAttributes;
-
-    constructor(
-        private workflowService: FieldVisitWorkflowService,
-        private fieldVisitService: FieldVisitService,
-        private alertService: AlertService,
-        private router: Router
-    ) {}
+    constructor(private workflowService: FieldVisitWorkflowService, private router: Router) {}
 
     ngOnInit(): void {
         this.workflow$ = this.workflowService.workflow$;
     }
 
-    expandPanel(panel: InventoryPanel): void {
-        this.activePanel = panel;
+    reviewInventory(workflow: FieldVisitWorkflowDto): void {
+        this.router.navigate(["/field-visits", workflow.FieldVisitID, "inventory", "location"]);
     }
 
-    collapsePanel(): void {
-        this.activePanel = null;
-    }
-
-    onLocationSaved(): void {
-        // Stay on the inventory step; collapse panel and refresh workflow header.
-        this.activePanel = null;
-        this.workflowService.refresh().subscribe();
-    }
-
-    onPhotosSaved(): void {
-        // Photos editor pushes its own success alert; just refresh and keep panel open
-        // so users can continue uploading or tweaking captions.
-        this.workflowService.refresh().subscribe();
-    }
-
-    onAttributesSaved(): void {
-        this.activePanel = null;
-        this.workflowService.refresh().subscribe();
-    }
-
-    markInventoryUpdatedAndContinue(workflow: FieldVisitWorkflowDto): void {
-        const dto = new FieldVisitInventoryUpdatedDto({ InventoryUpdated: true });
-        this.fieldVisitService.updateInventoryUpdatedFieldVisit(workflow.FieldVisitID, dto).subscribe(() => {
-            this.alertService.pushAlert(new Alert("Inventory updates confirmed.", AlertContext.Success));
-            this.workflowService.refresh().subscribe(() => {
-                this.router.navigate(["/field-visits", workflow.FieldVisitID, "assessment"]);
-            });
-        });
-    }
-
-    skipInventoryAndContinue(workflow: FieldVisitWorkflowDto): void {
-        // Skip is a navigation-only action; do not flip InventoryUpdated.
+    skipToAssessment(workflow: FieldVisitWorkflowDto): void {
         this.router.navigate(["/field-visits", workflow.FieldVisitID, "assessment"]);
     }
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.html
@@ -1,8 +1,8 @@
 @if (workflow$ | async; as workflow) {
-    <h2>Edit Maintenance Record</h2>
+    <page-header pageTitle="Edit Maintenance Record"></page-header>
     <p>Capture the maintenance type, a description of what was done, and observations for the applicable maintenance attributes.</p>
 
-    @if (isLoading) {
+    @if (isLoading()) {
         <div [loadingSpinner]="{ isLoading: true }"></div>
     } @else {
         <form [formGroup]="formGroup">
@@ -26,12 +26,12 @@
                 </div>
             </div>
 
-            @if (observationFields.length > 0) {
+            @if (observationFields().length > 0) {
                 <div class="card">
                     <div class="card-header"><span class="card-title">Observations</span></div>
                     <div class="card-body">
                         <div class="grid-12">
-                            @for (field of observationFields; track field.customAttributeTypeID) {
+                            @for (field of observationFields(); track field.customAttributeTypeID) {
                                 @switch (field.dataTypeKind) {
                                     @case ("integer") {
                                         <form-field
@@ -111,7 +111,9 @@
         <div class="step-footer">
             <button type="button" class="btn btn-danger" (click)="deleteRecord(workflow)">Delete Record</button>
             <span class="spacer"></span>
-            <button type="button" class="btn btn-primary" [disabled]="formGroup.invalid" (click)="save(workflow)">Save &amp; Continue</button>
+            <button type="button" class="btn btn-primary" [disabled]="formGroup.invalid" (click)="save(workflow)">
+                Save &amp; Continue <i class="fa fa-caret-right ml-2"></i>
+            </button>
         </div>
     }
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.scss
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.scss
@@ -31,17 +31,6 @@
     margin: 0 0 $spacing-300;
 }
 
-.step-footer {
-    display: flex;
-    align-items: center;
-    gap: $spacing-300;
-    margin-top: $spacing-500;
-
-    .spacer {
-        flex-grow: 1;
-    }
-}
-
 form-field {
     display: block;
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, signal } from "@angular/core";
 import { Router } from "@angular/router";
 import { AsyncPipe } from "@angular/common";
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
@@ -6,6 +6,7 @@ import { combineLatest, map, Observable, switchMap, take } from "rxjs";
 
 import { FormFieldComponent, FormFieldType, SelectDropdownOption } from "src/app/shared/components/forms/form-field/form-field.component";
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 
 import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visit-workflow-dto";
 import { MaintenanceRecordService } from "src/app/shared/generated/api/maintenance-record.service";
@@ -43,15 +44,17 @@ interface ObservationField {
 @Component({
     selector: "field-visit-maintenance-edit-step",
     standalone: true,
-    imports: [AsyncPipe, ReactiveFormsModule, FormFieldComponent, LoadingDirective],
+    imports: [AsyncPipe, ReactiveFormsModule, FormFieldComponent, LoadingDirective, PageHeaderComponent],
     templateUrl: "./maintenance-edit-step.component.html",
     styleUrl: "./maintenance-edit-step.component.scss",
 })
 export class FieldVisitMaintenanceEditStepComponent implements OnInit {
     public workflow$: Observable<FieldVisitWorkflowDto | null>;
-    public maintenanceRecord: MaintenanceRecordDetailDto | null = null;
-    public observationFields: ObservationField[] = [];
-    public isLoading = true;
+    // Signals — plain fields don't reliably trigger CD when mutated inside subscribe callbacks
+    // under zoneless behavior, leaving the spinner stuck until a stray click forces a render.
+    public maintenanceRecord = signal<MaintenanceRecordDetailDto | null>(null);
+    public observationFields = signal<ObservationField[]>([]);
+    public isLoading = signal(true);
     public FormFieldType = FormFieldType;
     public maintenanceRecordTypeOptions: SelectDropdownOption[] = MaintenanceRecordTypesAsSelectDropdownOptions;
 
@@ -87,7 +90,7 @@ export class FieldVisitMaintenanceEditStepComponent implements OnInit {
                 })
             )
             .subscribe(({ record, attributeTypes }) => {
-                this.maintenanceRecord = record;
+                this.maintenanceRecord.set(record);
                 this.formGroup.patchValue({
                     MaintenanceRecordTypeID: record?.MaintenanceRecordTypeID ?? null,
                     MaintenanceRecordDescription: record?.MaintenanceRecordDescription ?? "",
@@ -100,16 +103,17 @@ export class FieldVisitMaintenanceEditStepComponent implements OnInit {
                 const observationsGroup = this.formGroup.controls.Observations;
                 Object.keys(observationsGroup.controls).forEach((k) => observationsGroup.removeControl(k));
 
-                this.observationFields = maintenanceTypes
+                const fields = maintenanceTypes
                     .map((t) => this.buildObservationField(t, record))
                     .sort((a, b) => a.sortOrder - b.sortOrder);
+                this.observationFields.set(fields);
 
                 // Register each field's active control so formGroup.invalid reflects required observations.
-                for (const field of this.observationFields) {
+                for (const field of fields) {
                     const active = field.dataTypeKind === "multi-select" ? field.multiControl : field.control;
                     observationsGroup.addControl(`${field.customAttributeTypeID}`, active);
                 }
-                this.isLoading = false;
+                this.isLoading.set(false);
             });
     }
 
@@ -170,9 +174,10 @@ export class FieldVisitMaintenanceEditStepComponent implements OnInit {
     }
 
     save(workflow: FieldVisitWorkflowDto): void {
-        if (this.formGroup.invalid || !this.maintenanceRecord) return;
+        const record = this.maintenanceRecord();
+        if (this.formGroup.invalid || !record) return;
 
-        const observations: MaintenanceRecordObservationUpsertDto[] = this.observationFields
+        const observations: MaintenanceRecordObservationUpsertDto[] = this.observationFields()
             .map((field) => ({
                 CustomAttributeTypeID: field.customAttributeTypeID,
                 Values: this.collectFieldValues(field),
@@ -185,7 +190,7 @@ export class FieldVisitMaintenanceEditStepComponent implements OnInit {
             Observations: observations,
         });
 
-        this.maintenanceRecordService.updateMaintenanceRecord(this.maintenanceRecord.MaintenanceRecordID, dto).subscribe(() => {
+        this.maintenanceRecordService.updateMaintenanceRecord(record.MaintenanceRecordID, dto).subscribe(() => {
             this.alertService.pushAlert(new Alert("Maintenance Record saved.", AlertContext.Success));
             this.workflowService.refresh().subscribe(() => {
                 this.router.navigate(["/field-visits", workflow.FieldVisitID, "post-maintenance-assessment"]);
@@ -210,8 +215,9 @@ export class FieldVisitMaintenanceEditStepComponent implements OnInit {
     }
 
     deleteRecord(workflow: FieldVisitWorkflowDto): void {
-        if (!this.maintenanceRecord) return;
-        const recordID = this.maintenanceRecord.MaintenanceRecordID;
+        const record = this.maintenanceRecord();
+        if (!record) return;
+        const recordID = record.MaintenanceRecordID;
         this.confirmService
             .confirm({
                 title: "Delete Maintenance Record",

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-step/maintenance-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-step/maintenance-step.component.html
@@ -1,22 +1,24 @@
 @if (workflow$ | async; as workflow) {
-    <h2>Maintenance</h2>
+    <page-header pageTitle="Maintenance"></page-header>
 
-    @if (!workflow.MaintenanceRecordID) {
-        <p>Did maintenance occur during this Field Visit? Begin a Maintenance Record to capture what was done, or skip to the post-maintenance assessment.</p>
-        <div class="step-footer">
-            <button type="button" class="btn btn-link" (click)="skipToPostMaintenanceAssessment(workflow)">Skip to Post-Maintenance Assessment</button>
-            <button type="button" class="btn btn-primary" (click)="beginMaintenance(workflow)">Begin Maintenance Record</button>
-        </div>
-    } @else {
-        <div class="card">
-            <div class="card-header"><span class="card-title">Maintenance Record</span></div>
-            <div class="card-body">
-                <p>A maintenance record exists for this visit. Open it to record observations and details.</p>
-            </div>
-        </div>
-        <div class="step-footer">
-            <button type="button" class="btn btn-link" (click)="skipToPostMaintenanceAssessment(workflow)">Skip to Post-Maintenance Assessment</button>
-            <button type="button" class="btn btn-primary" (click)="editMaintenance(workflow)">Edit Maintenance Record</button>
-        </div>
-    }
+    <p>The maintenance workflow allows input of observations to quantify the type and amount of maintenance performed.</p>
+    <p>
+        Some observations are required for the Maintenance Record to be considered complete. The required observations are marked with a
+        <span class="required-asterisk">*</span> on the form.
+    </p>
+
+    <div class="step-footer">
+        <button type="button" class="btn btn-primary" (click)="skipToPostMaintenanceAssessment(workflow)">
+            Skip to Post-Maintenance Assessment <i class="fa fa-forward ml-2"></i>
+        </button>
+        @if (!workflow.MaintenanceRecordID) {
+            <button type="button" class="btn btn-primary" (click)="beginMaintenance(workflow)">
+                Create Maintenance Record <i class="fa fa-caret-right ml-2"></i>
+            </button>
+        } @else {
+            <button type="button" class="btn btn-primary" (click)="editMaintenance(workflow)">
+                Edit Maintenance Record <i class="fa fa-caret-right ml-2"></i>
+            </button>
+        }
+    </div>
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-step/maintenance-step.component.scss
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-step/maintenance-step.component.scss
@@ -1,9 +1,6 @@
 @use "/src/scss/abstracts" as *;
 
-.step-footer {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: $spacing-300;
-    margin-top: $spacing-500;
+.required-asterisk {
+    color: $red-default;
+    font-weight: bold;
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-step/maintenance-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-step/maintenance-step.component.ts
@@ -5,6 +5,7 @@ import { Observable } from "rxjs";
 
 import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visit-workflow-dto";
 import { MaintenanceRecordService } from "src/app/shared/generated/api/maintenance-record.service";
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 
 import { FieldVisitWorkflowService } from "../../services/field-visit-workflow.service";
 import { AlertService } from "src/app/shared/services/alert.service";
@@ -14,7 +15,7 @@ import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 @Component({
     selector: "field-visit-maintenance-step",
     standalone: true,
-    imports: [AsyncPipe],
+    imports: [AsyncPipe, PageHeaderComponent],
     templateUrl: "./maintenance-step.component.html",
     styleUrl: "./maintenance-step.component.scss",
 })

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component.html
@@ -1,16 +1,16 @@
 @if (workflow$ | async; as workflow) {
-    <h2>{{ headerLabel }}</h2>
+    <page-header pageTitle="Observations"></page-header>
 
-    @if (isLoading) {
+    @if (isLoading()) {
         <div [loadingSpinner]="{ isLoading: true }"></div>
-    } @else if (!assessment) {
+    } @else if (!assessment()) {
         <p>No assessment exists yet for this field visit. Return to the Assessment landing page to begin one.</p>
-    } @else {
-        @if (panels.length === 0) {
+    } @else if (assessment(); as assessmentDetail) {
+        @if (panels().length === 0) {
             <p>No observation types are configured for this BMP type.</p>
         }
 
-        @if (isPostMaintenance && assessment.ObservationTypes.length > 0) {
+        @if (isPostMaintenance && assessmentDetail.ObservationTypes.length > 0) {
             <div class="copy-from-initial">
                 <button type="button" class="btn btn-secondary" (click)="copyFromInitial(workflow)">
                     Copy data from Initial Assessment
@@ -18,7 +18,7 @@
             </div>
         }
 
-        @for (panel of panels; track panel.observationTypeID) {
+        @for (panel of panels(); track panel.observationTypeID) {
             <div class="card observation-panel">
                 <div class="card-header"><span class="card-title">{{ panel.name }}</span></div>
                 <div class="card-body">
@@ -38,61 +38,50 @@
                         </dl>
                     }
 
-                    <div class="property-rows">
-                        @for (property of panel.properties; track property.propertyObserved) {
-                            <div class="property-row grid-12">
-                                <label class="property-label g-col-12 g-col-md-3">{{ property.propertyObserved }}</label>
-
-                                @switch (panel.collectionMethod) {
-                                    @case ("DiscreteValue") {
-                                        <div class="value-input g-col-12 g-col-md-3">
-                                            <input
-                                                type="number"
-                                                class="form-control"
-                                                [formControl]="property.valueControl"
-                                                [attr.min]="panel.minValue ?? null"
-                                                [attr.max]="panel.maxValue ?? null"
-                                                [placeholder]="panel.measurementUnitLabel || 'value'" />
-                                            @if (panel.measurementUnitLabel) {
-                                                <span class="unit-suffix">{{ panel.measurementUnitLabel }}</span>
-                                            }
-                                        </div>
-                                    }
-                                    @case ("PassFail") {
-                                        <div class="value-input g-col-12 g-col-md-3">
-                                            <select class="form-control" [formControl]="property.valueControl">
-                                                <option [ngValue]="null">— select —</option>
-                                                @for (opt of property.passFailOptions; track opt.Value) {
-                                                    <option [value]="opt.Value">{{ opt.Label }}</option>
-                                                }
-                                            </select>
-                                        </div>
-                                    }
-                                    @case ("Percentage") {
-                                        <div class="value-input g-col-12 g-col-md-3">
-                                            <input
-                                                type="number"
-                                                class="form-control"
-                                                [formControl]="property.valueControl"
-                                                min="0"
-                                                max="100"
-                                                placeholder="0–100" />
-                                            <span class="unit-suffix">%</span>
-                                        </div>
-                                    }
-                                    @default {
-                                        <div class="value-input g-col-12 g-col-md-3">
-                                            <input type="text" class="form-control" [formControl]="property.valueControl" />
-                                        </div>
-                                    }
+                    @for (property of panel.properties; track property.propertyObserved) {
+                        <div class="grid-12 property-row">
+                            @switch (panel.collectionMethod) {
+                                @case ("DiscreteValue") {
+                                    <form-field
+                                        class="g-col-12 g-col-md-6"
+                                        [formControl]="property.valueControl"
+                                        [fieldLabel]="property.propertyObserved"
+                                        [type]="FormFieldType.Number"
+                                        [units]="panel.measurementUnitLabel || ''"></form-field>
                                 }
-
-                                <div class="notes-input g-col-12 g-col-md-6">
-                                    <input type="text" class="form-control" [formControl]="property.notesControl" placeholder="Notes (optional)" />
-                                </div>
-                            </div>
-                        }
-                    </div>
+                                @case ("PassFail") {
+                                    <form-field
+                                        class="g-col-12 g-col-md-6"
+                                        [formControl]="property.valueControl"
+                                        [fieldLabel]="property.propertyObserved"
+                                        [type]="FormFieldType.Select"
+                                        [formInputOptions]="property.passFailOptions || []"
+                                        placeholder="— select —"></form-field>
+                                }
+                                @case ("Percentage") {
+                                    <form-field
+                                        class="g-col-12 g-col-md-6"
+                                        [formControl]="property.valueControl"
+                                        [fieldLabel]="property.propertyObserved"
+                                        [type]="FormFieldType.Number"
+                                        units="%"></form-field>
+                                }
+                                @default {
+                                    <form-field
+                                        class="g-col-12 g-col-md-6"
+                                        [formControl]="property.valueControl"
+                                        [fieldLabel]="property.propertyObserved"
+                                        [type]="FormFieldType.Text"></form-field>
+                                }
+                            }
+                            <form-field
+                                class="g-col-12 g-col-md-6"
+                                [formControl]="property.notesControl"
+                                fieldLabel="Notes"
+                                [type]="FormFieldType.Text"
+                                placeholder="Optional"></form-field>
+                        </div>
+                    }
                 </div>
             </div>
         }
@@ -100,7 +89,7 @@
         <div class="step-footer">
             <button type="button" class="btn btn-secondary" (click)="save(workflow, false)">Save</button>
             <button type="button" class="btn btn-primary" (click)="save(workflow, true)">
-                Save &amp; Continue
+                Save &amp; Continue <i class="fa fa-caret-right ml-2"></i>
             </button>
         </div>
     }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component.scss
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component.scss
@@ -36,35 +36,14 @@
     }
 }
 
-.property-rows {
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-300;
-}
-
 .property-row {
-    align-items: center;
+    margin-bottom: $spacing-300;
 
-    .property-label {
-        font-weight: 600;
+    &:last-child {
+        margin-bottom: 0;
     }
 
-    .value-input {
-        display: flex;
-        align-items: center;
-        gap: $spacing-200;
-
-        .unit-suffix {
-            color: $gray-600;
-            font-size: $type-size-200;
-        }
+    form-field {
+        display: block;
     }
-}
-
-.step-footer {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: $spacing-300;
-    margin-top: $spacing-500;
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component.ts
@@ -1,11 +1,12 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, Input, OnInit, signal } from "@angular/core";
 import { Router } from "@angular/router";
 import { AsyncPipe } from "@angular/common";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { Observable, of, switchMap, take } from "rxjs";
 
-import { FormFieldType, SelectDropdownOption } from "src/app/shared/components/forms/form-field/form-field.component";
+import { FormFieldComponent, FormFieldType, SelectDropdownOption } from "src/app/shared/components/forms/form-field/form-field.component";
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 
 import { TreatmentBMPAssessmentByFieldVisitService } from "src/app/shared/generated/api/treatment-bmp-assessment-by-field-visit.service";
 import { TreatmentBMPAssessmentService } from "src/app/shared/generated/api/treatment-bmp-assessment.service";
@@ -61,7 +62,7 @@ interface ObservationTypePanel {
 @Component({
     selector: "field-visit-observations-step",
     standalone: true,
-    imports: [AsyncPipe, ReactiveFormsModule, LoadingDirective],
+    imports: [AsyncPipe, ReactiveFormsModule, LoadingDirective, PageHeaderComponent, FormFieldComponent],
     templateUrl: "./observations-step.component.html",
     styleUrl: "./observations-step.component.scss",
 })
@@ -70,9 +71,11 @@ export class FieldVisitObservationsStepComponent implements OnInit {
     @Input() assessmentTypeID: number = 1;
 
     public workflow$: Observable<FieldVisitWorkflowDto | null>;
-    public assessment: TreatmentBMPAssessmentDetailDto | null = null;
-    public panels: ObservationTypePanel[] = [];
-    public isLoading = true;
+    // Signals — plain fields don't reliably trigger CD when mutated inside subscribe callbacks
+    // under zoneless behavior, leaving the spinner stuck until a stray click forces a render.
+    public assessment = signal<TreatmentBMPAssessmentDetailDto | null>(null);
+    public panels = signal<ObservationTypePanel[]>([]);
+    public isLoading = signal(true);
     public FormFieldType = FormFieldType;
 
     constructor(
@@ -89,7 +92,9 @@ export class FieldVisitObservationsStepComponent implements OnInit {
     }
 
     public get headerLabel(): string {
-        return this.isPostMaintenance ? "Post-Maintenance Assessment Observations" : "Initial Assessment Observations";
+        // Single-word page title — the sidebar already says which assessment is active,
+        // so no need to repeat "Initial / Post-Maintenance Assessment" in the page header.
+        return "Observations";
     }
 
     ngOnInit(): void {
@@ -103,11 +108,13 @@ export class FieldVisitObservationsStepComponent implements OnInit {
                 })
             )
             .subscribe((assessment) => {
-                this.assessment = assessment;
-                this.panels = (assessment?.ObservationTypes ?? [])
-                    .map((t) => this.buildPanel(t, assessment?.Observations ?? []))
-                    .filter((p): p is ObservationTypePanel => p != null);
-                this.isLoading = false;
+                this.assessment.set(assessment);
+                this.panels.set(
+                    (assessment?.ObservationTypes ?? [])
+                        .map((t) => this.buildPanel(t, assessment?.Observations ?? []))
+                        .filter((p): p is ObservationTypePanel => p != null)
+                );
+                this.isLoading.set(false);
             });
     }
 
@@ -184,9 +191,10 @@ export class FieldVisitObservationsStepComponent implements OnInit {
     }
 
     save(workflow: FieldVisitWorkflowDto, andContinue: boolean): void {
-        if (!this.assessment) return;
+        const assessment = this.assessment();
+        if (!assessment) return;
 
-        const observations = this.panels.map((panel) => {
+        const observations = this.panels().map((panel) => {
             const observationData = JSON.stringify({
                 SingleValueObservations: panel.properties.map((p) => ({
                     PropertyObserved: p.propertyObserved,
@@ -202,7 +210,7 @@ export class FieldVisitObservationsStepComponent implements OnInit {
 
         const dto = new TreatmentBMPAssessmentUpsertDto({ Observations: observations });
 
-        this.assessmentService.upsertObservationsTreatmentBMPAssessment(this.assessment.TreatmentBMPAssessmentID, dto).subscribe(() => {
+        this.assessmentService.upsertObservationsTreatmentBMPAssessment(assessment.TreatmentBMPAssessmentID, dto).subscribe(() => {
             this.alertService.pushAlert(new Alert("Observations saved.", AlertContext.Success));
             this.workflowService.refresh().subscribe(() => {
                 if (andContinue) {
@@ -228,7 +236,8 @@ export class FieldVisitObservationsStepComponent implements OnInit {
     }
 
     copyFromInitial(workflow: FieldVisitWorkflowDto): void {
-        if (!this.assessment) return;
+        const assessment = this.assessment();
+        if (!assessment) return;
         this.confirmService
             .confirm({
                 title: "Copy data from Initial Assessment?",
@@ -239,11 +248,13 @@ export class FieldVisitObservationsStepComponent implements OnInit {
             })
             .then((confirmed) => {
                 if (!confirmed) return;
-                this.assessmentService.copyFromInitialTreatmentBMPAssessment(this.assessment!.TreatmentBMPAssessmentID).subscribe((updated) => {
-                    this.assessment = updated;
-                    this.panels = (updated?.ObservationTypes ?? [])
-                        .map((t) => this.buildPanel(t, updated?.Observations ?? []))
-                        .filter((p): p is ObservationTypePanel => p != null);
+                this.assessmentService.copyFromInitialTreatmentBMPAssessment(assessment.TreatmentBMPAssessmentID).subscribe((updated) => {
+                    this.assessment.set(updated);
+                    this.panels.set(
+                        (updated?.ObservationTypes ?? [])
+                            .map((t) => this.buildPanel(t, updated?.Observations ?? []))
+                            .filter((p): p is ObservationTypePanel => p != null)
+                    );
                     this.alertService.pushAlert(new Alert("Copied observations from Initial Assessment.", AlertContext.Success));
                     this.workflowService.refresh().subscribe();
                 });

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, signal } from "@angular/core";
 import { Router } from "@angular/router";
 import { AsyncPipe } from "@angular/common";
-import { FormControl, ReactiveFormsModule } from "@angular/forms";
+import { FormControl, ReactiveFormsModule, ValidatorFn, Validators } from "@angular/forms";
 import { Observable, of, switchMap, take } from "rxjs";
 
 import { FormFieldComponent, FormFieldType, SelectDropdownOption } from "src/app/shared/components/forms/form-field/form-field.component";
@@ -141,13 +141,20 @@ export class FieldVisitObservationsStepComponent implements OnInit {
                   ]
                 : undefined;
 
+        const minValue = schemaObj?.MinimumValueOfObservations;
+        const maxValue = schemaObj?.MaximumValueOfObservations;
+        // Range validators replace the previous DOM-level min/max attrs (lost when we migrated to
+        // <form-field>, which doesn't surface min/max on the underlying number input). Validation
+        // now lives on the FormControl so formGroup.invalid + Save-button state reflect it.
+        const valueValidators = this.buildValueValidators(collectionMethod, minValue, maxValue);
+
         return {
             observationTypeID: typeForForm.TreatmentBMPAssessmentObservationTypeID,
             name: typeForForm.TreatmentBMPAssessmentObservationTypeName,
             collectionMethod,
             measurementUnitLabel: schemaObj?.MeasurementUnitLabel,
-            minValue: schemaObj?.MinimumValueOfObservations,
-            maxValue: schemaObj?.MaximumValueOfObservations,
+            minValue,
+            maxValue,
             assessmentDescription: schemaObj?.AssessmentDescription,
             benchmarkDescription: schemaObj?.BenchmarkDescription,
             thresholdDescription: schemaObj?.ThresholdDescription,
@@ -157,12 +164,25 @@ export class FieldVisitObservationsStepComponent implements OnInit {
                 const existing = existingValues.find((v) => v.PropertyObserved === prop);
                 return {
                     propertyObserved: prop,
-                    valueControl: new FormControl<string | null>(this.formatExisting(existing?.ObservationValue), { validators: [] }),
+                    valueControl: new FormControl<string | null>(this.formatExisting(existing?.ObservationValue), { validators: valueValidators }),
                     notesControl: new FormControl<string | null>(existing?.Notes ?? ""),
                     passFailOptions,
                 };
             }),
         };
+    }
+
+    private buildValueValidators(collectionMethod: string, minValue: number | undefined, maxValue: number | undefined): ValidatorFn[] {
+        if (collectionMethod === "Percentage") {
+            return [Validators.min(0), Validators.max(100)];
+        }
+        if (collectionMethod === "DiscreteValue") {
+            const validators: ValidatorFn[] = [];
+            if (typeof minValue === "number") validators.push(Validators.min(minValue));
+            if (typeof maxValue === "number") validators.push(Validators.max(maxValue));
+            return validators;
+        }
+        return [];
     }
 
     private parseSchema(schemaJson: string | null | undefined): any {
@@ -193,6 +213,20 @@ export class FieldVisitObservationsStepComponent implements OnInit {
     save(workflow: FieldVisitWorkflowDto, andContinue: boolean): void {
         const assessment = this.assessment();
         if (!assessment) return;
+
+        // Touch every value control so out-of-range / range-validator errors surface in form-field
+        // before we bail out. Notes have no validators, so no need to touch them.
+        let hasInvalid = false;
+        for (const panel of this.panels()) {
+            for (const prop of panel.properties) {
+                prop.valueControl.markAsTouched();
+                if (prop.valueControl.invalid) hasInvalid = true;
+            }
+        }
+        if (hasInvalid) {
+            this.alertService.pushAlert(new Alert("One or more observations are out of range. Please review and correct before saving.", AlertContext.Danger));
+            return;
+        }
 
         const observations = this.panels().map((panel) => {
             const observationData = JSON.stringify({

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/visit-summary-step/visit-summary-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/visit-summary-step/visit-summary-step.component.html
@@ -1,34 +1,34 @@
 @if (workflow$ | async; as workflow) {
-    <h2>Visit Summary</h2>
+    <page-header pageTitle="Visit Summary"></page-header>
 
     <div class="card">
         <div class="card-header"><span class="card-title">Visit Details</span></div>
-        <div class="card-body grid-12">
-            <dl class="g-col-12 g-col-md-6">
-                <dt>Visit Date</dt>
-                <dd>{{ workflow.VisitDate | date: "MM/dd/yyyy" }}</dd>
-                <dt>Visit Type</dt>
-                <dd>{{ workflow.FieldVisitTypeDisplayName }}</dd>
-                <dt>Performed By</dt>
-                <dd>{{ workflow.PerformedByPersonName }}</dd>
-            </dl>
-            <dl class="g-col-12 g-col-md-6">
-                <dt>Status</dt>
-                <dd>{{ workflow.FieldVisitStatusDisplayName }}</dd>
-                <dt>Verified</dt>
-                <dd>{{ workflow.IsFieldVisitVerified ? "Yes" : "No" }}</dd>
-                <dt>Inventory Updated</dt>
-                <dd>{{ workflow.InventoryUpdated ? "Yes" : "No" }}</dd>
+        <div class="card-body">
+            <dl class="grid-12">
+                <dt class="g-col-3">Visit Date</dt>
+                <dd class="g-col-3">{{ workflow.VisitDate | date: "MM/dd/yyyy" }}</dd>
+                <dt class="g-col-3">Status</dt>
+                <dd class="g-col-3">{{ workflow.FieldVisitStatusDisplayName }}</dd>
+
+                <dt class="g-col-3">Visit Type</dt>
+                <dd class="g-col-3">{{ workflow.FieldVisitTypeDisplayName }}</dd>
+                <dt class="g-col-3">Verified</dt>
+                <dd class="g-col-3">{{ workflow.IsFieldVisitVerified ? "Yes" : "No" }}</dd>
+
+                <dt class="g-col-3">Performed By</dt>
+                <dd class="g-col-3">{{ workflow.PerformedByPersonName }}</dd>
+                <dt class="g-col-3">Inventory Updated</dt>
+                <dd class="g-col-3">{{ workflow.InventoryUpdated ? "Yes" : "No" }}</dd>
             </dl>
         </div>
     </div>
 
-    <div class="card">
+    <div class="card mt-3">
         <div class="card-header"><span class="card-title">Assessments &amp; Maintenance</span></div>
-        <div class="card-body grid-12">
-            <dl class="g-col-12 g-col-md-6">
-                <dt>Initial Assessment</dt>
-                <dd>
+        <div class="card-body">
+            <dl class="grid-12">
+                <dt class="g-col-3">Initial Assessment</dt>
+                <dd class="g-col-9">
                     @if (workflow.InitialAssessmentID) {
                         {{ workflow.InitialAssessmentComplete ? "Complete" : "In Progress" }}
                         @if (workflow.InitialAssessmentScore != null) {
@@ -38,12 +38,12 @@
                         Not Performed
                     }
                 </dd>
-                <dt>Maintenance</dt>
-                <dd>{{ workflow.MaintenanceRecordID ? "Performed" : "Not Performed" }}</dd>
-            </dl>
-            <dl class="g-col-12 g-col-md-6">
-                <dt>Post-Maintenance Assessment</dt>
-                <dd>
+
+                <dt class="g-col-3">Maintenance</dt>
+                <dd class="g-col-9">{{ workflow.MaintenanceRecordID ? "Performed" : "Not Performed" }}</dd>
+
+                <dt class="g-col-3">Post-Maintenance Assessment</dt>
+                <dd class="g-col-9">
                     @if (workflow.PostMaintenanceAssessmentID) {
                         {{ workflow.PostMaintenanceAssessmentComplete ? "Complete" : "In Progress" }}
                         @if (workflow.PostMaintenanceAssessmentScore != null) {
@@ -57,11 +57,8 @@
         </div>
     </div>
 
-    <div class="step-footer">
-        <button type="button" class="btn btn-danger" (click)="deleteVisit(workflow)">Delete Visit</button>
-        <span class="spacer"></span>
-
-        @if (canManage) {
+    @if (canManage) {
+        <div class="step-footer">
             @if (workflow.IsFieldVisitVerified) {
                 <button type="button" class="btn btn-secondary" (click)="markProvisional(workflow)">Mark Provisional</button>
                 <button type="button" class="btn btn-secondary" (click)="returnToEdit(workflow)">Return to Edit</button>
@@ -69,6 +66,6 @@
                 <button type="button" class="btn btn-secondary" (click)="finalize(workflow)">Mark Complete</button>
                 <button type="button" class="btn btn-primary" (click)="verify(workflow)">Verify Field Visit</button>
             }
-        }
-    </div>
+        </div>
+    }
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/visit-summary-step/visit-summary-step.component.scss
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/visit-summary-step/visit-summary-step.component.scss
@@ -4,30 +4,18 @@
     margin-top: $spacing-400;
 }
 
-dl {
+// Browser default `dd { margin-left: 40px }` and the global `dt { padding-bottom: 0.5rem }`
+// both throw off the grid-row alignment. Zero them out so each dt/dd pair sits flush on the same baseline.
+dl.grid-12 {
     margin: 0;
+    row-gap: $spacing-300;
 
     dt {
-        font-weight: 600;
-        margin-top: $spacing-200;
-
-        &:first-child {
-            margin-top: 0;
-        }
+        padding-bottom: 0;
     }
 
     dd {
         margin-left: 0;
-    }
-}
-
-.step-footer {
-    display: flex;
-    align-items: center;
-    gap: $spacing-300;
-    margin-top: $spacing-500;
-
-    .spacer {
-        flex-grow: 1;
+        margin-bottom: 0;
     }
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/visit-summary-step/visit-summary-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/visit-summary-step/visit-summary-step.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from "@angular/core";
-import { Router } from "@angular/router";
 import { AsyncPipe, DatePipe, DecimalPipe } from "@angular/common";
 import { Observable } from "rxjs";
 
@@ -8,15 +7,15 @@ import { FieldVisitService } from "src/app/shared/generated/api/field-visit.serv
 
 import { FieldVisitWorkflowService } from "../../services/field-visit-workflow.service";
 import { AlertService } from "src/app/shared/services/alert.service";
-import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
 import { Alert } from "src/app/shared/models/alert";
 import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 import { AuthenticationService } from "src/app/services/authentication.service";
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 
 @Component({
     selector: "field-visit-visit-summary-step",
     standalone: true,
-    imports: [AsyncPipe, DatePipe, DecimalPipe],
+    imports: [AsyncPipe, DatePipe, DecimalPipe, PageHeaderComponent],
     templateUrl: "./visit-summary-step.component.html",
     styleUrl: "./visit-summary-step.component.scss",
 })
@@ -28,9 +27,7 @@ export class FieldVisitVisitSummaryStepComponent implements OnInit {
         private workflowService: FieldVisitWorkflowService,
         private fieldVisitService: FieldVisitService,
         private alertService: AlertService,
-        private confirmService: ConfirmService,
-        private authenticationService: AuthenticationService,
-        private router: Router
+        private authenticationService: AuthenticationService
     ) {}
 
     ngOnInit(): void {
@@ -66,22 +63,4 @@ export class FieldVisitVisitSummaryStepComponent implements OnInit {
         });
     }
 
-    deleteVisit(workflow: FieldVisitWorkflowDto): void {
-        this.confirmService
-            .confirm({
-                title: "Delete Field Visit",
-                message:
-                    "Are you sure you want to delete this Field Visit? This will remove the visit, all assessments, and the maintenance record.",
-                buttonClassYes: "btn btn-danger",
-                buttonTextYes: "Delete",
-                buttonTextNo: "Cancel",
-            })
-            .then((confirmed) => {
-                if (!confirmed) return;
-                this.fieldVisitService.deleteFieldVisit(workflow.FieldVisitID).subscribe(() => {
-                    this.alertService.pushAlert(new Alert("Field Visit deleted.", AlertContext.Success));
-                    this.router.navigate(["/treatment-bmps", workflow.TreatmentBMPID]);
-                });
-            });
-    }
 }

--- a/Neptune.Web/src/app/pages/field-visits/services/field-visit-workflow.service.ts
+++ b/Neptune.Web/src/app/pages/field-visits/services/field-visit-workflow.service.ts
@@ -37,8 +37,15 @@ export class FieldVisitWorkflowService {
      * Flip InventoryUpdated=true on the field visit (server-side) and refresh the local workflow signal.
      * Used by every Inventory sub-step (Location / Photos / Attributes) on save so the Inventory parent
      * nav-item gets its green check, matching legacy MVC behavior where any sub-step submit set the flag.
+     *
+     * Short-circuits when the flag is already true — avoids redundant round-trips on every photo
+     * upload/delete during a single visit (the photos sub-step calls this on each persistence event).
      */
     public markInventoryUpdatedAndRefresh(fieldVisitID: number): Observable<FieldVisitWorkflowDto | null> {
+        const current = this.workflowSubject.value;
+        if (current?.InventoryUpdated) {
+            return of(current);
+        }
         const dto = new FieldVisitInventoryUpdatedDto({ InventoryUpdated: true });
         return this.fieldVisitService.updateInventoryUpdatedFieldVisit(fieldVisitID, dto).pipe(switchMap(() => this.refresh()));
     }

--- a/Neptune.Web/src/app/pages/field-visits/services/field-visit-workflow.service.ts
+++ b/Neptune.Web/src/app/pages/field-visits/services/field-visit-workflow.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from "@angular/core";
-import { BehaviorSubject, Observable, of } from "rxjs";
+import { BehaviorSubject, Observable, of, switchMap } from "rxjs";
 import { tap } from "rxjs/operators";
 
 import { FieldVisitService } from "src/app/shared/generated/api/field-visit.service";
 import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visit-workflow-dto";
+import { FieldVisitInventoryUpdatedDto } from "src/app/shared/generated/model/field-visit-inventory-updated-dto";
 
 @Injectable({ providedIn: "root" })
 export class FieldVisitWorkflowService {
@@ -30,5 +31,15 @@ export class FieldVisitWorkflowService {
 
     public getCurrent(): FieldVisitWorkflowDto | null {
         return this.workflowSubject.value;
+    }
+
+    /**
+     * Flip InventoryUpdated=true on the field visit (server-side) and refresh the local workflow signal.
+     * Used by every Inventory sub-step (Location / Photos / Attributes) on save so the Inventory parent
+     * nav-item gets its green check, matching legacy MVC behavior where any sub-step submit set the flag.
+     */
+    public markInventoryUpdatedAndRefresh(fieldVisitID: number): Observable<FieldVisitWorkflowDto | null> {
+        const dto = new FieldVisitInventoryUpdatedDto({ InventoryUpdated: true });
+        return this.fieldVisitService.updateInventoryUpdatedFieldVisit(fieldVisitID, dto).pipe(switchMap(() => this.refresh()));
     }
 }

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.html
@@ -406,9 +406,7 @@
             <div class="card-header">
                 <span class="card-title">Field Visits</span>
                 @if (currentPersonCanManage) {
-                    <span class="card-actions">
-                        <button class="btn btn-primary" (click)="openBeginFieldVisitModal()"><span class="icon-plus"></span> Begin Field Visit</button>
-                    </span>
+                    <button class="btn btn-white-outline btn-sm" (click)="openBeginFieldVisitModal()"><i class="fa fa-plus"></i> Begin Field Visit</button>
                 }
             </div>
             <div class="card-body">
@@ -425,12 +423,10 @@
 
         <!-- Funding Events -->
         <div class="card g-col-6 mt-3">
-            <div class="card-header d-flex justify-content-between align-items-center">
+            <div class="card-header">
                 <span class="card-title">Funding Events</span>
                 @if (currentPersonCanManage) {
-                    <span class="card-actions">
-                        <button class="btn btn-primary" (click)="openAddFundingEventModal()"><span class="icon-plus"></span> Add Funding Event</button>
-                    </span>
+                    <button class="btn btn-white-outline btn-sm" (click)="openAddFundingEventModal()"><i class="fa fa-plus"></i> Add Funding Event</button>
                 }
             </div>
             <div class="card-body">
@@ -535,9 +531,7 @@
                 <div class="card-header">
                     <span class="card-title">Documents</span>
                     @if (currentPersonCanManage) {
-                        <span class="card-actions">
-                            <button class="btn btn-primary" (click)="openDocumentUploadModal()"><span class="icon-plus"></span> Upload Document</button>
-                        </span>
+                        <button class="btn btn-white-outline btn-sm" (click)="openDocumentUploadModal()"><i class="fa fa-plus"></i> Upload Document</button>
                     }
                 </div>
                 <div class="card-body">

--- a/Neptune.Web/src/app/shared/components/treatment-bmp-editors/images-editor/treatment-bmp-images-editor.component.ts
+++ b/Neptune.Web/src/app/shared/components/treatment-bmp-editors/images-editor/treatment-bmp-images-editor.component.ts
@@ -32,6 +32,10 @@ export class TreatmentBmpImagesEditorComponent implements OnInit {
 
     @Output() saved = new EventEmitter<void>();
     @Output() cancelled = new EventEmitter<void>();
+    /** Fired after a successful image upload — distinct from `(saved)` (caption save click). */
+    @Output() uploaded = new EventEmitter<void>();
+    /** Fired after a successful image delete — distinct from `(saved)` (caption save click). */
+    @Output() deleted = new EventEmitter<void>();
 
     public treatmentBMPImages$!: Observable<TreatmentBMPImageDto[]>;
     public reloadTrigger$ = new BehaviorSubject<void>(undefined);
@@ -66,6 +70,7 @@ export class TreatmentBmpImagesEditorComponent implements OnInit {
                 this.reloadTrigger$.next();
                 this.alertService.pushAlert(new Alert("Image added successfully.", AlertContext.Success));
                 this.isLoadingSubmit = false;
+                this.uploaded.emit();
             },
             error: () => (this.isLoadingSubmit = false),
         });
@@ -78,6 +83,7 @@ export class TreatmentBmpImagesEditorComponent implements OnInit {
                 this.reloadTrigger$.next();
                 this.alertService.pushAlert(new Alert("Image deleted successfully.", AlertContext.Success));
                 this.isLoadingSubmit = false;
+                this.deleted.emit();
             },
             error: () => (this.isLoadingSubmit = false),
         });

--- a/Neptune.Web/src/app/shared/components/workflow-nav/workflow-nav-item/workflow-nav-item.component.html
+++ b/Neptune.Web/src/app/shared/components/workflow-nav/workflow-nav-item/workflow-nav-item.component.html
@@ -1,24 +1,34 @@
-<li class="sidebar-item workflow-sidebar-item">
-  <a [routerLink]="navRouterLink" routerLinkActive="active" class="sidebar-link" [class.disabled]="disabled">
-    <div>
-      @switch (required) {
-        @case (true) {
-          @switch (complete) {
-            @case (true) {
-              <icon class="complete" icon="StepComplete"></icon>
+<li class="sidebar-item workflow-sidebar-item" [class.has-sub-nav]="hasSubNav">
+    <a
+        [routerLink]="navRouterLink"
+        routerLinkActive="active"
+        (isActiveChange)="onIsActiveChange($event)"
+        class="sidebar-link"
+        [class.disabled]="disabled">
+        <div>
+            @switch (required) {
+                @case (true) {
+                    @switch (complete) {
+                        @case (true) {
+                            <icon class="complete" icon="StepComplete"></icon>
+                        }
+                        @default {
+                            <icon class="fade" icon="StepIncomplete"></icon>
+                        }
+                    }
+                }
+                @case (false) {
+                    <icon class="info" icon="Info"></icon>
+                }
             }
-            @default {
-              <icon class="fade" icon="StepIncomplete"></icon>
-            }
-          }
-        }
-        @case (false) {
-          <icon class="info" icon="Info"></icon>
-        }
-      }
-    </div>
-    <div>
-      <ng-content></ng-content>
-    </div>
-  </a>
+        </div>
+        <div>
+            <ng-content></ng-content>
+        </div>
+    </a>
+    @if (hasSubNav && isActive) {
+        <ul class="sidebar-sub-nav">
+            <ng-content select="[subnav]"></ng-content>
+        </ul>
+    }
 </li>

--- a/Neptune.Web/src/app/shared/components/workflow-nav/workflow-nav-item/workflow-nav-item.component.ts
+++ b/Neptune.Web/src/app/shared/components/workflow-nav/workflow-nav-item/workflow-nav-item.component.ts
@@ -8,13 +8,19 @@ import { RouterLink, RouterLinkActive } from "@angular/router";
     standalone: true,
     imports: [IconComponent, RouterLink, RouterLinkActive],
     templateUrl: "./workflow-nav-item.component.html",
-    styleUrls: ["./workflow-nav-item.component.scss"]
+    styleUrls: ["./workflow-nav-item.component.scss"],
 })
 export class WorkflowNavItemComponent {
     @Input() navRouterLink: string | string[];
     @Input() complete: boolean = false;
     @Input() disabled: boolean = false;
     @Input() required: boolean = true;
+    /** When true, render the projected sub-nav slot whenever the parent route is active. */
+    @Input() hasSubNav: boolean = false;
 
-    constructor() {}
+    public isActive: boolean = false;
+
+    onIsActiveChange(active: boolean): void {
+        this.isActive = active;
+    }
 }

--- a/Neptune.Web/src/app/shared/components/workflow-nav/workflow-nav-sub-item/workflow-nav-sub-item.component.html
+++ b/Neptune.Web/src/app/shared/components/workflow-nav/workflow-nav-sub-item/workflow-nav-sub-item.component.html
@@ -1,0 +1,10 @@
+<li class="sidebar-sub-item">
+    <a [routerLink]="navRouterLink" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="sidebar-sub-link" [class.disabled]="disabled">
+        @if (complete) {
+            <icon class="complete" icon="StepComplete"></icon>
+        } @else {
+            <icon class="fade" icon="StepIncomplete"></icon>
+        }
+        <span class="sub-label"><ng-content></ng-content></span>
+    </a>
+</li>

--- a/Neptune.Web/src/app/shared/components/workflow-nav/workflow-nav-sub-item/workflow-nav-sub-item.component.scss
+++ b/Neptune.Web/src/app/shared/components/workflow-nav/workflow-nav-sub-item/workflow-nav-sub-item.component.scss
@@ -1,0 +1,44 @@
+@use "/src/scss/abstracts" as *;
+
+.sidebar-sub-item {
+
+    .sidebar-sub-link {
+        display: flex;
+        align-items: center;
+        gap: $spacing-200;
+        // Reserve space for the active-state left border so the label doesn't shift on selection.
+        border-left: 3px solid transparent;
+
+        icon {
+            width: 1rem;
+            display: inline-flex;
+        }
+
+        .complete {
+            color: $green-default;
+        }
+
+        .fade {
+            color: $gray-400;
+        }
+
+        // Subtle active treatment: teal left rail + primary-colored bold label, no background flood.
+        &.active,
+        &.active:hover {
+            background: transparent;
+            border-left-color: $primary;
+            color: $primary;
+            font-weight: 600;
+        }
+
+        &:hover {
+            background: rgba($primary, 0.08);
+            color: $primary;
+        }
+
+        &.disabled {
+            pointer-events: none;
+            cursor: default;
+        }
+    }
+}

--- a/Neptune.Web/src/app/shared/components/workflow-nav/workflow-nav-sub-item/workflow-nav-sub-item.component.ts
+++ b/Neptune.Web/src/app/shared/components/workflow-nav/workflow-nav-sub-item/workflow-nav-sub-item.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from "@angular/core";
+import { RouterLink, RouterLinkActive } from "@angular/router";
+
+import { IconComponent } from "../../icon/icon.component";
+
+@Component({
+    selector: "workflow-nav-sub-item",
+    standalone: true,
+    imports: [IconComponent, RouterLink, RouterLinkActive],
+    templateUrl: "./workflow-nav-sub-item.component.html",
+    styleUrl: "./workflow-nav-sub-item.component.scss",
+})
+export class WorkflowNavSubItemComponent {
+    @Input() navRouterLink: string | string[];
+    @Input() complete: boolean = false;
+    @Input() disabled: boolean = false;
+}

--- a/Neptune.Web/src/scss/components/_workflow.scss
+++ b/Neptune.Web/src/scss/components/_workflow.scss
@@ -18,3 +18,21 @@ workflow-body {
         border-top: 1px solid $gray-light;
     }
 }
+
+// Shared footer used by every Field Visit workflow step page so primary actions
+// land in the same spot with the same spacing.
+// Place destructive / cancel actions before a `<span class="spacer"></span>` to push
+// the primary actions to the right.
+.step-footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: $spacing-300;
+    margin-top: $spacing-500;
+    padding-top: $spacing-400;
+    border-top: 1px solid $gray-light;
+
+    .spacer {
+        flex: 1;
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to NPT-984 (FieldVisits SPA migration) addressing UX polish gaps surfaced during walkthrough — restoring legacy MVC parity for the wizard flow, fixing layout bugs, and unblocking a zoneless change-detection issue that left forms stuck behind a spinner.

## What's in here

**Workflow nav + sub-steps**
- New `WorkflowNavSubItemComponent` plus `[hasSubNav]` extension on `WorkflowNavItemComponent` (named `[subnav]` content slot, projected only when parent route is active).
- Inventory split into routed sub-steps (`inventory/location`, `inventory/photos`, `inventory/attributes`) — each wraps the existing reusable BMP editor, has its own `<page-header>`, navigates forward on save, returns to landing on cancel.
- Initial / Post-Maintenance Assessment surface their existing `observations` + `photos` sub-routes as sub-items in the nav.
- Active sub-item styled with subtle teal left rail + bold primary text rather than full background fill.

**Landing pages**
- Inventory / Assessment / Maintenance / Post-Maintenance landing pages rewritten to mirror legacy MVC intro pages (workflow description, navigation hint, icon legend explaining StepIncomplete / StepComplete icons, Begin/Continue/Skip footer).
- Visit Summary rewritten with `dl.grid-12` + project's actual `g-col-N` utility classes (the previous `g-col-md-N` doesn't exist). Local SCSS resets `dd { margin-left: 0 }` and `dt { padding-bottom: 0 }` so `dt`/`dd` pairs sit on the same baseline.

**Sidebar actions**
- Delete Visit moved into the outlet sidebar as an inline trash icon next to the existing pencil icon (so it's globally available, not buried at the bottom of the Visit Summary page).
- Wrap Up Visit moved below the workflow nav with a confirm dialog that warns about unsaved form changes.

**Forms + change detection**
- `observations-step`, `maintenance-edit-step`, `assessment-photos-step` converted from imperative `isLoading: boolean` + plain data fields to **signals** so the template's `@if (isLoading)` guard re-evaluates when subscribe callbacks fire under zoneless behavior. Without this, forms sat behind a spinner until a stray click forced CD.
- Observations form uses the shared `<form-field>` component (Number / Select / Text) with `units` for measurement labels, instead of bespoke `<input>` / `<select>` markup.
- Page titles simplified to `"Observations"` / `"Photos"` since the sidebar already conveys which assessment is active.

**Routing fix**
- `data: { assessmentTypeID: 1 }` added to `/assessment`, `/assessment/observations`, `/assessment/photos` routes. With `withComponentInputBinding()` enabled, missing route data was overriding the `@Input() assessmentTypeID: number = 1` default with `undefined`, which made `Begin Initial Assessment` silently fail (generated client null guard).

**Misc**
- `markInventoryUpdatedAndRefresh()` helper on `FieldVisitWorkflowService` so every Inventory sub-step is a one-liner.
- `treatment-bmp-images-editor` emits new `(uploaded)` and `(deleted)` outputs — uploads/deletes now count toward `InventoryUpdated` (matches legacy where any Photos action submit set the flag).
- Centralized `.step-footer` rule in `src/scss/components/_workflow.scss`; removed five duplicate copies from individual step component SCSS.
- Step pages standardized on `<page-header>` + `.step-footer` + `btn-primary` forward buttons with `fa-forward` / `fa-caret-right` icons.
- Treatment BMP detail card-header buttons (Begin Field Visit / Add Funding Event / Upload Document) normalized to `btn-white-outline btn-sm` + `fa-plus`, matching the WQMP detail panel pattern.

## Test plan

- [ ] Open a field visit on a BMP — sidebar shows BMP info, pencil + trash icons next to date, Wrap Up Visit button below the nav, white sidebar background (no gray override).
- [ ] Inventory landing — three primary buttons (Skip to Assessment / Review Inventory). Click Review → land on Location sub-step with sub-items showing in nav.
- [ ] Save Location → routes to Photos sub-step; sidebar shows Inventory checkmark.
- [ ] Upload a photo without clicking Save Captions → still flips `InventoryUpdated=true`.
- [ ] Save captions → routes to Attributes sub-step. Save attributes → returns to Inventory landing.
- [ ] Initial Assessment landing — description + icon legend + Begin Initial Assessment button (the previously broken one). Click → routes to Observations sub-step.
- [ ] Observations form — `<form-field>` rendering for DiscreteValue / PassFail / Percentage / Text inputs + Notes column, no spinner stuck.
- [ ] Maintenance landing — Create Maintenance Record → routes to edit form. No spinner stuck.
- [ ] Post-Maintenance Assessment landing — no Skip button (matches legacy).
- [ ] Visit Summary — labels/values aligned, two pairs per row in Visit Details card.
- [ ] Click Wrap Up Visit from any step → confirm dialog → finalizes visit and routes back to BMP.
- [ ] Click trash icon in sidebar → confirm dialog → deletes visit and routes back to BMP.
- [ ] Treatment BMP detail — Field Visits / Funding Events / Documents card-header buttons match WQMP styling (white outline + fa-plus).
- [ ] All `Neptune.Tests` still pass (verified locally: 207/207).

🤖 Generated with [Claude Code](https://claude.com/claude-code)