### PR TITLE
NPT-1032: PO rework — lock Select Area picker, scroll alerts on save

### DIFF
--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-add-remove-parcels/trash-ovta-add-remove-parcels.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-add-remove-parcels/trash-ovta-add-remove-parcels.component.html
@@ -1,21 +1,23 @@
 <page-header pageTitle="Select Assessment Area" [templateRight]="templateRight"></page-header>
 <ng-template #templateRight>
-  <button class="btn btn-primary" (click)="refreshParcels()">Refresh Assessment Area Based on Observations</button>
+  <button class="btn btn-primary" (click)="refreshTrigger$.next()">Refresh Assessment Area Based on Observations</button>
 </ng-template>
 @if (selectAreaContext$ | async; as selectAreaContext) {
   <workflow-body>
     <div class="grid-12">
       <div class="g-col-12 copy copy-2 mb-3">
-        <span [hidden]="selectAreaContext.IsDraftGeometryManuallyRefined">
-          Click the map to add or remove
-          {{ sourceTypeID === OvtaAreaSourceTypeEnum.LandUseBlock ? "land use blocks" : "parcels" }}
-          from the Assessment Area. Note that it may be necessary to zoom the map to see features.
-        </span>
-        <span [hidden]="!selectAreaContext.IsDraftGeometryManuallyRefined">
-          The Assessment Area has been manually refined in the Refine Assessment Area step. Adding or removing
-          {{ sourceTypeID === OvtaAreaSourceTypeEnum.LandUseBlock ? "land use blocks" : "parcels" }}
-          here, or using Refresh Assessment Area Based on Observations, will replace the refined shape.
-        </span>
+        @if (!selectAreaContext.IsDraftGeometryManuallyRefined) {
+          <span>
+            Click the map to add or remove
+            {{ sourceTypeID === OvtaAreaSourceTypeEnum.LandUseBlock ? "land use blocks" : "parcels" }}
+            from the Assessment Area. Note that it may be necessary to zoom the map to see features.
+          </span>
+        } @else {
+          <note noteType="warning">
+            The Assessment Area has been manually refined in the Refine Assessment Area step. Editing is locked here.
+            To replace the refined shape, refresh the assessment area above.
+          </note>
+        }
       </div>
     </div>
     <div class="grid-12 mb-2">
@@ -25,12 +27,9 @@
           [(ngModel)]="sourceTypeID"
           (ngModelChange)="onSourceTypeChange($event)">
         </btn-group-radio-input>
-        @if (!selectAreaContext.JurisdictionHasLandUseBlocks) {
-          <div class="text-muted mt-1"><small>No land use blocks uploaded for this jurisdiction.</small></div>
-        }
       </div>
     </div>
-    <app-alert-display></app-alert-display>
+    <app-alert-display #alertAnchor></app-alert-display>
     <neptune-map (onMapLoad)="handleMapReady($event, selectAreaContext)" mapHeight="600px" [showLegend]="true">
       @if (mapIsReady && sourceTypeID === OvtaAreaSourceTypeEnum.LandUseBlock) {
         <selected-land-use-block-layer
@@ -65,6 +64,6 @@
   </workflow-body>
 }
 <div class="page-footer">
-  <button class="btn btn-primary mr-2" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
+  <button class="btn btn-primary" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
   <button class="btn btn-primary-outline ml-auto" (click)="save(true)" [disabled]="isLoadingSubmit">Save & Continue</button>
 </div>

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-add-remove-parcels/trash-ovta-add-remove-parcels.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-add-remove-parcels/trash-ovta-add-remove-parcels.component.ts
@@ -1,9 +1,9 @@
-import { Component } from "@angular/core";
+import { Component, ElementRef, ViewChild } from "@angular/core";
 import { PageHeaderComponent } from "../../../../shared/components/page-header/page-header.component";
 import { AlertDisplayComponent } from "../../../../shared/components/alert-display/alert-display.component";
 import { Router } from "@angular/router";
 import { Input } from "@angular/core";
-import { Observable, of, tap } from "rxjs";
+import { merge, Observable, of, Subject, switchMap, tap } from "rxjs";
 import { NeptuneMapInitEvent, NeptuneMapComponent } from "src/app/shared/components/leaflet/neptune-map/neptune-map.component";
 import { WfsService } from "src/app/shared/services/wfs.service";
 import * as L from "leaflet";
@@ -28,6 +28,7 @@ import {
     BtnGroupRadioInputComponent,
     IBtnGroupRadioInputOption,
 } from "src/app/shared/components/inputs/btn-group-radio-input/btn-group-radio-input.component";
+import { NoteComponent } from "src/app/shared/components/note/note.component";
 
 @Component({
     selector: "trash-ovta-add-remove-parcels",
@@ -43,12 +44,18 @@ import {
         WorkflowBodyComponent,
         TransectLineLayerComponent,
         ParcelLayerComponent,
+        NoteComponent,
     ],
     templateUrl: "./trash-ovta-add-remove-parcels.component.html",
     styleUrl: "./trash-ovta-add-remove-parcels.component.scss",
 })
 export class TrashOvtaAddRemoveParcelsComponent {
     @Input() onlandVisualTrashAssessmentID!: number;
+    @ViewChild("alertAnchor", { read: ElementRef }) alertAnchor?: ElementRef<HTMLElement>;
+    /** Ping from the template (Refresh button) to re-fetch the context after backend regenerates
+     * DraftGeometry from observations. Wired into selectAreaContext$ via merge() so a single
+     * async-pipe subscription drives both initial load and refresh. */
+    public refreshTrigger$ = new Subject<void>();
     public selectAreaContext$: Observable<OnlandVisualTrashAssessmentSelectAreaContextDto>;
     public selectAreaContext: OnlandVisualTrashAssessmentSelectAreaContextDto;
     public map: L.Map;
@@ -84,14 +91,33 @@ export class TrashOvtaAddRemoveParcelsComponent {
 
     ngOnInit(): void {
         this.isLoading = true;
-        this.selectAreaContext$ = this.onlandVisualTrashAssessmentService
-            .getSelectAreaContextOnlandVisualTrashAssessment(this.onlandVisualTrashAssessmentID)
-            .pipe(
-                tap((context) => {
-                    this.applyContext(context);
-                    this.isLoading = false;
-                })
-            );
+        // Refresh flow: POST to clear DraftGeometry, then update the workflow progress sidebar.
+        // The trailing emission feeds into the merge below so the context is re-fetched after.
+        const refreshAndUpdateProgress$ = this.refreshTrigger$.pipe(
+            switchMap(() => this.onlandVisualTrashAssessmentService.refreshOnlandVisualTrashAssessmentParcelsOnlandVisualTrashAssessment(this.onlandVisualTrashAssessmentID)),
+            tap(() => this.ovtaWorkflowProgressService.updateProgress(this.onlandVisualTrashAssessmentID))
+        );
+        // One stream drives both initial load (of(undefined)) and post-refresh re-fetch. The
+        // async pipe in the template is the single subscriber.
+        this.selectAreaContext$ = merge(of(undefined), refreshAndUpdateProgress$).pipe(
+            switchMap(() => this.onlandVisualTrashAssessmentService.getSelectAreaContextOnlandVisualTrashAssessment(this.onlandVisualTrashAssessmentID)),
+            tap((context) => {
+                this.applyContext(context);
+                this.isLoading = false;
+                // On post-refresh emissions, the map is already initialized — re-style the
+                // parcel highlight and re-bind the click handler so they pick up the new context.
+                if (this.mapIsReady) {
+                    this.refreshParcelSelectionLayer(true);
+                    this.enableDisableMapClickEvent(context);
+                }
+            })
+        );
+    }
+
+    /** True when the area was hand-refined on the Refine step — picker is locked until the user
+     * presses Refresh, which clears DraftGeometry server-side and the flag flips back to false. */
+    public get isLockedPendingRefresh(): boolean {
+        return this.selectAreaContext?.IsDraftGeometryManuallyRefined === true;
     }
 
     private applyContext(context: OnlandVisualTrashAssessmentSelectAreaContextDto) {
@@ -99,9 +125,10 @@ export class TrashOvtaAddRemoveParcelsComponent {
         this.sourceTypeID = context.OvtaAreaSourceTypeID as OvtaAreaSourceTypeEnum;
         this.selectedParcelIDs = context.SelectedParcelIDs ?? [];
         this.selectedLandUseBlockIDs = context.SelectedLandUseBlockIDs ?? [];
+        const locked = context.IsDraftGeometryManuallyRefined === true;
         this.sourceTypeOptions = [
-            { label: "Parcels", value: OvtaAreaSourceTypeEnum.Parcel },
-            { label: "Land Use Blocks", value: OvtaAreaSourceTypeEnum.LandUseBlock, disabled: !context.JurisdictionHasLandUseBlocks },
+            { label: "Parcels", value: OvtaAreaSourceTypeEnum.Parcel, disabled: locked },
+            { label: "Land Use Blocks", value: OvtaAreaSourceTypeEnum.LandUseBlock, disabled: locked || !context.JurisdictionHasLandUseBlocks },
         ];
     }
 
@@ -121,6 +148,12 @@ export class TrashOvtaAddRemoveParcelsComponent {
         if (this.sourceTypeID === newSourceTypeID) {
             return;
         }
+        // While locked the radio options are disabled, but ngModel can still be flipped
+        // programmatically — snap back to the saved source type and bail.
+        if (this.isLockedPendingRefresh) {
+            this.sourceTypeID = this.selectAreaContext.OvtaAreaSourceTypeID as OvtaAreaSourceTypeEnum;
+            return;
+        }
         // Clear the inactive list so we don't accidentally save a stale union of mixed sources.
         // The user can still re-pick from the now-active layer; nothing is lost on the server
         // until they click Save.
@@ -137,6 +170,7 @@ export class TrashOvtaAddRemoveParcelsComponent {
      * selectedLandUseBlockIDs; we replace the array (rather than mutating) so Angular fires
      * ngOnChanges on the layer and it can re-style. */
     public onLandUseBlockClicked(landUseBlockID: number) {
+        if (this.isLockedPendingRefresh) return;
         if (this.selectedLandUseBlockIDs.includes(landUseBlockID)) {
             this.selectedLandUseBlockIDs = this.selectedLandUseBlockIDs.filter((id) => id !== landUseBlockID);
         } else {
@@ -183,32 +217,22 @@ export class TrashOvtaAddRemoveParcelsComponent {
                 this.ovtaWorkflowProgressService.updateProgress(this.onlandVisualTrashAssessmentID);
                 if (andContinue) {
                     this.router.navigate([`/trash/onland-visual-trash-assessments/edit/${this.onlandVisualTrashAssessmentID}/refine-assessment-area`]);
+                    return;
                 }
+                this.alertAnchor?.nativeElement.scrollIntoView({ behavior: "smooth", block: "start" });
             });
     }
 
-    public refreshParcels() {
-        this.onlandVisualTrashAssessmentService.refreshOnlandVisualTrashAssessmentParcelsOnlandVisualTrashAssessment(this.onlandVisualTrashAssessmentID).subscribe(() => {
-            // After clearing DraftGeometry, re-fetch the context so the saved source type and
-            // freshly-recomputed selection (from the transect line) come back together.
-            this.onlandVisualTrashAssessmentService
-                .getSelectAreaContextOnlandVisualTrashAssessment(this.onlandVisualTrashAssessmentID)
-                .subscribe((context) => {
-                    this.applyContext(context);
-                    this.refreshParcelSelectionLayer(true);
-                    this.enableDisableMapClickEvent(context);
-                    this.selectAreaContext$ = of(context);
-                });
-        });
-    }
-
-    /** Map-level click handler — used only for parcel mode (coordinate-query against WMS). LUB
-     * mode handles per-feature clicks directly on the vector layer. Stays active even when the
-     * area was manually refined: re-picking is a valid way for the user to discard the
-     * refinement (matches the LUB layer's behavior and the Refresh button's intent). */
+/** Map-level click handler — used only for parcel mode (coordinate-query against WMS). LUB
+     * mode handles per-feature clicks directly on the vector layer. Disabled while
+     * IsDraftGeometryManuallyRefined is true so a stray click can't silently overwrite the
+     * hand-refined polygon — user must press Refresh to unlock. */
     private enableDisableMapClickEvent(_context: OnlandVisualTrashAssessmentSelectAreaContextDto) {
         this.map.off("click");
         this.map.on("click", (event: L.LeafletMouseEvent): void => {
+            if (this.isLockedPendingRefresh) {
+                return;
+            }
             if (this.sourceTypeID !== OvtaAreaSourceTypeEnum.Parcel) {
                 return;
             }

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.html
@@ -1,7 +1,7 @@
 <page-header pageTitle="Record Observations"></page-header>
 @if (onlandVisualTrashAssessment$ | async; as onlandVisualTrashAssessment) {
   <workflow-body>
-    <app-alert-display></app-alert-display>
+    <app-alert-display #alertAnchor></app-alert-display>
     <p class="mb-3">
       Use the buttons below to add observations along your transect. Click "Record Observation at Current Location" to use your device's GPS,
       or "Add an Observation by clicking the map" to place a marker manually. Click a marker on the map to select it, then use the card below to add photos and notes.
@@ -89,6 +89,6 @@
   </workflow-body>
 }
 <div class="page-footer">
-  <button class="btn btn-primary mr-2" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
+  <button class="btn btn-primary" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
   <button class="btn btn-primary-outline ml-auto" (click)="save(true)" [disabled]="isLoadingSubmit">Save & Continue</button>
 </div>

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-record-observations/trash-ovta-record-observations.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from "@angular/core";
+import { Component, ElementRef, signal, ViewChild } from "@angular/core";
 import * as L from "leaflet";
 import { PageHeaderComponent } from "../../../../shared/components/page-header/page-header.component";
 import { NeptuneMapComponent, NeptuneMapInitEvent } from "../../../../shared/components/leaflet/neptune-map/neptune-map.component";
@@ -75,6 +75,7 @@ export class TrashOvtaRecordObservationsComponent {
     // Template ref used to ask the transect-line layer to re-fetch + redraw after a save so
     // the map reflects observation edits on the backing assessment without a full page reload.
     @ViewChild("transectLineLayer") transectLineLayer?: TransectLineLayerComponent;
+    @ViewChild("alertAnchor", { read: ElementRef }) alertAnchor?: ElementRef<HTMLElement>;
 
     constructor(
         private onlandVisualTrashAssessmentService: OnlandVisualTrashAssessmentService,
@@ -236,7 +237,9 @@ export class TrashOvtaRecordObservationsComponent {
                             this.router.navigate([`/trash/onland-visual-trash-assessments/edit/${this.onlandVisualTrashAssessmentID}/add-or-remove-parcels`]);
                         }
                     });
+                    return;
                 }
+                this.alertAnchor?.nativeElement.scrollIntoView({ behavior: "smooth", block: "start" });
             });
     }
 

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-refine-assessment-area/trash-ovta-refine-assessment-area.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-refine-assessment-area/trash-ovta-refine-assessment-area.component.html
@@ -1,7 +1,7 @@
 <page-header pageTitle="Refine Assessment Area"></page-header>
 @if (onlandVisualTrashAssessment$ | async; as onlandVisualTrashAssessment) {
 <workflow-body>
-    <app-alert-display></app-alert-display>
+    <app-alert-display #alertAnchor></app-alert-display>
     <div class="copy copy-2 mb-3">
         You may click or tap the edit button (<icon icon="GeomanEdit"></icon>) on the map below to adjust the Assessment Area's vertices. You may drag vertices to move them, click
         or tap existing vertices to create possible additional vertices near them, click or tap the slightly transparent vertices to create new vertices, or right-click to delete
@@ -30,6 +30,6 @@
 </workflow-body>
 }
 <div class="page-footer">
-    <button class="btn btn-primary mr-2" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
+    <button class="btn btn-primary" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
     <button class="btn btn-primary-outline ml-auto" (click)="save(true)" [disabled]="isLoadingSubmit">Save & Continue</button>
 </div>

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-refine-assessment-area/trash-ovta-refine-assessment-area.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-refine-assessment-area/trash-ovta-refine-assessment-area.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { Component, ElementRef, Input, ViewChild } from "@angular/core";
 import { Router } from "@angular/router";
 import { Observable, switchMap, tap } from "rxjs";
 import { NeptuneMapInitEvent, NeptuneMapComponent } from "src/app/shared/components/leaflet/neptune-map/neptune-map.component";
@@ -41,6 +41,7 @@ import { LeafletHelperService } from "src/app/shared/services/leaflet-helper.ser
 })
 export class TrashOvtaRefineAssessmentAreaComponent {
     @Input() onlandVisualTrashAssessmentID!: number;
+    @ViewChild("alertAnchor", { read: ElementRef }) alertAnchor?: ElementRef<HTMLElement>;
     public customRichTextTypeID = NeptunePageTypeEnum.EditOVTAArea;
     public isLoading: boolean = false;
 
@@ -108,7 +109,9 @@ export class TrashOvtaRefineAssessmentAreaComponent {
                 this.ovtaWorkflowProgressService.updateProgress(this.onlandVisualTrashAssessmentID);
                 if (andContinue) {
                     this.router.navigate([`/trash/onland-visual-trash-assessments/edit/${this.onlandVisualTrashAssessmentID}/review-and-finalize`]);
+                    return;
                 }
+                this.alertAnchor?.nativeElement.scrollIntoView({ behavior: "smooth", block: "start" });
             });
     }
 

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-review-and-finalize/trash-ovta-review-and-finalize.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-review-and-finalize/trash-ovta-review-and-finalize.component.html
@@ -1,7 +1,7 @@
 <page-header pageTitle="Review and Finalize"></page-header>
 @if (onlandVisualTrashAssessment$ | async; as onlandVisualTrashAssessment) {
   <workflow-body [showLoadingSpinner]="isLoadingSubmit">
-    <app-alert-display></app-alert-display>
+    <app-alert-display #alertAnchor></app-alert-display>
     <form class="form" [formGroup]="formGroup">
       <div class="grid-12">
         <form-field
@@ -88,6 +88,6 @@
     </workflow-body>
   }
   <div class="page-footer">
-    <button class="btn btn-primary mr-2" (click)="save()" [disabled]="formGroup.invalid || isLoadingSubmit">Save</button>
+    <button class="btn btn-primary" (click)="save()" [disabled]="formGroup.invalid || isLoadingSubmit">Save</button>
     <button class="btn btn-primary-outline ml-auto" (click)="save(true)" [disabled]="formGroup.invalid || isLoadingSubmit">Finalize</button>
   </div>

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-review-and-finalize/trash-ovta-review-and-finalize.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-review-and-finalize/trash-ovta-review-and-finalize.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { Component, ElementRef, ViewChild } from "@angular/core";
 import { FormArray, FormBuilder, FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from "@angular/forms";
 import { OnlandVisualTrashAssessmentService } from "src/app/shared/generated/api/onland-visual-trash-assessment.service";
 import { PageHeaderComponent } from "../../../../shared/components/page-header/page-header.component";
@@ -64,6 +64,7 @@ export class TrashOvtaReviewAndFinalizeComponent {
     });
 
     @Input() onlandVisualTrashAssessmentID!: number;
+    @ViewChild("alertAnchor", { read: ElementRef }) alertAnchor?: ElementRef<HTMLElement>;
 
     constructor(
         private onlandVisualTrashAssessmentService: OnlandVisualTrashAssessmentService,
@@ -151,7 +152,9 @@ export class TrashOvtaReviewAndFinalizeComponent {
                 this.ovtaWorkflowProgressService.updateProgress(this.onlandVisualTrashAssessmentID);
                 if (andContinue) {
                     this.router.navigate([`/trash/onland-visual-trash-assessments/${this.onlandVisualTrashAssessmentID}`]);
+                    return;
                 }
+                this.alertAnchor?.nativeElement.scrollIntoView({ behavior: "smooth", block: "start" });
             });
     }
 }


