### PR TITLE
NPT-1051: Clean up modeling results on WQMP Status transitions

### DIFF
--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -90,8 +90,18 @@ namespace Neptune.API.Controllers
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         public async Task<ActionResult<WaterQualityManagementPlanDto>> Update([FromRoute] int waterQualityManagementPlanID, [FromBody] WaterQualityManagementPlanUpsertDto dto)
         {
+            // NPT-1051: Status transitions across the Active boundary need cleanup + re-solve; the
+            // SPA Basics modal hits this endpoint and can flip Active <-> Inactive.
+            var oldStatusID = await DbContext.WaterQualityManagementPlans.AsNoTracking()
+                .Where(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID)
+                .Select(x => x.WaterQualityManagementPlanStatusID)
+                .FirstAsync();
             var updated = await WaterQualityManagementPlans.UpdateAsync(DbContext, waterQualityManagementPlanID, dto);
             if (updated == null) return NotFound();
+            if (await WaterQualityManagementPlans.HandleStatusTransitionAsync(DbContext, waterQualityManagementPlanID, oldStatusID))
+            {
+                BackgroundJob.Enqueue<DeltaSolveJob>(x => x.RunJob());
+            }
             return Ok(updated);
         }
 
@@ -743,18 +753,18 @@ namespace Neptune.API.Controllers
                 return BadRequest(new { MissingFields = missingFields });
             }
 
+            var oldStatusID = entity.WaterQualityManagementPlanStatusID;
             entity.WaterQualityManagementPlanStatusID = (int)WaterQualityManagementPlanStatusEnum.Active;
             await DbContext.SaveChangesAsync();
 
