### PR TITLE
NPT-984: Custom-attribute description popovers + field-records action verb alignment

### DIFF
--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -14576,6 +14576,9 @@
             "type": "string",
             "nullable": true
           },
+          "IsFieldVisitVerified": {
+            "type": "boolean"
+          },
           "StructuralRepairConducted": {
             "type": "string",
             "nullable": true
@@ -18083,6 +18086,9 @@
             "type": "number",
             "format": "double",
             "nullable": true
+          },
+          "IsFieldVisitVerified": {
+            "type": "boolean"
           },
           "Status": {
             "type": "string",

--- a/Neptune.Database/dbo/Views/dbo.vMaintenanceRecordDetailed.sql
+++ b/Neptune.Database/dbo/Views/dbo.vMaintenanceRecordDetailed.sql
@@ -13,7 +13,7 @@ as
 )
 
 select  mr.MaintenanceRecordID, mr.MaintenanceRecordDescription, mr.MaintenanceRecordTypeID, mrt.MaintenanceRecordTypeDisplayName,
-        bmp.TreatmentBMPID, bmp.TreatmentBMPTypeID, bmp.TreatmentBMPName, fv.VisitDate,
+        bmp.TreatmentBMPID, bmp.TreatmentBMPTypeID, bmp.TreatmentBMPName, fv.VisitDate, fv.IsFieldVisitVerified,
         fv.FieldVisitID, fv.PerformedByPersonID, fvp.FirstName + ' ' + fvp.LastName as PerformedByPersonName,
         sj.StormwaterJurisdictionID, o.OrganizationName as StormwaterJurisdictionName, sj.StormwaterJurisdictionPublicWQMPVisibilityTypeID,
         wqmp.WaterQualityManagementPlanID, wqmp.WaterQualityManagementPlanName,

--- a/Neptune.Database/dbo/Views/dbo.vTreatmentBMPAssessmentDetailed.sql
+++ b/Neptune.Database/dbo/Views/dbo.vTreatmentBMPAssessmentDetailed.sql
@@ -44,7 +44,7 @@ as
 
 select  tba.TreatmentBMPAssessmentID, tbat.TreatmentBMPAssessmentTypeDisplayName, tba.IsAssessmentComplete, tba.AssessmentScore,
         bmp.TreatmentBMPID, bmp.TreatmentBMPName, bmp.TreatmentBMPTypeID, bmpt.TreatmentBMPTypeName,
-        fv.FieldVisitID, fvt.FieldVisitTypeDisplayName, fv.VisitDate,
+        fv.FieldVisitID, fvt.FieldVisitTypeDisplayName, fv.VisitDate, fv.IsFieldVisitVerified,
         fv.PerformedByPersonID, fvp.FirstName + ' ' + fvp.LastName as PerformedByPersonName,
         sj.StormwaterJurisdictionID, o.OrganizationName as StormwaterJurisdictionName, sj.StormwaterJurisdictionPublicWQMPVisibilityTypeID,
         wqmp.WaterQualityManagementPlanID, wqmp.WaterQualityManagementPlanName

--- a/Neptune.EFModels/Entities/Generated/vMaintenanceRecordDetailed.cs
+++ b/Neptune.EFModels/Entities/Generated/vMaintenanceRecordDetailed.cs
@@ -32,6 +32,8 @@ public partial class vMaintenanceRecordDetailed
     [Column(TypeName = "datetime")]
     public DateTime VisitDate { get; set; }
 
+    public bool IsFieldVisitVerified { get; set; }
+
     public int FieldVisitID { get; set; }
 
     public int PerformedByPersonID { get; set; }

--- a/Neptune.EFModels/Entities/Generated/vTreatmentBMPAssessmentDetailed.cs
+++ b/Neptune.EFModels/Entities/Generated/vTreatmentBMPAssessmentDetailed.cs
@@ -40,6 +40,8 @@ public partial class vTreatmentBMPAssessmentDetailed
     [Column(TypeName = "datetime")]
     public DateTime VisitDate { get; set; }
 
+    public bool IsFieldVisitVerified { get; set; }
+
     public int PerformedByPersonID { get; set; }
 
     [StringLength(201)]