### PR DESCRIPTION
## Summary

Addresses KE's PO testing feedback (5/6/2026) on the OVTA Select / Refine Assessment Area flow.

- **Select Assessment Area** is now **locked** when the area was manually refined on the next step. The parcel/LUB map picker AND the source-type toggle both become non-interactive — a stray click can no longer silently overwrite the refined polygon. User must press **Refresh Assessment Area Based on Observations** to unlock. Locked-state help text now renders in a `<note noteType="warning">` instead of plain copy.
- **Reactive refresh pipeline**: `refreshParcels` is gone; the button click pings a `Subject` and a `merge(of(undefined), refreshTrigger$.pipe(switchMap → POST))` drives a single `selectAreaContext$` stream. The async pipe is the only subscriber, so the help text, toggle, and workflow sidebar all refresh together with no imperative `.subscribe()`.
- **Smooth-scroll alerts**: after a successful in-place Save on every OVTA workflow step (Record Observations, Select Assessment Area, Refine Assessment Area, Review and Finalize), the alert area is `scrollIntoView`'d so the success toast lands in the viewport instead of off-screen above the 600px map.
- **Save buttons**: dropped redundant `mr-2` on all four page-footer Save buttons — the global `.page-footer` flex `gap` already provides the spacing.

## Test plan