-            // Now that the WQMP is Active, it flows into modeling result calculations. Mark it
-            // dirty so the next network solve picks it up rather than waiting for some other
-            // mutation to trigger it.
-            await NereidUtilities.MarkWqmpDirty(entity, DbContext);
-
-            // NPT-1051 rework: kick off the incremental solve immediately. Without this, the
-            // dirty marker only gets consumed when HRURefreshJob next runs (hours away on the
-            // schedule), so a freshly-promoted WQMP shows no modeling results until then.
-            BackgroundJob.Enqueue<DeltaSolveJob>(x => x.RunJob());
+            // Mark the WQMP dirty + kick off the incremental solve immediately. Without the
+            // enqueue, the dirty marker would only be consumed when HRURefreshJob next runs
+            // (hours away on the schedule), so a freshly-promoted WQMP would show no modeling
+            // results until then.
+            if (await WaterQualityManagementPlans.HandleStatusTransitionAsync(DbContext, waterQualityManagementPlanID, oldStatusID))
+            {
+                BackgroundJob.Enqueue<DeltaSolveJob>(x => x.RunJob());
+            }
 
             var dto = await WaterQualityManagementPlans.GetByIDAsDtoAsync(DbContext, waterQualityManagementPlanID);
             return Ok(dto);

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlanModeledPerformance.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlanModeledPerformance.cs
@@ -10,6 +10,14 @@ public static class WaterQualityManagementPlanModeledPerformance
     {
         var wqmp = WaterQualityManagementPlans.GetByID(dbContext, waterQualityManagementPlanID);
 
+        // NPT-1051: Non-Active WQMPs are excluded from modeling result calculations. The status
+        // transition cleanup deletes the WQMP's NereidResult rows, but this defense-in-depth
+        // short-circuit protects direct API callers from any residual rows that slip through.
+        if (wqmp.WaterQualityManagementPlanStatusID != (int)WaterQualityManagementPlanStatusEnum.Active)
+        {
+            return null;
+        }
+
         List<vLoadReducingResult> nereidResults;
         DateTime? lastDeltaQueue;
 

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlans.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlans.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Neptune.Common.DesignByContract;
+using Neptune.EFModels.Nereid;
 using Neptune.Models.DataTransferObjects;
 
 namespace Neptune.EFModels.Entities;
@@ -154,6 +155,57 @@ public static class WaterQualityManagementPlans
         entity.UpdateFromUpsertDto(dto);
         await dbContext.SaveChangesAsync();
         return await GetByIDAsDtoAsync(dbContext, entity.WaterQualityManagementPlanID);
+    }
+
+    // NPT-1051: Side effects of a WQMP Status transition. Read-time gating (NereidService graph
+    // filter, vTrashGeneratingUnitLoadStatistic CASE, TrashGeneratingUnitHelper) hides non-Active
+    // WQMPs from results going forward, but the DB still carries the WQMP's previously-cached
+    // NereidResult rows, and the WQMP's neighbors hold solve results that were computed *with*
+    // this WQMP in the network. On any transition that crosses the Active boundary we have to
+    // (a) invalidate stale rows and (b) dirty the affected nodes so the next DeltaSolveJob
+    // recomputes them. Returns true when the caller should enqueue a DeltaSolveJob.
+    public static async Task<bool> HandleStatusTransitionAsync(NeptuneDbContext dbContext, int waterQualityManagementPlanID, int? oldStatusID)
+    {
+        var newStatusID = await dbContext.WaterQualityManagementPlans
+            .Where(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID)
+            .Select(x => x.WaterQualityManagementPlanStatusID)
+            .FirstAsync();
+
+        if (oldStatusID == newStatusID) return false;
+
+        var activeStatusID = (int)WaterQualityManagementPlanStatusEnum.Active;
+        var wasActive = oldStatusID == activeStatusID;
+        var isActive = newStatusID == activeStatusID;
+
+        // Draft <-> Inactive flips don't change result calculations either way.
+        if (!wasActive && !isActive) return false;
+
+        if (wasActive)
+        {
+            // Active -> non-Active: WQMP leaves the modeling graph. Dirty the downstream regional
+            // subbasins / centralized BMPs that previously folded this WQMP into their solves so
+            // they get recomputed without it; then delete the WQMP's own (now stale) result rows.
+            var wqmp = await dbContext.WaterQualityManagementPlans
+                .Include(x => x.LoadGeneratingUnits)
+                .FirstAsync(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID);
+            await NereidUtilities.MarkDownstreamNodeDirty(wqmp, dbContext);
+            await dbContext.NereidResults
+                .Where(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID)
+                .ExecuteDeleteAsync();
+            await dbContext.ProjectNereidResults
+                .Where(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID)
+                .ExecuteDeleteAsync();
+        }
+        else
+        {
+            // non-Active -> Active: WQMP enters the graph. Dirty it directly so DeltaSolve picks
+            // up the new node on its next run.
+            var wqmp = await dbContext.WaterQualityManagementPlans
+                .FirstAsync(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID);
+            await NereidUtilities.MarkWqmpDirty(wqmp, dbContext);
+        }
+
+        return true;
     }
 
     public static async Task<bool> DeleteAsync(NeptuneDbContext dbContext, int waterQualityManagementPlanID)

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlans.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlans.cs
@@ -157,6 +157,19 @@ public static class WaterQualityManagementPlans
         return await GetByIDAsDtoAsync(dbContext, entity.WaterQualityManagementPlanID);
     }
 
+    // NPT-1051: Classifies a Status transition's effect on the modeling pipeline. Pure function,
+    // hermetically unit-testable. Same-status saves and Draft <-> Inactive flips are no-ops
+    // because neither state participates in the modeling graph. Crossing the Active boundary in
+    // either direction requires DB-side cleanup or re-dirtying.
+    public static StatusTransitionEffect ClassifyStatusTransition(int? oldStatusID, int? newStatusID)
+    {
+        if (oldStatusID == newStatusID) return StatusTransitionEffect.None;
+        var active = (int)WaterQualityManagementPlanStatusEnum.Active;
+        if (oldStatusID == active) return StatusTransitionEffect.LeavingActive;
+        if (newStatusID == active) return StatusTransitionEffect.EnteringActive;
+        return StatusTransitionEffect.None;
+    }
+
     // NPT-1051: Side effects of a WQMP Status transition. Read-time gating (NereidService graph
     // filter, vTrashGeneratingUnitLoadStatistic CASE, TrashGeneratingUnitHelper) hides non-Active
     // WQMPs from results going forward, but the DB still carries the WQMP's previously-cached