--- a/Neptune.EFModels/Entities/MaintenanceRecords.cs
+++ b/Neptune.EFModels/Entities/MaintenanceRecords.cs
@@ -118,6 +118,7 @@ public static class MaintenanceRecords
                 MaintenanceRecordTypeID = x.MaintenanceRecordTypeID,
                 MaintenanceRecordTypeDisplayName = x.MaintenanceRecordTypeDisplayName,
                 MaintenanceRecordDescription = x.MaintenanceRecordDescription,
+                IsFieldVisitVerified = x.IsFieldVisitVerified,
                 StructuralRepairConducted = x.Structural_Repair_Conducted,
                 MechanicalRepairConducted = x.Mechanical_Repair_Conducted,
                 InfiltrationSurfaceRestored = x.Infiltration_Surface_Restored,

--- a/Neptune.EFModels/Entities/TreatmentBMPAssessments.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPAssessments.cs
@@ -150,6 +150,7 @@ public static class TreatmentBMPAssessments
                 TreatmentBMPAssessmentTypeDisplayName = x.TreatmentBMPAssessmentTypeDisplayName,
                 IsAssessmentComplete = x.IsAssessmentComplete,
                 AssessmentScore = x.AssessmentScore,
+                IsFieldVisitVerified = x.IsFieldVisitVerified,
             })
             .ToList();
     }

--- a/Neptune.Models/DataTransferObjects/FieldVisit/MaintenanceRecordGridDto.cs
+++ b/Neptune.Models/DataTransferObjects/FieldVisit/MaintenanceRecordGridDto.cs
@@ -19,6 +19,7 @@ public class MaintenanceRecordGridDto
     public int? MaintenanceRecordTypeID { get; set; }
     public string? MaintenanceRecordTypeDisplayName { get; set; }
     public string? MaintenanceRecordDescription { get; set; }
+    public bool IsFieldVisitVerified { get; set; }
 
     // Maintenance observation columns mirroring vMaintenanceRecordDetailed
     public string? StructuralRepairConducted { get; set; }

--- a/Neptune.Models/DataTransferObjects/FieldVisit/TreatmentBMPAssessmentGridDto.cs
+++ b/Neptune.Models/DataTransferObjects/FieldVisit/TreatmentBMPAssessmentGridDto.cs
@@ -21,5 +21,6 @@ public class TreatmentBMPAssessmentGridDto
     public string? TreatmentBMPAssessmentTypeDisplayName { get; set; }
     public bool IsAssessmentComplete { get; set; }
     public double? AssessmentScore { get; set; }
+    public bool IsFieldVisitVerified { get; set; }
     public string Status => IsAssessmentComplete ? "Complete" : "In Progress";
 }