- [ ] **Refine Assessment Area save preserves edit mode**: enter vertex edit mode, drag a vertex, press Save → success toast scrolls into view, map stays in edit mode (user can keep editing).
- [ ] **Select Assessment Area lock after refinement**:
  - [ ] Complete Refine step (drag a vertex, Save), navigate back to Select Assessment Area.
  - [ ] Warning Note appears explaining editing is locked.
  - [ ] Parcels / Land Use Blocks radio toggle is disabled.
  - [ ] Clicking the parcel layer or a LUB feature does nothing.
- [ ] **Refresh unlocks**: press Refresh Assessment Area Based on Observations → warning Note disappears, toggle re-enables, clicks toggle selection again, workflow sidebar progress refreshes without a page reload.
- [ ] **Negative case**: on a fresh OVTA where the area was never hand-refined, picker and toggle work normally on first visit.
- [ ] **Scroll-on-save** on each of the four OVTA workflow steps with a long page: press Save → alert area smoothly scrolls into view.
- [ ] **Save button spacing**: page-footer Save / Save & Continue have visible gap (from the global flex rule) with no double-spacing.
- [ ] **Regression sweep**: green-passing AC items from KE's review still hold — Parcel/LUB toggle present, defaults correct per jurisdiction LUB availability, switching modes clears inactive list, sidebar label still reads "Select Assessment Area".

🤖 Generated with [Claude Code](https://claude.com/claude-code)