@@ -171,41 +184,35 @@ public static class WaterQualityManagementPlans
             .Select(x => x.WaterQualityManagementPlanStatusID)
             .FirstAsync();
 
-        if (oldStatusID == newStatusID) return false;
-
-        var activeStatusID = (int)WaterQualityManagementPlanStatusEnum.Active;
-        var wasActive = oldStatusID == activeStatusID;
-        var isActive = newStatusID == activeStatusID;
-
-        // Draft <-> Inactive flips don't change result calculations either way.
-        if (!wasActive && !isActive) return false;
-
-        if (wasActive)
+        switch (ClassifyStatusTransition(oldStatusID, newStatusID))
         {
-            // Active -> non-Active: WQMP leaves the modeling graph. Dirty the downstream regional
-            // subbasins / centralized BMPs that previously folded this WQMP into their solves so
-            // they get recomputed without it; then delete the WQMP's own (now stale) result rows.
-            var wqmp = await dbContext.WaterQualityManagementPlans
-                .Include(x => x.LoadGeneratingUnits)
-                .FirstAsync(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID);
-            await NereidUtilities.MarkDownstreamNodeDirty(wqmp, dbContext);
-            await dbContext.NereidResults
-                .Where(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID)
-                .ExecuteDeleteAsync();
-            await dbContext.ProjectNereidResults
-                .Where(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID)
-                .ExecuteDeleteAsync();
-        }
-        else
-        {
-            // non-Active -> Active: WQMP enters the graph. Dirty it directly so DeltaSolve picks
-            // up the new node on its next run.
-            var wqmp = await dbContext.WaterQualityManagementPlans
-                .FirstAsync(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID);
-            await NereidUtilities.MarkWqmpDirty(wqmp, dbContext);
-        }
+            case StatusTransitionEffect.LeavingActive:
+                // WQMP leaves the modeling graph. Dirty the downstream regional subbasins /
+                // centralized BMPs that previously folded this WQMP into their solves so they
+                // get recomputed without it; then delete the WQMP's own (now stale) result rows.
+                var leavingWqmp = await dbContext.WaterQualityManagementPlans
+                    .Include(x => x.LoadGeneratingUnits)
+                    .FirstAsync(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID);
+                await NereidUtilities.MarkDownstreamNodeDirty(leavingWqmp, dbContext);
+                await dbContext.NereidResults
+                    .Where(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID)
+                    .ExecuteDeleteAsync();
+                await dbContext.ProjectNereidResults
+                    .Where(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID)
+                    .ExecuteDeleteAsync();
+                return true;
 
-        return true;
+            case StatusTransitionEffect.EnteringActive:
+                // WQMP enters the graph. Dirty it directly so DeltaSolve picks up the new node
+                // on its next run.
+                var enteringWqmp = await dbContext.WaterQualityManagementPlans
+                    .FirstAsync(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID);
+                await NereidUtilities.MarkWqmpDirty(enteringWqmp, dbContext);
+                return true;
+
+            default:
+                return false;
+        }
     }
 
     public static async Task<bool> DeleteAsync(NeptuneDbContext dbContext, int waterQualityManagementPlanID)
@@ -344,4 +351,11 @@ public static class WaterQualityManagementPlans
         if (string.IsNullOrWhiteSpace(entity.WaterQualityManagementPlanName)) missing.Add("WQMP Name");
         return missing;
     }
+}
+
+public enum StatusTransitionEffect
+{
+    None,
+    LeavingActive,
+    EnteringActive,
 }