--- a/Neptune.Web/src/app/pages/field-records/field-records.component.ts
+++ b/Neptune.Web/src/app/pages/field-records/field-records.component.ts
@@ -154,7 +154,7 @@ export class FieldRecordsComponent implements OnInit {
                 const branch = row.TreatmentBMPAssessmentTypeDisplayName?.toLowerCase().includes("post") ? "post-maintenance-assessment" : "assessment";
                 return [
                     {
-                        ActionName: "View Observations",
+                        ActionName: row.IsFieldVisitVerified ? "View Observations" : "Edit Observations",
                         ActionHandler: () => this.router.navigate(["/field-visits", row.FieldVisitID, branch, "observations"]),
                     },
                 ];
@@ -181,7 +181,7 @@ export class FieldRecordsComponent implements OnInit {
                 const row: MaintenanceRecordGridDto = params.data;
                 return [
                     {
-                        ActionName: "Edit",
+                        ActionName: row.IsFieldVisitVerified ? "View" : "Edit",
                         ActionHandler: () => this.router.navigate(["/field-visits", row.FieldVisitID, "maintenance", "edit"]),
                     },
                 ];

--- a/Neptune.Web/src/app/shared/components/custom-attributes-editor/custom-attributes-editor.component.html
+++ b/Neptune.Web/src/app/shared/components/custom-attributes-editor/custom-attributes-editor.component.html
@@ -8,6 +8,7 @@
                 <form-field
                     [formControl]="attributeValuesByTypeIDFormControls[attrType.CustomAttributeType.CustomAttributeTypeID]"
                     [fieldLabel]="attrType.CustomAttributeType.CustomAttributeTypeName"
+                    [popoverDescription]="attrType.CustomAttributeType.CustomAttributeTypeDescription"
                     [type]="attributeFormTypeByTypeID[attrType.CustomAttributeType.CustomAttributeTypeID]"
                     [formInputOptions]="selectOptionsByTypeID[attrType.CustomAttributeType.CustomAttributeTypeID]"
                     [placeholder]="'Enter ' + attrType.CustomAttributeType.CustomAttributeTypeName"

--- a/Neptune.Web/src/app/shared/components/forms/form-field/form-field.component.html
+++ b/Neptune.Web/src/app/shared/components/forms/form-field/form-field.component.html
@@ -5,6 +5,17 @@
         } @else {
             {{ fieldLabel }}
         }
+        @if (popoverDescription) {
+            <i
+                class="fas fa-question-circle small"
+                style="cursor: help; margin-left: 0.25rem"
+                [popper]="popoverContentTpl"
+                [popperTitle]="popoverTitle || fieldLabel"
+                [useBodyContainer]="true"></i>
+            <ng-template #popoverContentTpl>
+                <div>{{ popoverDescription }}</div>
+            </ng-template>
+        }
     </ng-template>
     @if (!readOnly) {
         @switch (type) {

--- a/Neptune.Web/src/app/shared/components/forms/form-field/form-field.component.ts
+++ b/Neptune.Web/src/app/shared/components/forms/form-field/form-field.component.ts
@@ -43,7 +43,7 @@ export class FormFieldComponent {
     @Input() units: string;
     @Input() name: string;
     @Input() fieldDefinitionName: string;
-    /** Free-text description that renders as a hoverable/clickable help-icon next to the label,
+    /** Free-text description that renders as a click-to-open help-icon next to the label,
      * matching the pattern used on the BMP detail page's custom-attributes-display table for
      * attributes that have a description but no backing FieldDefinitionType row. Leave unset to
      * skip the icon entirely. */

--- a/Neptune.Web/src/app/shared/components/forms/form-field/form-field.component.ts
+++ b/Neptune.Web/src/app/shared/components/forms/form-field/form-field.component.ts
@@ -5,6 +5,7 @@ import { TinyMceConfigPipe } from "src/app/shared/pipes/tiny-mce-config.pipe";
 import { RequiredPipe } from "src/app/shared/pipes/required.pipe";
 import { InputErrorsComponent } from "src/app/shared/components/inputs/input-errors/input-errors.component";
 import { FieldDefinitionComponent } from "src/app/shared/components/field-definition/field-definition.component";
+import { PopperDirective } from "src/app/shared/directives/popper.directive";
 import { EditorComponent, TINYMCE_SCRIPT_SRC } from "@tinymce/tinymce-angular";
 
 import { NgxMaskDirective, provideNgxMask } from "ngx-mask";
@@ -26,7 +27,7 @@ import { NgSelectModule } from "@ng-select/ng-select";
         },
         provideNgxMask(),
     ],
-    imports: [NgTemplateOutlet, NgxMaskDirective, FormsModule, ReactiveFormsModule, EditorComponent, FieldDefinitionComponent, InputErrorsComponent, RequiredPipe, TinyMceConfigPipe, NgSelectModule],
+    imports: [NgTemplateOutlet, NgxMaskDirective, FormsModule, ReactiveFormsModule, EditorComponent, FieldDefinitionComponent, PopperDirective, InputErrorsComponent, RequiredPipe, TinyMceConfigPipe, NgSelectModule],
 })
 export class FormFieldComponent {
     public FormFieldType = FormFieldType;
@@ -42,6 +43,13 @@ export class FormFieldComponent {
     @Input() units: string;
     @Input() name: string;
     @Input() fieldDefinitionName: string;
+    /** Free-text description that renders as a hoverable/clickable help-icon next to the label,
+     * matching the pattern used on the BMP detail page's custom-attributes-display table for
+     * attributes that have a description but no backing FieldDefinitionType row. Leave unset to
+     * skip the icon entirely. */
+    @Input() popoverDescription: string;
+    /** Optional popover title; defaults to fieldLabel. */
+    @Input() popoverTitle: string;
     @Input() toggleHeight: string = "";
     @Input() mask: string;
 

--- a/Neptune.Web/src/app/shared/generated/model/maintenance-record-grid-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/maintenance-record-grid-dto.ts
@@ -26,6 +26,7 @@ export class MaintenanceRecordGridDto {
     MaintenanceRecordTypeID?: number | null;
     MaintenanceRecordTypeDisplayName?: string | null;
     MaintenanceRecordDescription?: string | null;
+    IsFieldVisitVerified?: boolean;
     StructuralRepairConducted?: string | null;
     MechanicalRepairConducted?: string | null;
     InfiltrationSurfaceRestored?: string | null;
@@ -61,6 +62,7 @@ export interface MaintenanceRecordGridDtoForm {
     MaintenanceRecordTypeID?: FormControl<number>;
     MaintenanceRecordTypeDisplayName?: FormControl<string>;
     MaintenanceRecordDescription?: FormControl<string>;
+    IsFieldVisitVerified?: FormControl<boolean>;
     StructuralRepairConducted?: FormControl<string>;
     MechanicalRepairConducted?: FormControl<string>;
     InfiltrationSurfaceRestored?: FormControl<string>;
@@ -219,6 +221,16 @@ export class MaintenanceRecordGridDtoFormControls {
         }
     );
     public static MaintenanceRecordDescription = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static IsFieldVisitVerified = (value: FormControlState<boolean> | boolean = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<boolean>(
         value,
         formControlOptions ?? 
         {

--- a/Neptune.Web/src/app/shared/generated/model/treatment-bmp-assessment-grid-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/treatment-bmp-assessment-grid-dto.ts
@@ -28,6 +28,7 @@ export class TreatmentBMPAssessmentGridDto {
     TreatmentBMPAssessmentTypeDisplayName?: string | null;
     IsAssessmentComplete?: boolean;
     AssessmentScore?: number | null;
+    IsFieldVisitVerified?: boolean;
     readonly Status?: string | null;
     constructor(obj?: any) {
         Object.assign(this, obj);
@@ -52,6 +53,7 @@ export interface TreatmentBMPAssessmentGridDtoForm {
     TreatmentBMPAssessmentTypeDisplayName?: FormControl<string>;
     IsAssessmentComplete?: FormControl<boolean>;
     AssessmentScore?: FormControl<number>;
+    IsFieldVisitVerified?: FormControl<boolean>;
     Status?: FormControl<string>;
 }
 
@@ -217,6 +219,16 @@ export class TreatmentBMPAssessmentGridDtoFormControls {
         }
     );
     public static AssessmentScore = (value: FormControlState<number> | number = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<number>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static IsFieldVisitVerified = (value: FormControlState<boolean> | boolean = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<boolean>(
         value,
         formControlOptions ?? 
         {


### PR DESCRIPTION
## Summary
- **J2 — Custom-attribute description popovers.** Add `popoverDescription` / `popoverTitle` inputs to the shared `form-field` component and wire `CustomAttributeTypeDescription` through `custom-attributes-editor`, so admins see each attribute's description (question-circle popover) while filling in the editor. Mirrors the existing `custom-attributes-display` pattern from the BMP detail view.
- **C — Action verb alignment across `/field-records` grids by verified status.** Surface `fv.IsFieldVisitVerified` through `vTreatmentBMPAssessmentDetailed` and `vMaintenanceRecordDetailed` into the two grid DTOs so the Angular component can render Edit vs View based on whether the parent field visit is verified.
  - Assessments grid action: `Edit Observations` if not verified, `View Observations` if verified.
  - Maintenance Records grid action: `Edit` if not verified, `View` if verified.
  - Field Visits grid was already dynamic (Continue/View) — unchanged.

## Test plan
- [ ] Spin up dev server, sign in as Admin.
- [ ] Navigate to a BMP whose type has custom attributes with non-empty `CustomAttributeTypeDescription`. Open a field visit → Inventory → Attributes step. Each attribute name should show a `?` icon; clicking opens the description popover.
- [ ] Sanity-check the BMP detail edit-custom-attributes / edit-images pages (also use `<custom-attributes-editor>`) — icons should render with no layout regression.
- [ ] On `/field-records`, switch between the three tabs. Pick a verified and an in-progress field visit in each tab and confirm the action labels flip between Edit/View as expected.