### PR TITLE
NPT-995: Round 5 — refresh verifications grid after delete

### DIFF
--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
@@ -232,7 +232,18 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
                 }));
             })
         );
-        this.verifications$ = this.wqmpService.listVerificationsWaterQualityManagementPlan(this.waterQualityManagementPlanID);
+        // NPT-995 round 5: verifications$ rides the same reload$ pipeline as wqmp$ so
+        // mutations (e.g. delete from the row-actions menu) refresh the grid via
+        // reload$.next() rather than inline observable reassignment, which the AsyncPipe
+        // didn't reliably re-subscribe to (same anti-pattern NPT-1051 PR #488 fixed for
+        // wqmp$). Initialized once; subsequent loadData() calls inherit wqmp$'s
+        // reload$.next() above.
+        if (!this.verifications$) {
+            this.verifications$ = this.reload$.pipe(
+                switchMap(() => this.wqmpService.listVerificationsWaterQualityManagementPlan(this.waterQualityManagementPlanID)),
+                shareReplay(1)
+            );
+        }
 
         this.modeledPerformance$ = this.wqmpService.getModeledPerformanceWaterQualityManagementPlan(this.waterQualityManagementPlanID);
 
@@ -535,8 +546,9 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
                 this.wqmpService.deleteVerificationWaterQualityManagementPlan(this.waterQualityManagementPlanID, verifyID).subscribe({
                     next: () => {
                         this.alertService.pushAlert(new Alert("Verification deleted.", AlertContext.Success));
-                        // Re-assign the observable so the async pipe re-subscribes and the grid refreshes.
-                        this.verifications$ = this.wqmpService.listVerificationsWaterQualityManagementPlan(this.waterQualityManagementPlanID);
+                        // NPT-995 round 5: push reload$ instead of reassigning verifications$
+                        // — the inline reassign wasn't reliably re-triggering the AsyncPipe.
+                        this.reload$.next();
                     },
                     error: () => {
                         this.alertService.pushAlert(new Alert("An error occurred while deleting the verification.", AlertContext.Danger));

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
@@ -92,6 +92,11 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
     // robust against AsyncPipe re-subscription quirks that can leave the page showing
     // stale Status / Modeling Approach values when wqmp$ is reassigned mid-stream.
     private reload$ = new BehaviorSubject<void>(undefined);
+    // NPT-995 round 5: separate signal for verifications$ so a row-delete only refreshes
+    // the verifications grid — pushing reload$ would also refetch wqmp$ + rebuild the
+    // map layers, which is unnecessary work and a potential source of UI flicker on a
+    // verification mutation.
+    private verificationsReload$ = new BehaviorSubject<void>(undefined);
     wqmp$: Observable<WaterQualityManagementPlanDto>;
     quickBMPs$: Observable<QuickBMPDto[]>;
     quickBMPTotalRow: any[] = [];
@@ -232,14 +237,12 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
                 }));
             })
         );