--- a/Neptune.Tests/WaterQualityManagementPlansClassifyStatusTransitionTests.cs
+++ b/Neptune.Tests/WaterQualityManagementPlansClassifyStatusTransitionTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1051: Pure-decision matrix for <see cref="WaterQualityManagementPlans.ClassifyStatusTransition"/>.
+    /// The function decides what side effects a Status transition needs (none, cleanup-on-leave, or
+    /// dirty-on-enter); the DB-touching <see cref="WaterQualityManagementPlans.HandleStatusTransitionAsync"/>
+    /// dispatches on this classification. Status semantics (per Kathleen 2026-04-30):
+    /// Active = binding legal record (the only state that participates in modeling),
+    /// Draft = transcription in progress, Inactive = agreement no longer in force.
+    /// </summary>
+    [TestClass]
+    public class WaterQualityManagementPlansClassifyStatusTransitionTests
+    {
+        private const int Active = (int)WaterQualityManagementPlanStatusEnum.Active;
+        private const int Inactive = (int)WaterQualityManagementPlanStatusEnum.Inactive;
+        private const int Draft = (int)WaterQualityManagementPlanStatusEnum.Draft;
+
+        [TestMethod]
+        public void SameStatus_Active_None()
+        {
+            Assert.AreEqual(StatusTransitionEffect.None,
+                WaterQualityManagementPlans.ClassifyStatusTransition(Active, Active));
+        }
+
+        [TestMethod]
+        public void SameStatus_Draft_None()
+        {
+            Assert.AreEqual(StatusTransitionEffect.None,
+                WaterQualityManagementPlans.ClassifyStatusTransition(Draft, Draft));
+        }
+
+        [TestMethod]
+        public void SameStatus_Inactive_None()
+        {
+            Assert.AreEqual(StatusTransitionEffect.None,
+                WaterQualityManagementPlans.ClassifyStatusTransition(Inactive, Inactive));
+        }
+
+        [TestMethod]
+        public void ActiveToInactive_LeavingActive()
+        {
+            Assert.AreEqual(StatusTransitionEffect.LeavingActive,
+                WaterQualityManagementPlans.ClassifyStatusTransition(Active, Inactive));
+        }
+
+        [TestMethod]
+        public void ActiveToDraft_LeavingActive()
+        {
+            // Data-quality rollback case — Kathleen confirmed this is a valid transition
+            // (e.g., transcription error discovered after promotion).
+            Assert.AreEqual(StatusTransitionEffect.LeavingActive,
+                WaterQualityManagementPlans.ClassifyStatusTransition(Active, Draft));
+        }
+
+        [TestMethod]
+        public void InactiveToActive_EnteringActive()
+        {
+            Assert.AreEqual(StatusTransitionEffect.EnteringActive,
+                WaterQualityManagementPlans.ClassifyStatusTransition(Inactive, Active));
+        }
+
+        [TestMethod]
+        public void DraftToActive_EnteringActive()
+        {
+            // The Promote endpoint path — Draft transcription becomes the binding legal record.
+            Assert.AreEqual(StatusTransitionEffect.EnteringActive,
+                WaterQualityManagementPlans.ClassifyStatusTransition(Draft, Active));
+        }
+
+        [TestMethod]
+        public void DraftToInactive_None()
+        {
+            // Neither state is in the modeling graph — no cleanup or dirtying needed.
+            Assert.AreEqual(StatusTransitionEffect.None,
+                WaterQualityManagementPlans.ClassifyStatusTransition(Draft, Inactive));
+        }
+
+        [TestMethod]
+        public void InactiveToDraft_None()
+        {
+            Assert.AreEqual(StatusTransitionEffect.None,
+                WaterQualityManagementPlans.ClassifyStatusTransition(Inactive, Draft));
+        }
+
+        [TestMethod]
+        public void NullOldStatusToActive_EnteringActive()
+        {
+            // Defensive: a freshly created WQMP record could have a null old status if a caller
+            // captures it before the row's status was set. Treat null as "not yet Active."
+            Assert.AreEqual(StatusTransitionEffect.EnteringActive,
+                WaterQualityManagementPlans.ClassifyStatusTransition(null, Active));
+        }
+
+        [TestMethod]
+        public void NullOldStatusToDraft_None()
+        {
+            Assert.AreEqual(StatusTransitionEffect.None,
+                WaterQualityManagementPlans.ClassifyStatusTransition(null, Draft));
+        }
+
+        [TestMethod]
+        public void ActiveToNullNewStatus_LeavingActive()
+        {
+            // Symmetric defensive case (in practice the entity's status column is NOT NULL,
+            // but the classifier handles the null variant rather than blowing up).
+            Assert.AreEqual(StatusTransitionEffect.LeavingActive,
+                WaterQualityManagementPlans.ClassifyStatusTransition(Active, null));
+        }
+    }
+}

--- a/Neptune.Tests/WaterQualityManagementPlansValidateForPromoteTests.cs
+++ b/Neptune.Tests/WaterQualityManagementPlansValidateForPromoteTests.cs
@@ -8,6 +8,12 @@ namespace Neptune.Tests
     /// Covers the NPT-1051 promotion gate. <see cref="WaterQualityManagementPlans.ValidateForPromote"/>
     /// is the legal-record completeness check that runs before flipping a Draft WQMP to Active —
     /// missing fields are surfaced to the SPA so the reviewer can fill them in before retrying.
+    ///
+    /// Per the post-NPT-1051 loosening (dbb7d2567), validation mirrors the Basics editor modal's
+    /// required-field set. Only WQMP Name needs an explicit check here: Jurisdiction,
+    /// ModelingApproach, and TrashCaptureStatus are also modal-required but are NOT NULL on the
+    /// entity and so are guaranteed to be populated. Everything else (record numbers, dates,
+    /// contact info, hydromod) is optional in the modal and therefore optional at Promote.
     /// </summary>
     [TestClass]
     public class WaterQualityManagementPlansValidateForPromoteTests
@@ -53,39 +59,39 @@ namespace Neptune.Tests
         }
 
         [TestMethod]
-        public void NullHydrologicSubarea_FlagsHydrologicSubarea()
+        public void NullHydrologicSubarea_DoesNotFlag_OptionalAtPromote()
         {
             var entity = FullyPopulated();
             entity.HydrologicSubareaID = null;
-            Assert.IsTrue(WaterQualityManagementPlans.ValidateForPromote(entity).Contains("Hydrologic Subarea"));
+            Assert.IsFalse(WaterQualityManagementPlans.ValidateForPromote(entity).Contains("Hydrologic Subarea"));
         }
 
         [TestMethod]
-        public void NullRecordedAcreage_FlagsAcreage()
+        public void NullRecordedAcreage_DoesNotFlag_OptionalAtPromote()
         {
             var entity = FullyPopulated();
             entity.RecordedWQMPAreaInAcres = null;
-            Assert.IsTrue(WaterQualityManagementPlans.ValidateForPromote(entity).Contains("Recorded WQMP Area (Acres)"));
+            Assert.IsFalse(WaterQualityManagementPlans.ValidateForPromote(entity).Contains("Recorded WQMP Area (Acres)"));
         }
 
         [TestMethod]
-        public void NullApprovalDate_FlagsApprovalDate()
+        public void NullApprovalDate_DoesNotFlag_OptionalAtPromote()
         {
             var entity = FullyPopulated();
             entity.ApprovalDate = null;
-            Assert.IsTrue(WaterQualityManagementPlans.ValidateForPromote(entity).Contains("Approval Date"));
+            Assert.IsFalse(WaterQualityManagementPlans.ValidateForPromote(entity).Contains("Approval Date"));
         }
 
         [TestMethod]
-        public void NullMaintenanceContactOrganization_FlagsOrganization()
+        public void NullMaintenanceContactOrganization_DoesNotFlag_OptionalAtPromote()
         {
             var entity = FullyPopulated();
             entity.MaintenanceContactOrganization = null;
-            Assert.IsTrue(WaterQualityManagementPlans.ValidateForPromote(entity).Contains("Maintenance Contact Organization"));
+            Assert.IsFalse(WaterQualityManagementPlans.ValidateForPromote(entity).Contains("Maintenance Contact Organization"));
         }
 
         [TestMethod]