-        // NPT-995 round 5: verifications$ rides the same reload$ pipeline as wqmp$ so
-        // mutations (e.g. delete from the row-actions menu) refresh the grid via
-        // reload$.next() rather than inline observable reassignment, which the AsyncPipe
-        // didn't reliably re-subscribe to (same anti-pattern NPT-1051 PR #488 fixed for
-        // wqmp$). Initialized once; subsequent loadData() calls inherit wqmp$'s
-        // reload$.next() above.
+        // NPT-995 round 5: stable observable driven by verificationsReload$. Delete
+        // mutations push the dedicated reload signal rather than inline-reassigning
+        // verifications$ — same AsyncPipe re-subscription fix as wqmp$ (NPT-1051 PR #488),
+        // scoped narrowly so unrelated wqmp$ refreshes don't drag the grid along.
         if (!this.verifications$) {
-            this.verifications$ = this.reload$.pipe(
+            this.verifications$ = this.verificationsReload$.pipe(
                 switchMap(() => this.wqmpService.listVerificationsWaterQualityManagementPlan(this.waterQualityManagementPlanID)),
                 shareReplay(1)
             );
@@ -546,9 +549,9 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
                 this.wqmpService.deleteVerificationWaterQualityManagementPlan(this.waterQualityManagementPlanID, verifyID).subscribe({
                     next: () => {
                         this.alertService.pushAlert(new Alert("Verification deleted.", AlertContext.Success));
-                        // NPT-995 round 5: push reload$ instead of reassigning verifications$
-                        // — the inline reassign wasn't reliably re-triggering the AsyncPipe.
-                        this.reload$.next();
+                        // NPT-995 round 5: scoped reload — refresh only the verifications grid,
+                        // not wqmp$ + map layers (delete doesn't affect WQMP fields/geometry).
+                        this.verificationsReload$.next();
                     },
                     error: () => {
                         this.alertService.pushAlert(new Alert("An error occurred while deleting the verification.", AlertContext.Danger));

--- a/Neptune.Web/src/app/shared/services/wqmp-verification-workflow.service.ts
+++ b/Neptune.Web/src/app/shared/services/wqmp-verification-workflow.service.ts
@@ -317,8 +317,6 @@ export class WqmpVerificationWorkflowService {
         save$.subscribe({
             next: (saved) => {
                 this.isSaving.set(false);
-                this.alertService.pushAlert(new Alert(opts.isDraft ? "Verification saved." : "Verification finalized.", AlertContext.Success));
-
                 this.isFinalized.set(!saved?.IsDraft);
 
                 if (saved?.WaterQualityManagementPlanVerifyID && this.waterQualityManagementPlanVerifyID() == null) {
@@ -326,17 +324,23 @@ export class WqmpVerificationWorkflowService {
                     this.mode.set("edit");
                 }
 
-                if (opts.returnToDetail) {
-                    this.router.navigate(["/water-quality-management-plans", wqmpID]);
-                    return;
-                }
-
-                const targetKey = opts.andContinue ? this.nextStepKey(opts.currentStepKey) ?? opts.currentStepKey : opts.currentStepKey;
-                this.router.navigate([
-                    "/water-quality-management-plans", wqmpID, "verifications",
-                    ...this.verifyIDPathSegment(),
-                    targetKey,
-                ], { replaceUrl: isCreate });
+                // Push the success alert *after* navigation completes — the alert-display on
+                // the source page calls clearAlerts() in ngOnDestroy, so a pre-navigate push
+                // gets wiped during route teardown (notably on initial create where the URL
+                // changes from .../new/... to .../{id}/... and on returnToDetail). Pushing
+                // post-navigate lands the alert on the destination page after its
+                // alert-display has mounted and subscribed.
+                const successMsg = opts.isDraft ? "Verification saved." : "Verification finalized.";
+                const navigation$ = opts.returnToDetail
+                    ? this.router.navigate(["/water-quality-management-plans", wqmpID])
+                    : this.router.navigate([
+                        "/water-quality-management-plans", wqmpID, "verifications",
+                        ...this.verifyIDPathSegment(),
+                        opts.andContinue ? this.nextStepKey(opts.currentStepKey) ?? opts.currentStepKey : opts.currentStepKey,
+                    ], { replaceUrl: isCreate });
+                navigation$.then(() => {
+                    this.alertService.pushAlert(new Alert(successMsg, AlertContext.Success));
+                });
             },
             error: () => {
                 this.isSaving.set(false);


### PR DESCRIPTION
## Summary

Round-5 rework on NPT-995 (WQMP O&M Verification migration). KE flagged a single red item from 5/5/26 testing: deleting a verification from the row-actions menu on the WQMP detail page leaves the deleted row visible in the grid until the user manually reloads.

Same anti-pattern NPT-1051 PR #488 fixed for `wqmp$` (inline observable reassignment doesn't reliably re-trigger the AsyncPipe through subscribe-callback layers). Fold `verifications$` onto the same `reload$` BehaviorSubject pipeline that already drives `wqmp$`; the delete success callback now calls `reload$.next()` instead of reassigning the observable inline.

Pure SPA fix — no backend, DTO, or codegen changes. One file touched.

## Test plan

- [ ] Open WQMP detail page on a WQMP with at least one Draft verification → row-actions menu → Delete → Confirm. Grid refreshes immediately on modal close, no manual reload.
- [ ] Regression: edit Status via Basics modal → Save. WQMP status display refreshes (existing) AND the verifications grid still shows the same rows (verifies the fold-onto-`reload$` didn't introduce a side effect).
- [ ] Regression: Promote a Draft WQMP. WQMP status updates; verifications grid unchanged.