-        public void EmptyEntity_FlagsAllRequiredFields()
+        public void EmptyEntity_FlagsOnlyName()
         {
             var missing = WaterQualityManagementPlans.ValidateForPromote(new WaterQualityManagementPlan
             {
@@ -94,22 +100,22 @@ namespace Neptune.Tests
                 MaintenanceContactName = null,
                 MaintenanceContactOrganization = null,
             });
-            // Every single field on FullyPopulated maps to one missing-field entry.
-            Assert.AreEqual(13, missing.Count);
+            // Post-loosening, only Name is explicitly required at Promote — everything else on
+            // FullyPopulated is modal-optional and therefore Promote-optional.
+            Assert.AreEqual(1, missing.Count);
+            Assert.IsTrue(missing.Contains("WQMP Name"));
         }
 
         [TestMethod]
-        public void MultipleMissing_ReturnsAllOfThem()
+        public void MultipleMissingOptional_FlagsNone()
         {
             var entity = FullyPopulated();
             entity.RecordNumber = null;
             entity.ApprovalDate = null;
             entity.HydromodificationAppliesTypeID = null;
+            // All three are modal-optional, so Promote should accept the entity as-is.
             var missing = WaterQualityManagementPlans.ValidateForPromote(entity);
-            Assert.AreEqual(3, missing.Count);
-            Assert.IsTrue(missing.Contains("Record Number"));
-            Assert.IsTrue(missing.Contains("Approval Date"));
-            Assert.IsTrue(missing.Contains("Hydromodification Applies"));
+            Assert.AreEqual(0, missing.Count);
         }
     }
 }

--- a/Neptune.WebMvc/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.WebMvc/Controllers/WaterQualityManagementPlanController.cs
@@ -13,8 +13,10 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Neptune.Common;
 using Neptune.Common.GeoSpatial;
+using Hangfire;
 using Neptune.EFModels.Entities;
 using Neptune.EFModels.Nereid;
+using Neptune.Jobs.Hangfire;
 using Neptune.Models.DataTransferObjects;
 using Neptune.WebMvc.Common.Models;
 using Neptune.WebMvc.Common.MvcResults;
@@ -366,9 +368,17 @@ namespace Neptune.WebMvc.Controllers
                 return ViewEdit(viewModel);
             }
 
+            // NPT-1051: Status transitions across the Active boundary need cleanup + re-solve;
+            // legacy Edit form is the primary path admins use to flip Active <-> Inactive.
+            var oldStatusID = waterQualityManagementPlan.WaterQualityManagementPlanStatusID;
             viewModel.UpdateModel(waterQualityManagementPlan);
             SetMessageForDisplay($"Successfully updated \"{waterQualityManagementPlan.WaterQualityManagementPlanName}\".");
             await _dbContext.SaveChangesAsync();
+
+            if (await WaterQualityManagementPlans.HandleStatusTransitionAsync(_dbContext, waterQualityManagementPlan.WaterQualityManagementPlanID, oldStatusID))
+            {
+                BackgroundJob.Enqueue<DeltaSolveJob>(x => x.RunJob());
+            }
 
             return new ModalDialogFormJsonResult(
                 SitkaRoute<WaterQualityManagementPlanController>.BuildUrlFromExpression(_linkGenerator, x => x.Detail(waterQualityManagementPlan)));


### PR DESCRIPTION
## Summary

Read-time gating from the original NPT-1051 (NereidService graph filter, `vTrashGeneratingUnitLoadStatistic` CASE, `TrashGeneratingUnitHelper.ActiveWaterQualityManagementPlan`) hides non-Active WQMPs from results — but a Status flip itself never cleaned the DB or re-solved neighbors. Local receipts before the fix: 136 Inactive WQMPs locally had 228 leftover `NereidResult` rows.

This PR closes that gap from every Status-changing path.

## Changes

- **New `WaterQualityManagementPlans.HandleStatusTransitionAsync`** — fires from every Status-changing path (SPA Basics modal `PUT`, legacy MVC Edit form, `Promote` endpoint).
  - **Active → non-Active** (Draft or Inactive): `MarkDownstreamNodeDirty` (re-solves neighbor RSBs/centralized BMPs without this WQMP) + delete `NereidResult` / `ProjectNereidResult` for this WQMP; caller enqueues `DeltaSolveJob`.
  - **non-Active → Active**: `MarkWqmpDirty`; caller enqueues `DeltaSolveJob`.
  - **Draft ↔ Inactive** and same-state: no-op.
- **New `ClassifyStatusTransition` pure function** (returns `StatusTransitionEffect { None, LeavingActive, EnteringActive }`) so the decision logic is hermetically unit-testable in CI without a DbContext.
- **`Promote` refactored** to use the shared helper (no behavior change vs. the inline `MarkWqmpDirty` + `BackgroundJob.Enqueue` it replaced).
- **`GetModeledPerformanceAsync` defense-in-depth** — short-circuits to `null` for non-Active WQMPs so direct API consumers (PowerBI, integrations) can't see residual rows even if a future bug leaves stale data behind.
- **Stale `ValidateForPromote` tests rewritten** — 6 tests left over from the post-NPT-1051 validation loosening in `dbb7d2567` were asserting on field checks that were intentionally removed; rewrites them to document the modal-required-only contract.

## Transition matrix (per Kathleen 2026-04-30 + this PR)

| From → To | Effect |
|---|---|
| Active → Inactive | `LeavingActive` — cleanup + dirty downstream |
| Active → Draft | `LeavingActive` — same (data-quality rollback case is supported) |
| Inactive → Active | `EnteringActive` — `MarkWqmpDirty` |
| Draft → Active | `EnteringActive` — mirrors `Promote` |
| Draft ↔ Inactive | `None` — neither state is in the modeling graph |
| Same status | `None` |

## Test plan

- [x] `dotnet test Neptune.Tests` — **252/252 passing** (was 234/240 with 6 stale failures on develop tip). Adds 12 new `ClassifyStatusTransition` tests covering the full 3×3 matrix + null edge cases.
- [x] **Verified locally end-to-end**: ran `TotalNetworkSolveJob` on dev rig with a freshly-configured local Nereid container (loaded the OC watershed bundle into `c:/Sitka/Neptune/nereid_data/ca/oc`). Solve produced 16,356 baseline + 16,356 scenario rows. The 228 previously-stale `NereidResult` rows for Inactive WQMPs were wiped by `pDeleteNereidResults` and not repopulated — confirms the Phase A read-time filter + new write-side cleanup behave correctly together.
- [x] **Helper end-to-end** (during smoke testing, scaffolding since removed): all 6 transition branches exercised against the real local DB in rollback transactions, 6/6 green. Confirmed `NereidResult` deletes, `ProjectNereidResult` deletes, `DirtyModelNode` inserts for downstream RSBs (LeavingActive) and for the WQMP itself (EnteringActive).
- [ ] QA smoke after deploy: flip an Active WQMP to Inactive via SPA Basics modal → `NereidResult` rows for the WQMP are gone, `DeltaSolveJob` is enqueued in Hangfire.
- [ ] QA smoke: flip back to Active → modeling results reappear on the detail page after the solve completes.

## Notes / non-goals

- The SPA Basics modal Status dropdown still allows all transitions including the unusual ones (Draft → Inactive). Per discussion, leaving the UI permissive — `Active → Draft` was confirmed as a valid data-quality rollback case ("to err is human (and AI)"), and the helper handles every direction correctly. If we want stricter UI gating later, that's a follow-up.
- No swagger/TypeScript/Scaffold regen needed — no API signature changes, no DB schema changes.