### PR TITLE
NPT-1054: AI Module - Source Control BMPs (wizard Step 4)

### DIFF
--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component.html
@@ -61,18 +61,26 @@
     </div>
 
     @if (extractionEvidence || documentSource) {
-        <button class="field-card__evidence-toggle" (click)="toggleEvidence()">
-            <i class="fa" [class.fa-chevron-down]="!showEvidence()" [class.fa-chevron-up]="showEvidence()"></i>
-            Evidence
-        </button>
-        @if (showEvidence()) {
+        <!--
+            NPT-1054: page-number link sits inline with the Evidence toggle so the user can
+            jump to the PDF page without expanding the panel. The expandable panel now only
+            contains the extracted snippet text; when there's no snippet (just a page link),
+            no toggle button is rendered at all.
+        -->
+        <div class="field-card__evidence-header">
+            @if (extractionEvidence) {
+                <button class="field-card__evidence-toggle" (click)="toggleEvidence()">
+                    <i class="fa" [class.fa-chevron-down]="!showEvidence()" [class.fa-chevron-up]="showEvidence()"></i>
+                    Evidence
+                </button>
+            }
+            @if (documentSource) {
+                <span class="field-card__source field-card__source--clickable" (click)="goToSource()"><i class="fa fa-file-pdf-o"></i> {{ documentSource }}</span>
+            }
+        </div>
+        @if (showEvidence() && extractionEvidence) {
             <div class="field-card__evidence">
-                @if (documentSource) {
-                    <span class="field-card__source field-card__source--clickable" (click)="goToSource()"><i class="fa fa-file-pdf-o"></i> {{ documentSource }}</span>
-                }
-                @if (extractionEvidence) {
-                    <p class="field-card__snippet field-card__snippet--clickable" (click)="goToSource()" title="Jump to this passage in the PDF">{{ extractionEvidence }}</p>
-                }
+                <p class="field-card__snippet field-card__snippet--clickable" (click)="goToSource()" title="Jump to this passage in the PDF">{{ extractionEvidence }}</p>
             </div>
         }
     }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component.scss
@@ -136,13 +136,22 @@
         margin-top: 0.5rem;
     }
 
+    // NPT-1054: row that holds the Evidence toggle and the (now-inline) document-source
+    // page link side-by-side, so users can jump to the PDF page without expanding the panel.
+    &__evidence-header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.75rem;
+        margin-top: 0.25rem;
+    }
+
     &__evidence-toggle {
         border: none;
         background: none;
         color: $gray-400;
         font-size: $type-size-100;
         cursor: pointer;
-        margin-top: 0.25rem;
         padding: 0;
 
         &:hover {
@@ -165,8 +174,7 @@
     &__source {
         font-weight: 600;
         color: $primary;
-        display: block;
-        margin-bottom: 0.25rem;
+        font-size: $type-size-100;
 
         &--clickable {
             cursor: pointer;

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.html
@@ -28,7 +28,7 @@
             <thead>
                 <tr>
                     <th class="review-summary__col-label">Field</th>
-                    <th class="review-summary__col-value">Extracted Value</th>
+                    <th class="review-summary__col-value">Workflow Value</th>
                     <th class="review-summary__col-value">WQMP Record</th>
                     <th class="review-summary__col-status">Status</th>
                 </tr>
@@ -37,28 +37,22 @@
                 @for (row of rows; track row.label) {
                     <tr>
                         <td class="review-summary__col-label">{{ row.label }}</td>
-                        <td class="review-summary__col-value" [class.review-summary__col-value--empty]="row.displayValue === '(not set)' || row.displayValue === '(rejected)'">
+                        <td class="review-summary__col-value"
+                            [class.review-summary__col-value--empty]="row.displayValue === '(not set)'"
+                            [class.review-summary__col-value--rejected]="isWorkflowRejected(row)">
                             {{ row.displayValue }}
+                            @if (row.origin === "ai" && row.state !== "rejected" && row.displayValue !== "(not set)") {
+                                <span class="review-summary__ai-badge" title="AI-extracted from the uploaded PDF"><i class="fa fa-magic"></i> AI</span>
+                            }
                         </td>
                         <td class="review-summary__col-value" [class.review-summary__col-value--empty]="!row.wqmpRecordValue">
                             {{ row.wqmpRecordValue ?? "—" }}
                         </td>
                         <td class="review-summary__col-status">
-                            @switch (row.state) {
-                                @case ("accepted") { <span class="status-pill status-pill--accepted">Accepted</span> }
-                                @case ("edited") { <span class="status-pill status-pill--edited">Edited</span> }
-                                @case ("rejected") { <span class="status-pill status-pill--rejected">Rejected</span> }
-                                @default {
-                                    @if (row.wqmpRecordValue) {
-                                        <span class="status-pill status-pill--accepted">Accepted</span>
-                                    } @else if (row.origin === "user") {
-                                        <span class="status-pill status-pill--user">User-entered</span>
-                                    } @else if (row.origin === "blank") {
-                                        <span class="status-pill status-pill--blank">Blank in source</span>
-                                    } @else {
-                                        <span class="status-pill status-pill--pending">AI-pending</span>
-                                    }
-                                }
+                            @switch (getSaveStatus(row)) {
+                                @case ("saved") { <span class="status-pill status-pill--saved">Saved</span> }
+                                @case ("pending") { <span class="status-pill status-pill--pending">Pending save</span> }
+                                @case ("empty") { <span class="status-pill status-pill--empty">Empty</span> }
                             }
                         </td>
                     </tr>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.html
@@ -1,52 +1,69 @@
 <div class="review-summary">
     @for (group of groups; track group.title) {
-        <section class="review-summary__group">
-            <h3 class="review-summary__group-title">{{ group.title }}</h3>
-            <table class="review-summary__table">
-                <thead>
-                    <tr>
-                        <th class="review-summary__col-label">Field</th>
-                        <th class="review-summary__col-value">Extracted Value</th>
-                        <th class="review-summary__col-value">WQMP Record</th>
-                        <th class="review-summary__col-status">Status</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @for (row of group.rows; track row.label) {
-                        <tr>
-                            <td class="review-summary__col-label">{{ row.label }}</td>
-                            <td class="review-summary__col-value" [class.review-summary__col-value--empty]="row.displayValue === '(not set)' || row.displayValue === '(rejected)'">
-                                {{ row.displayValue }}
-                            </td>
-                            <td class="review-summary__col-value" [class.review-summary__col-value--empty]="!row.wqmpRecordValue">
-                                {{ row.wqmpRecordValue ?? "—" }}
-                            </td>
-                            <td class="review-summary__col-status">
-                                @switch (row.state) {
-                                    @case ("accepted") { <span class="status-pill status-pill--accepted">Accepted</span> }
-                                    @case ("edited") { <span class="status-pill status-pill--edited">Edited</span> }
-                                    @case ("rejected") { <span class="status-pill status-pill--rejected">Rejected</span> }
-                                    @default {
-                                        @if (row.wqmpRecordValue) {
-                                            <!-- pending but a value already exists on the WQMP record -->
-                                            <span class="status-pill status-pill--accepted">Accepted</span>
-                                        } @else if (row.origin === "user") {
-                                            <span class="status-pill status-pill--user">User-entered</span>
-                                        } @else if (row.origin === "blank") {
-                                            <span class="status-pill status-pill--blank">Blank in source</span>
-                                        } @else {
-                                            <span class="status-pill status-pill--pending">AI-pending</span>
-                                        }
-                                    }
-                                }
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
+        <section class="review-summary__group" [class.review-summary__group--collapsible]="group.collapsible">
+            @if (group.collapsible) {
+                <!-- NPT-1054: native <details> collapsible for groups that can run long (Source
+                     Control BMP categories). Defaults to closed; user expands per category. -->
+                <details [attr.open]="group.initiallyOpen ? '' : null">
+                    <summary class="review-summary__group-summary">
+                        <h3 class="review-summary__group-title">
+                            {{ group.title }}
+                            <span class="review-summary__count">({{ group.rows.length }})</span>
+                        </h3>
+                    </summary>
+                    <ng-container *ngTemplateOutlet="groupTable; context: { rows: group.rows }"></ng-container>
+                </details>
+            } @else {
+                <h3 class="review-summary__group-title">{{ group.title }}</h3>
+                <ng-container *ngTemplateOutlet="groupTable; context: { rows: group.rows }"></ng-container>
+            }
         </section>
     }
     @if (groups.length === 0) {
         <p class="review-summary__empty">No extracted data to summarize.</p>
     }
+
+    <ng-template #groupTable let-rows="rows">
+        <table class="review-summary__table">
+            <thead>
+                <tr>
+                    <th class="review-summary__col-label">Field</th>
+                    <th class="review-summary__col-value">Extracted Value</th>
+                    <th class="review-summary__col-value">WQMP Record</th>
+                    <th class="review-summary__col-status">Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for (row of rows; track row.label) {
+                    <tr>
+                        <td class="review-summary__col-label">{{ row.label }}</td>
+                        <td class="review-summary__col-value" [class.review-summary__col-value--empty]="row.displayValue === '(not set)' || row.displayValue === '(rejected)'">
+                            {{ row.displayValue }}
+                        </td>
+                        <td class="review-summary__col-value" [class.review-summary__col-value--empty]="!row.wqmpRecordValue">
+                            {{ row.wqmpRecordValue ?? "—" }}
+                        </td>
+                        <td class="review-summary__col-status">
+                            @switch (row.state) {
+                                @case ("accepted") { <span class="status-pill status-pill--accepted">Accepted</span> }
+                                @case ("edited") { <span class="status-pill status-pill--edited">Edited</span> }
+                                @case ("rejected") { <span class="status-pill status-pill--rejected">Rejected</span> }
+                                @default {
+                                    @if (row.wqmpRecordValue) {
+                                        <span class="status-pill status-pill--accepted">Accepted</span>
+                                    } @else if (row.origin === "user") {
+                                        <span class="status-pill status-pill--user">User-entered</span>
+                                    } @else if (row.origin === "blank") {
+                                        <span class="status-pill status-pill--blank">Blank in source</span>
+                                    } @else {
+                                        <span class="status-pill status-pill--pending">AI-pending</span>
+                                    }
+                                }
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </ng-template>
 </div>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.scss
@@ -83,3 +83,39 @@
     &--user { background: $gray-100; color: $gray-700; }
     &--blank { background: $gray-100; color: $gray-500; }
 }
+
+// NPT-1054: collapsible category sections (Source Control BMPs).
+.review-summary__group--collapsible {
+    details {
+        > summary {
+            cursor: pointer;
+            user-select: none;
+            list-style: none;
+            display: flex;
+            align-items: center;
+            padding: 0.25rem 0;
+
+            &::-webkit-details-marker { display: none; }
+            &::before {
+                content: "\25B6";
+                margin-right: 0.5rem;
+                font-size: 0.7rem;
+                color: $gray-600;
+                transition: transform 0.15s ease;
+            }
+        }
+
+        &[open] > summary::before { transform: rotate(90deg); }
+    }
+}
+
+.review-summary__count {
+    font-weight: normal;
+    color: $gray-600;
+    margin-left: 0.4rem;
+    font-size: 0.85em;
+}
+
+.review-summary__group-summary {
+    .review-summary__group-title { margin: 0; }
+}

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.scss
@@ -52,6 +52,13 @@
             color: $gray-400;
             font-style: italic;
         }
+        // NPT-1054: rejection-intent is shown in the cell (workflow value "(rejected)") while
+        // Status only carries the save-state diff. Muted red distinguishes it from a plain
+        // empty cell so the user can see at a glance that the rejection still needs saving.
+        &--rejected {
+            color: $danger;
+            font-style: italic;
+        }
     }
 
     &__col-status {
@@ -65,8 +72,12 @@
     }
 }
 
-// Status pill colors mirror the field-card origin pills so the visual language is
-// consistent across the workflow.
+// NPT-1054: Status pill now encodes the workflow-vs-record diff state only — provenance
+// (AI / record / user) is conveyed by the inline AI pill in the Workflow Value cell and
+// the WQMP Record column itself. Three states:
+//   - Saved        → workflow matches record (both non-empty, equal). Green.
+//   - Pending save → workflow differs from record (edit/add/reject not yet persisted). Amber.
+//   - Empty        → both workflow and record are empty. Muted gray.
 .status-pill {
     display: inline-block;
     font-size: 0.7rem;
@@ -76,12 +87,9 @@
     letter-spacing: 0.04em;
     font-weight: 600;
 
-    &--accepted { background: rgba(34, 197, 94, 0.15); color: #15803d; }
-    &--edited { background: rgba(245, 158, 11, 0.14); color: #b45309; }
-    &--rejected { background: rgba(220, 53, 69, 0.12); color: $danger; }
-    &--pending { background: rgba(0, 153, 171, 0.12); color: $primary; }
-    &--user { background: $gray-100; color: $gray-700; }
-    &--blank { background: $gray-100; color: $gray-500; }
+    &--saved { background: rgba(34, 197, 94, 0.15); color: #15803d; }
+    &--pending { background: rgba(245, 158, 11, 0.14); color: #b45309; }
+    &--empty { background: $gray-100; color: $gray-500; }
 }
 
 // NPT-1054: collapsible category sections (Source Control BMPs).
@@ -118,4 +126,24 @@
 
 .review-summary__group-summary {
     .review-summary__group-title { margin: 0; }
+}
+
+// NPT-1054: inline AI tag rendered next to the Workflow Value when that value originated
+// from extraction. Compact pill so it doesn't dominate the cell.
+.review-summary__ai-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-left: 0.4rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    background: rgba(0, 153, 171, 0.12);
+    color: $primary;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    vertical-align: middle;
+
+    i { font-size: 0.6rem; }
 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from "@angular/core";
+import { NgTemplateOutlet } from "@angular/common";
 import { ExtractedField } from "src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component";
 import { FormFieldType, SelectDropdownOption } from "src/app/shared/components/forms/form-field/form-field.component";
 
@@ -14,6 +15,11 @@ import { FormFieldType, SelectDropdownOption } from "src/app/shared/components/f
 export interface ReviewSummaryGroup {
     title: string;
     rows: ReviewSummaryRow[];
+    // NPT-1054: when true, the group renders as a native <details> so the user can toggle
+    // visibility. Used for the Source Control BMP categories — there are ~36 rows total
+    // and collapsing keeps the summary scannable.
+    collapsible?: boolean;
+    initiallyOpen?: boolean;
 }
 
 export interface ReviewSummaryRow {
@@ -30,7 +36,7 @@ export interface ReviewSummaryRow {
 @Component({
     selector: "review-summary",
     standalone: true,
-    imports: [],
+    imports: [NgTemplateOutlet],
     templateUrl: "./review-summary.component.html",
     styleUrl: "./review-summary.component.scss",
 })
@@ -39,6 +45,10 @@ export class ReviewSummaryComponent {
     @Input() basicsFields: ExtractedField[] = [];
     @Input() parcelFields: ExtractedField[] = [];
     @Input() bmpGroups: { bmpIndex: number; displayName: string | null; fields: ExtractedField[]; isRejected: boolean }[] = [];
+    // NPT-1054: flat list of Source Control BMP rows with values (rows where IsPresent is
+    // null AND Note is empty are pre-filtered out by the parent). hasEvidence is true when
+    // any of the row's fields came from the AI extractor.
+    @Input() sourceControlRows: { categoryName: string; attributeName: string; isPresent: boolean | null; note: string; hasEvidence: boolean; wqmpRecordValue: string | null }[] = [];
     @Input() lookupOptionsByKey: Record<string, SelectDropdownOption[]> = {};
     // NPT-1051: parent supplies a key→liveWqmpValue resolver so the summary can render the
     // third "WQMP Record" column without duplicating the key→DTO field mapping in the child.
@@ -57,6 +67,31 @@ export class ReviewSummaryComponent {
 
         if (this.basicsFields.length) {
             groups.push({ title: "Basics", rows: this.basicsFields.map((f) => this.toRow(f)) });
+        }
+
+        if (this.sourceControlRows.length) {
+            // NPT-1054: group by category and emit one collapsible section per category so
+            // the summary stays scannable even with ~36 total SC rows. Show ALL attributes,
+            // including unset ones (rendered as "(not set)" with a blank-source pill).
+            const byCategory = new Map<string, ReviewSummaryRow[]>();
+            for (const r of this.sourceControlRows) {
+                if (!byCategory.has(r.categoryName)) byCategory.set(r.categoryName, []);
+                const isUnset = r.isPresent == null && !r.note;
+                const presentDisplay = r.isPresent === true ? "Yes" : r.isPresent === false ? "No" : "—";
+                const display = isUnset
+                    ? "(not set)"
+                    : r.note ? `${presentDisplay} — ${r.note}` : presentDisplay;
+                byCategory.get(r.categoryName)!.push({
+                    label: r.attributeName,
+                    displayValue: display,
+                    wqmpRecordValue: r.wqmpRecordValue,
+                    state: isUnset ? "pending" : "accepted",
+                    origin: isUnset ? "blank" : r.hasEvidence ? "ai" : "user",
+                });
+            }
+            for (const [category, rows] of byCategory.entries()) {
+                groups.push({ title: category, rows, collapsible: true, initiallyOpen: false });
+            }
         }
 
         if (this.bmpGroups.length) {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.ts
@@ -141,4 +141,25 @@ export class ReviewSummaryComponent {
         }
         return String(raw);
     }
+
+    /**
+     * NPT-1054 diff-dashboard Status. Status carries only the workflow-vs-record diff state;
+     * provenance ("AI", "User", etc.) is conveyed elsewhere (AI pill in the Workflow Value
+     * cell, the WQMP Record column itself). Three states:
+     *  - "saved":   Workflow value matches WQMP record (both non-empty, equal strings).
+     *  - "empty":   Both workflow and record are empty — nothing to save, nothing on record.
+     *  - "pending": Workflow differs from record — the user has unsaved changes (including
+     *               additions, edits, and rejections that haven't been persisted yet).
+     */
+    public getSaveStatus(row: ReviewSummaryRow): "saved" | "pending" | "empty" {
+        const workflowEmpty = !row.displayValue || row.displayValue === "(not set)" || row.displayValue === "(rejected)";
+        const recordEmpty = !row.wqmpRecordValue;
+        if (workflowEmpty && recordEmpty) return "empty";
+        if (!workflowEmpty && !recordEmpty && row.displayValue === row.wqmpRecordValue) return "saved";
+        return "pending";
+    }
+
+    public isWorkflowRejected(row: ReviewSummaryRow): boolean {
+        return row.displayValue === "(rejected)";
+    }
 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
@@ -56,7 +56,7 @@
              reference evidence on the PDF. Use [hidden] rather than @if so the iframe
              stays mounted across step navigation; otherwise pdfLoaded / pendingNavigation /
              pdfTextCache get out of sync with the new iframe instance on return. -->
-        <div class="pdf-panel" [hidden]="currentStep() === 4">
+        <div class="pdf-panel" [hidden]="currentStep() === 5">
             @if (isNavigating()) {
                 <div class="pdf-panel__loading">
                     <i class="fa fa-spinner fa-spin"></i> Finding in document...
@@ -83,7 +83,7 @@
         </div>
 
         <!-- Review Panel -->
-        <div class="review-panel" [class.review-panel--full-width]="currentStep() === 4">
+        <div class="review-panel" [class.review-panel--full-width]="currentStep() === 5">
             <div class="review-panel__header">
                 <div class="review-panel__header-text">
                     <h2>{{ steps[currentStep() - 1].title }}</h2>
@@ -105,6 +105,10 @@
                 } @else if (pageData.hasResult && currentStep() === 3) {
                     <button class="btn btn-primary review-panel__header-action" (click)="saveBmps()" [disabled]="savingSection() !== null || isExtracting()">
                         @if (savingSection() === "bmps") { <i class="fa fa-spinner fa-spin"></i> Saving... } @else { Save }
+                    </button>
+                } @else if (pageData.hasResult && currentStep() === 4) {
+                    <button class="btn btn-primary review-panel__header-action" (click)="saveSourceControlBmps()" [disabled]="savingSection() !== null || isExtracting()">
+                        @if (savingSection() === "source-control") { <i class="fa fa-spinner fa-spin"></i> Saving... } @else { Save }
                     </button>
                 }
             </div>
@@ -167,12 +171,13 @@
                         </button>
                     }
 
-                    @if (currentStep() === 4) {
+                    @if (currentStep() === 5) {
                         <review-summary
                             [locationFields]="summaryLocationFields"
                             [basicsFields]="summaryBasicsFields"
                             [parcelFields]="summaryParcelFields"
                             [bmpGroups]="summaryBmpGroups"
+                            [sourceControlRows]="summarySourceControlRows"
                             [lookupOptionsByKey]="summaryLookupOptionsByKey"
                             [getWqmpFieldValue]="getWqmpFieldValueBound">
                         </review-summary>
@@ -197,6 +202,82 @@
                         @if (bmpGroupsForCurrentStep.length === 0) {
                             <div class="review-panel__empty-state">
                                 No Simple BMPs were detected in this document. You can proceed to the next step.
+                            </div>
+                        }
+                    }
+
+                    @if (currentStep() === 4) {
+                        <p class="review-panel__sc-intro">
+                            All Source Control BMP attributes are listed below, grouped by category. AI-extracted suggestions are pre-filled and marked with <i class="fa fa-magic"></i>. Click the icon to jump to the supporting evidence in the PDF.
+                        </p>
+                        @for (group of sourceControlGroups; track group.category) {
+                            <div class="sc-category-panel">
+                                <div class="sc-category-panel__heading" (click)="toggleSourceControlCategory(group)">
+                                    <h5>
+                                        {{ group.category }}
+                                        <i class="fa" [class.fa-chevron-down]="!group.collapsed" [class.fa-chevron-right]="group.collapsed"></i>
+                                    </h5>
+                                </div>
+                                @if (!group.collapsed) {
+                                    <div class="sc-category-panel__body">
+                                        <table class="source-control-review-table">
+                                            <thead>
+                                                <tr>
+                                                    <th class="col-attribute">Source Control Attribute</th>
+                                                    <th class="col-present">Present?</th>
+                                                    <th class="col-notes">Note</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                @for (row of group.rows; track row.get("SourceControlBMPAttributeID")!.value) {
+                                                    <tr [formGroup]="row">
+                                                        <td class="col-attribute">
+                                                            <label>{{ row.get("SourceControlBMPAttributeName")!.value }}</label>
+                                                        </td>
+                                                        <td class="col-present">
+                                                            <div class="sc-cell">
+                                                                <form-field
+                                                                    size="sm"
+                                                                    [formControl]="$any(row.controls['IsPresent'])"
+                                                                    [type]="FormFieldType.Radio"
+                                                                    [name]="'isPresent_' + row.get('SourceControlBMPAttributeID')!.value"
+                                                                    [formInputOptions]="isPresentOptions"></form-field>
+                                                                @if (sourceControlIsPresentEvidence.get(row.get("SourceControlBMPAttributeID")!.value); as ev) {
+                                                                    <button type="button" class="sc-ai-badge"
+                                                                        [title]="ev.evidence ?? 'AI-extracted from the uploaded PDF'"
+                                                                        (click)="navigateToSourceControlEvidence(row.get('SourceControlBMPAttributeID')!.value, 'isPresent')">
+                                                                        <i class="fa fa-magic"></i>
+                                                                    </button>
+                                                                }
+                                                            </div>
+                                                        </td>
+                                                        <td class="col-notes">
+                                                            <div class="sc-cell">
+                                                                <form-field
+                                                                    size="sm"
+                                                                    [formControl]="$any(row.controls['SourceControlBMPNote'])"
+                                                                    [type]="FormFieldType.Text"
+                                                                    placeholder=""></form-field>
+                                                                @if (sourceControlNoteEvidence.get(row.get("SourceControlBMPAttributeID")!.value); as ev) {
+                                                                    <button type="button" class="sc-ai-badge"
+                                                                        [title]="ev.evidence ?? 'AI-extracted from the uploaded PDF'"
+                                                                        (click)="navigateToSourceControlEvidence(row.get('SourceControlBMPAttributeID')!.value, 'note')">
+                                                                        <i class="fa fa-magic"></i>
+                                                                    </button>
+                                                                }
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                }
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                }
+                            </div>
+                        }
+                        @if (sourceControlGroups.length === 0) {
+                            <div class="review-panel__empty-state">
+                                No Source Control BMP attributes are configured. You can proceed to the next step.
                             </div>
                         }
                     }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
@@ -233,6 +233,12 @@
                                                     <tr [formGroup]="row">
                                                         <td class="col-attribute">
                                                             <label>{{ row.get("SourceControlBMPAttributeName")!.value }}</label>
+                                                            @switch (getSourceControlRowOrigin(row)) {
+                                                                @case ("edited") { <span class="sc-origin-pill sc-origin-pill--edited">Edited</span> }
+                                                                @case ("record") { <span class="sc-origin-pill sc-origin-pill--record">On record</span> }
+                                                                @case ("ai") { <span class="sc-origin-pill sc-origin-pill--ai">AI-extracted</span> }
+                                                                @case ("blank") { <span class="sc-origin-pill sc-origin-pill--blank">Blank</span> }
+                                                            }
                                                         </td>
                                                         <td class="col-present">
                                                             <div class="sc-cell">

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.scss
@@ -3,11 +3,16 @@
 .review-layout {
     display: flex;
     // Pin to viewport height minus the site header stack so the three panels always fit on
-    // one screen. min-height keeps the PDF panel large enough to render a readable page on
-    // short viewports; any overflow is absorbed by the field-list's internal scroll rather
-    // than by scrolling the whole review page.
+    // one screen. Any overflow is absorbed by the field-list's internal scroll rather than
+    // by scrolling the whole review page.
+    //
+    // NPT-1054: dropped min-height from 640px → 480px so the page-level scroll never
+    // engages on viewports ~700-820px tall. The previous 640px floor pushed `.review-layout`
+    // taller than the remaining viewport when extended, breaking the internal scroll of
+    // `.review-panel__fields`. 480 keeps the PDF readable on short viewports while letting
+    // the layout shrink to fit normal ones.
     height: calc(100dvh - 180px);
-    min-height: 640px;
+    min-height: 480px;
     overflow: hidden;
 }
 
@@ -220,7 +225,10 @@
 
 // Review Panel
 .review-panel {
-    width: 420px;
+    // NPT-1054: bumped from 420 to 720 so Step 4's 3-column Source Control table has room
+    // for long attribute names (e.g. "Design Outdoor Hazardous Material Storage Areas...")
+    // without wrapping. Other steps absorb the extra space cleanly (fields are flex anyway).
+    width: 720px;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
@@ -391,4 +399,109 @@
         flex: 0 0 auto;
         white-space: nowrap;
     }
+}
+
+// NPT-1054: Step 4 (Source Control BMPs) — mirrors edit-source-control-bmps's table layout
+// inside collapsible category panels.
+.review-panel__sc-intro {
+    margin: 0 0 0.75rem;
+    font-size: $type-size-200;
+    color: $gray-700;
+
+    i.fa-magic { color: $primary; }
+}
+
+// NPT-1054: simplified category styling — bold header + bottom border, no card/panel
+// chrome. Body keeps a max-height + internal scroll so users can keep all 3 categories
+// expanded and scroll within each to see all rows.
+.sc-category-panel {
+    margin-bottom: 0.75rem;
+
+    &__heading {
+        padding: 0.4rem 0 0.3rem;
+        cursor: pointer;
+        user-select: none;
+        border-bottom: 1px solid $gray-200;
+
+        h5 {
+            margin: 0;
+            font-size: $type-size-300;
+            font-weight: 700;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+    }
+
+    &__body {
+        padding: 0.25rem 0 0.5rem;
+        max-height: 28vh;
+        overflow-y: auto;
+    }
+}
+
+// NPT-1054: minimal table styling — no Bootstrap .table chrome, no outer border, no
+// row striping. Just bold uppercase column headers with a subtle underline, then plain
+// rows. Form-fields inside also inherit the compact size.
+.source-control-review-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: $type-size-150;
+
+    th, td {
+        vertical-align: middle;
+        padding: 0.3rem 0.4rem;
+        border: 0;
+        background: transparent;
+    }
+
+    thead th {
+        font-size: $type-size-100;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+        color: $gray-700;
+        border-bottom: 1px solid $gray-200;
+        text-align: left;
+    }
+
+    .col-attribute { width: auto; }
+    .col-present   { width: 130px; }
+    .col-notes     { width: 180px; }
+
+    label { font-weight: normal; margin: 0; }
+
+    form-field {
+        display: block;
+        font-size: $type-size-150;
+        ::ng-deep input, ::ng-deep .radio-group label { font-size: $type-size-150; }
+    }
+}
+
+.sc-cell {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+
+    form-field { flex: 1 1 auto; }
+}
+
+.sc-ai-badge {
+    flex: 0 0 auto;
+    background: transparent;
+    border: 1px solid $primary;
+    color: $primary;
+    border-radius: 50%;
+    width: 1.4rem;
+    height: 1.4rem;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.15s ease;
+    padding: 0;
+
+    &:hover { background: rgba($primary, 0.08); }
+
+    i { font-size: 0.7rem; }
 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.scss
@@ -486,6 +486,44 @@
     form-field { flex: 1 1 auto; }
 }
 
+// NPT-1054: per-row provenance pill on Step 4. Mirrors the .origin-pill on the field-card
+// component (Steps 1–3) so users can read where a row's value came from at a glance:
+//  - On record   → prefilled from saved WQMP state (won't be wiped on save)
+//  - AI-extracted → prefilled from the AI; no saved value on the record yet
+//  - Edited      → user changed it in this session
+//  - Blank       → nothing on record, AI didn't extract
+.sc-origin-pill {
+    display: inline-block;
+    margin-top: 0.15rem;
+    font-size: 0.65rem;
+    padding: 0.05rem 0.45rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+    line-height: 1.4;
+
+    &--ai {
+        background: rgba(0, 153, 171, 0.12);
+        color: $primary;
+    }
+
+    &--record {
+        background: rgba(34, 197, 94, 0.14);
+        color: #15803d;
+    }
+
+    &--edited {
+        background: rgba(245, 158, 11, 0.14);
+        color: #b45309;
+    }
+
+    &--blank {
+        background: $gray-100;
+        color: $gray-500;
+    }
+}
+
 .sc-ai-badge {
     flex: 0 0 auto;
     background: transparent;

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -6,7 +6,7 @@ import { BehaviorSubject, EMPTY, finalize, forkJoin, map, Observable, switchMap,
 import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
 import { PdfJsViewerModule, PdfJsViewerComponent } from "ng2-pdfjs-viewer";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
-import { FormFieldType, SelectDropdownOption } from "src/app/shared/components/forms/form-field/form-field.component";
+import { FormFieldComponent, FormFieldType, SelectDropdownOption } from "src/app/shared/components/forms/form-field/form-field.component";
 import { AlertService } from "src/app/shared/services/alert.service";
 import { Alert } from "src/app/shared/models/alert";
 import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
@@ -23,6 +23,9 @@ import { WaterQualityManagementPlanSectionSaveResponseDto } from "src/app/shared
 import { EvidenceBoundingBox, FieldCardComponent, SourceNavigation } from "src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component";
 import { BmpReviewCardComponent } from "src/app/pages/wqmps/wqmp-detail/wqmp-review/bmp-review-card/bmp-review-card.component";
 import { ReviewSummaryComponent } from "src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component";
+import { SourceControlBMPUpsertDto } from "src/app/shared/generated/model/source-control-bmp-upsert-dto";
+import { SourceControlBMPDto } from "src/app/shared/generated/model/source-control-bmp-dto";
+import { FormArray, FormControl, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
 import { IDeactivateComponent } from "src/app/shared/guards/unsaved-changes.guard";
 import { escapeHtml } from "src/app/shared/helpers/html-escape";
 import { WaterQualityManagementPlanPrioritiesAsSelectDropdownOptions } from "src/app/shared/generated/enum/water-quality-management-plan-priority-enum";
@@ -64,7 +67,7 @@ export interface ExtractedField {
 @Component({
     selector: "wqmp-review",
     standalone: true,
-    imports: [AlertDisplayComponent, FieldCardComponent, BmpReviewCardComponent, ReviewSummaryComponent, PdfJsViewerModule, RouterLink, AsyncPipe],
+    imports: [AlertDisplayComponent, FieldCardComponent, BmpReviewCardComponent, ReviewSummaryComponent, PdfJsViewerModule, RouterLink, AsyncPipe, ReactiveFormsModule, FormFieldComponent],
     templateUrl: "./wqmp-review.component.html",
     styleUrl: "./wqmp-review.component.scss",
 })
@@ -94,6 +97,25 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     // draft persistence. The card-level "reject this BMP" overlay is tracked separately
     // in `rejectedBmpIndices` because it spans multiple fields.
     public readonly BMP_KEY_PREFIX = "__BMP__-";
+    // NPT-1054: Step 4 Source Control BMP state. Mirrors edit-source-control-bmps's
+    // FormArray-of-FormGroups so the table-row UX is identical. AI-extracted evidence is
+    // tracked in parallel maps keyed by SourceControlBMPAttributeID — surfaced as small
+    // inline AI badges in the IsPresent / Note cells (click → navigate to PDF source).
+    public readonly isPresentOptions: SelectDropdownOption[] = [
+        { Value: true, Label: "Yes" } as SelectDropdownOption,
+        { Value: false, Label: "No" } as SelectDropdownOption,
+    ];
+    public sourceControlRows = new FormArray<FormGroup>([]);
+    public sourceControlGroups: { category: string; rows: FormGroup[]; collapsed: boolean }[] = [];
+    public sourceControlIsPresentEvidence = new Map<number, { value: any; evidence: string | null; source: string | null; boundingBox: EvidenceBoundingBox | null }>();
+    public sourceControlNoteEvidence = new Map<number, { value: any; evidence: string | null; source: string | null; boundingBox: EvidenceBoundingBox | null }>();
+    public sourceControlDirty = signal(false);
+    /** Cached attribute list (categories + names + IDs) loaded once with the other lookups. */
+    private sourceControlAttributesCache: SourceControlBMPUpsertDto[] = [];
+    // What's actually saved on the WQMP record, keyed by AttributeID. Refreshed every time the
+    // inner forkJoin runs (initial mount + reload$ emissions). Drives the "WQMP Record" column
+    // on the Step 5 Review summary — Step 4 itself stays AI-only.
+    private existingSourceControlByAttributeID = new Map<number, SourceControlBMPDto>();
     public readonly BMP_FIELD_KEYS = [
         "QuickBMPName",
         "TreatmentBMPType",
@@ -139,7 +161,7 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     public pdfBlob: Blob | null = null;
     // NPT-1051: per-section save in progress. Set while POST /save-{location|basics|bmps} is
     // outstanding; binds the corresponding step's Save button to a spinner + disabled state.
-    public savingSection = signal<"location" | "basics" | "bmps" | null>(null);
+    public savingSection = signal<"location" | "basics" | "bmps" | "source-control" | null>(null);
     // NPT-1051: hasUnsavedChanges is derived from field state — any field accepted/edited/
     // rejected (or any card-level BMP rejection) counts as dirty until the corresponding section
     // Save commits. UnsavedChangesGuard reads canExit() which reads this.
@@ -149,6 +171,7 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     // suggestion. That auto-accept is settled state — not unsaved review work — so it doesn't
     // count toward hasUnsavedChanges. Editing or rejecting a user-entered field still counts.
     public hasUnsavedChanges = computed(() => {
+        if (this.sourceControlDirty()) return true;
         return this.fields().some((f) => {
             if (f.state === "pending") return false;
             if (f.isUserEntered && f.state === "accepted") return false;
@@ -187,7 +210,9 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
         { number: 1, title: "Location", desc: "Jurisdiction & parcels" },
         { number: 2, title: "Basics", desc: "Project details & contacts" },
         { number: 3, title: "BMPs", desc: "Treatment controls" },
-        { number: 4, title: "Review", desc: "Final review" },
+        // NPT-1054: Source Control BMPs slot in between BMPs and the final Review.
+        { number: 4, title: "Source Control BMPs", desc: "Operational / non-structural controls" },
+        { number: 5, title: "Review", desc: "Final review" },
     ];
 
     // Fields per step
@@ -225,6 +250,11 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     };
 
     ngOnInit(): void {
+        // NPT-1054: any user edit on the SC FormArray flips the dirty signal. Reset back to
+        // false on (re)build (buildSourceControlRowsFromParsed clears it after pushing rows)
+        // and after a successful save.
+        this.sourceControlRows.valueChanges.subscribe(() => this.sourceControlDirty.set(true));
+
         // Load lookup options first, then parse extraction results
         const jurisdictions$ = this.jurisdictionService.listViewableStormwaterJurisdiction().pipe(
             map((j) => j.map((x) => ({ Label: x.StormwaterJurisdictionName, Value: x.StormwaterJurisdictionID }) as SelectDropdownOption)),
@@ -244,10 +274,17 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 .sort((a, b) => a.Label.localeCompare(b.Label))),
             catchError(() => of([] as SelectDropdownOption[]))
         );
+        // NPT-1054: full Source Control BMP attribute list (with category info) drives Step 4's
+        // collapsible-by-category grid. Loaded with the other lookups so parseExtractionResult
+        // can pre-fill rows synchronously when extraction results are present.
+        const sourceControlAttributes$ = this.wqmpService.listSourceControlBMPAttributesWaterQualityManagementPlan().pipe(
+            catchError(() => of([] as SourceControlBMPUpsertDto[]))
+        );
 
-        this.pageData$ = forkJoin([jurisdictions$, hydrologicSubareas$, treatmentBMPTypes$]).pipe(
-            tap(([jurisdictions, hydrologicSubareas, treatmentBMPTypes]) => {
+        this.pageData$ = forkJoin([jurisdictions$, hydrologicSubareas$, treatmentBMPTypes$, sourceControlAttributes$]).pipe(
+            tap(([jurisdictions, hydrologicSubareas, treatmentBMPTypes, sourceControlAttributes]) => {
                 this.treatmentBMPTypeOptions.set(treatmentBMPTypes);
+                this.sourceControlAttributesCache = sourceControlAttributes;
                 this.lookupFieldConfig = {
                     Jurisdiction: { options: jurisdictions, dtoField: "StormwaterJurisdictionID" },
                     HydrologicSubarea: { options: hydrologicSubareas, dtoField: "HydrologicSubareaID" },
@@ -269,16 +306,31 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 documents: this.wqmpService.listDocumentsWaterQualityManagementPlan(this.waterQualityManagementPlanID),
                 // NPT-1051: live WQMP record drives Step 4's WQMP Record column.
                 wqmp: this.wqmpService.getWaterQualityManagementPlan(this.waterQualityManagementPlanID),
+                // NPT-1054: previously-saved Source Control BMPs feed the Step 5 Review's
+                // "WQMP Record" column so the user can see what's already on the record next
+                // to the (possibly empty) AI extraction for each attribute. Does NOT prefill
+                // Step 4 — the wizard intentionally only shows AI-extracted suggestions there.
+                existingSourceControl: this.wqmpService.listSourceControlBMPsWaterQualityManagementPlan(this.waterQualityManagementPlanID).pipe(
+                    catchError(() => of([] as SourceControlBMPDto[]))
+                ),
             })),
-            tap(({ extractionResult, wqmp }) => {
+            tap(({ extractionResult, wqmp, existingSourceControl }) => {
                 this.currentResult.set(extractionResult);
                 this.liveWqmp.set(wqmp);
+                this.existingSourceControlByAttributeID = new Map(
+                    (existingSourceControl ?? [])
+                        .filter((e) => e?.SourceControlBMPAttributeID != null)
+                        .map((e) => [e.SourceControlBMPAttributeID!, e] as const)
+                );
                 if (extractionResult?.ExtractionResultJson) {
                     this.parseExtractionResult(extractionResult.ExtractionResultJson);
                 } else {
                     // Either no extraction yet, or the prior run failed (failure row carries
                     // ErrorMessage/ErrorCode but null JSON). Surface the error if present.
                     this.fields.set([]);
+                    // NPT-1054: still build blank SC rows so Step 4 renders without error
+                    // when there's no extraction yet (AC: empty form, no error).
+                    this.buildSourceControlRowsFromParsed(null);
                     if (extractionResult?.ErrorMessage) {
                         // ErrorMessage echoes server-side data (Anthropic SDK errors include the
                         // upstream JSON body). Alerts render via [innerHTML] so HTML-escape the
@@ -392,9 +444,10 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     get fieldsForCurrentStep(): ExtractedField[] {
         // Step 3's BMP fields are grouped under bmp-review-card components rather than
         // rendered flat — exclude them from the top-level field list so the Step 1/2
-        // template path doesn't duplicate them.
+        // template path doesn't duplicate them. Step 4 (Source Control BMPs) doesn't put
+        // anything on the ExtractedField list; it uses its own FormArray state.
         return this.fields().filter(
-            (f) => f.step === this.currentStep() && !f.key.startsWith(this.BMP_KEY_PREFIX)
+            (f) => f.step === this.currentStep() && !f.key.startsWith(this.BMP_KEY_PREFIX),
         );
     }
 
@@ -432,6 +485,155 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 return { bmpIndex, displayName, fields, isRejected: rejected.has(bmpIndex) };
             });
     }
+    /**
+     * NPT-1054: build the Source Control FormArray from the loaded attribute list and
+     * (optionally) the extraction JSON. Mirrors edit-source-control-bmps's row schema so
+     * the table-row UX is identical. Evidence (per IsPresent / per Note) is parked in
+     * sibling Maps so the inline AI badge can render and source-navigate.
+     *
+     * Called from parseExtractionResult (both extraction-present and extraction-absent
+     * paths) so Step 4 always renders with all attribute rows visible (AC: empty form,
+     * no error).
+     */
+    private buildSourceControlRowsFromParsed(parsed: any): void {
+        // Map extraction entries by attribute-name for fast lookup. Empty when no extraction.
+        const extractedByName = new Map<string, any>();
+        const scArr = parsed?.SourceControlBMPs;
+        if (Array.isArray(scArr)) {
+            for (const entry of scArr) {
+                const name = entry?.SourceControlBMPAttribute?.Value;
+                if (typeof name === "string" && name.length > 0) {
+                    extractedByName.set(name.toLowerCase(), entry);
+                }
+            }
+        }
+
+        // Reset (load may run multiple times on reload$). Stop emitting valueChanges while
+        // we rebuild so we don't flip sourceControlDirty during seeding.
+        this.sourceControlRows.clear({ emitEvent: false });
+        this.sourceControlIsPresentEvidence.clear();
+        this.sourceControlNoteEvidence.clear();
+
+        for (const attr of this.sourceControlAttributesCache) {
+            const extractedEntry = extractedByName.get(attr.SourceControlBMPAttributeName?.toLowerCase() ?? "");
+            const isPresentExtracted = extractedEntry?.IsPresent;
+            const noteExtracted = extractedEntry?.SourceControlBMPNote;
+
+            // Coerce "Yes"/"No"/true/false from Claude to the boolean | null shape the
+            // form-field Radio + isPresentOptions expect.
+            let isPresentValue: boolean | null = null;
+            const rawIsPresent = isPresentExtracted?.Value;
+            if (typeof rawIsPresent === "boolean") {
+                isPresentValue = rawIsPresent;
+            } else if (typeof rawIsPresent === "string") {
+                const lc = rawIsPresent.trim().toLowerCase();
+                isPresentValue = lc === "yes" || lc === "true" ? true
+                    : lc === "no" || lc === "false" ? false
+                    : null;
+            }
+
+            // Step 4 is the AI-review surface: only AI-extracted values prefill the form.
+            // Previously-saved-but-not-AI values live on the WQMP record (visible from the
+            // standalone edit page) and intentionally do NOT bleed into the wizard so the
+            // user is always reviewing AI suggestions, not their own prior edits.
+            const row = new FormGroup({
+                SourceControlBMPAttributeID: new FormControl<number>(attr.SourceControlBMPAttributeID),
+                SourceControlBMPAttributeName: new FormControl<string>(attr.SourceControlBMPAttributeName ?? null),
+                SourceControlBMPAttributeCategoryID: new FormControl<number>(attr.SourceControlBMPAttributeCategoryID),
+                SourceControlBMPAttributeCategoryName: new FormControl<string>(attr.SourceControlBMPAttributeCategoryName ?? null),
+                IsPresent: new FormControl<boolean | null>(isPresentValue),
+                SourceControlBMPNote: new FormControl<string>(noteExtracted?.Value ?? "", { validators: [Validators.maxLength(200)] }),
+            });
+            this.sourceControlRows.push(row, { emitEvent: false });
+
+            // Park evidence for inline AI-badge rendering. Only stash when the AI actually
+            // matched the attribute (entry present) — empty rows render without a badge.
+            if (isPresentExtracted) {
+                this.sourceControlIsPresentEvidence.set(attr.SourceControlBMPAttributeID, {
+                    value: rawIsPresent,
+                    evidence: isPresentExtracted.ExtractionEvidence ?? null,
+                    source: isPresentExtracted.DocumentSource ?? null,
+                    boundingBox: this.parseBoundingBox(isPresentExtracted.BoundingBox),
+                });
+            }
+            if (noteExtracted) {
+                this.sourceControlNoteEvidence.set(attr.SourceControlBMPAttributeID, {
+                    value: noteExtracted.Value,
+                    evidence: noteExtracted.ExtractionEvidence ?? null,
+                    source: noteExtracted.DocumentSource ?? null,
+                    boundingBox: this.parseBoundingBox(noteExtracted.BoundingBox),
+                });
+            }
+        }
+
+        this.rebuildSourceControlGroups();
+        this.sourceControlDirty.set(false);
+    }
+
+    private rebuildSourceControlGroups(): void {
+        const groupMap = new Map<string, FormGroup[]>();
+        for (const row of this.sourceControlRows.controls) {
+            const category = row.get("SourceControlBMPAttributeCategoryName")!.value as string;
+            if (!groupMap.has(category)) groupMap.set(category, []);
+            groupMap.get(category)!.push(row);
+        }
+        this.sourceControlGroups = Array.from(groupMap.entries()).map(([category, rows]) => ({
+            category, rows, collapsed: false,
+        }));
+    }
+
+    public toggleSourceControlCategory(group: { collapsed: boolean }): void {
+        group.collapsed = !group.collapsed;
+    }
+
+    /** Used by Step 4 cells: navigate the PDF viewer to the AI evidence for a given attr+kind. */
+    public navigateToSourceControlEvidence(attrID: number, kind: "isPresent" | "note"): void {
+        const evidence = kind === "isPresent"
+            ? this.sourceControlIsPresentEvidence.get(attrID)
+            : this.sourceControlNoteEvidence.get(attrID);
+        if (!evidence) return;
+        const key = `__SourceControl__-${attrID}-${kind}`;
+        this.selectedFieldKey.set(key);
+        this.navigateToSource({
+            value: evidence.value != null ? String(evidence.value) : null,
+            evidence: evidence.evidence,
+            documentSource: evidence.source,
+            boundingBox: evidence.boundingBox,
+        });
+    }
+
+    /** Used by ReviewSummary input — flatten the FormArray to read-only rows for the summary. */
+    get summarySourceControlRows(): { categoryName: string; attributeName: string; isPresent: boolean | null; note: string; hasEvidence: boolean; wqmpRecordValue: string | null }[] {
+        // Emit every attribute row — the child summary renders unset rows as "(not set)" so
+        // all three categories still appear (collapsed) even when AI extracted nothing and
+        // the user hasn't touched Step 4. Keeps the Review structure stable.
+        const out: { categoryName: string; attributeName: string; isPresent: boolean | null; note: string; hasEvidence: boolean; wqmpRecordValue: string | null }[] = [];
+        for (const row of this.sourceControlRows.controls) {
+            const isPresent = row.get("IsPresent")!.value as boolean | null;
+            const note = ((row.get("SourceControlBMPNote")!.value as string) ?? "").trim();
+            const attrID = row.get("SourceControlBMPAttributeID")!.value as number;
+            const saved = this.existingSourceControlByAttributeID.get(attrID);
+            const savedDisplay = this.formatSavedSourceControlValue(saved);
+            out.push({
+                categoryName: row.get("SourceControlBMPAttributeCategoryName")!.value as string,
+                attributeName: row.get("SourceControlBMPAttributeName")!.value as string,
+                isPresent,
+                note,
+                hasEvidence: this.sourceControlIsPresentEvidence.has(attrID) || this.sourceControlNoteEvidence.has(attrID),
+                wqmpRecordValue: savedDisplay,
+            });
+        }
+        return out;
+    }
+
+    private formatSavedSourceControlValue(saved: SourceControlBMPDto | undefined): string | null {
+        if (!saved) return null;
+        const note = (saved.SourceControlBMPNote ?? "").trim();
+        if (saved.IsPresent == null && !note) return null;
+        const presentDisplay = saved.IsPresent === true ? "Yes" : saved.IsPresent === false ? "No" : "—";
+        return note ? `${presentDisplay} — ${note}` : presentDisplay;
+    }
+
     get summaryLookupOptionsByKey(): Record<string, SelectDropdownOption[]> {
         const map: Record<string, SelectDropdownOption[]> = {};
         for (const [key, cfg] of Object.entries(this.lookupFieldConfig)) {
@@ -1032,6 +1234,61 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
         });
     }
 
+    // NPT-1054: Source Control BMP section save. Reads from the FormArray (same state model
+    // as edit-source-control-bmps), filters out rows that have neither IsPresent nor a Note,
+    // and goes through the existing PUT /source-control-bmps endpoint (merge semantics).
+    // AC: 400 surfaces as inline alert without leaving Step 4.
+    saveSourceControlBmps(): void {
+        const noteMaxLength = 200;
+
+        if (this.sourceControlRows.invalid) {
+            this.sourceControlRows.markAllAsTouched();
+            const overflowed: string[] = [];
+            for (const row of this.sourceControlRows.controls) {
+                const noteCtl = row.get("SourceControlBMPNote");
+                if (noteCtl?.errors?.["maxlength"]) {
+                    overflowed.push(`"${row.get("SourceControlBMPAttributeName")!.value}"`);
+                }
+            }
+            this.alertService.pushAlert(new Alert(
+                overflowed.length > 0
+                    ? `${overflowed.length} note(s) exceed the ${noteMaxLength}-character limit: ${overflowed.join(", ")}.`
+                    : "Please correct the highlighted fields before saving.",
+                AlertContext.Danger,
+            ));
+            return;
+        }
+
+        this.savingSection.set("source-control");
+        this.alertService.clearAlerts();
+
+        const dtos: SourceControlBMPUpsertDto[] = [];
+        for (const row of this.sourceControlRows.controls) {
+            const isPresent = row.get("IsPresent")!.value as boolean | null;
+            const note = ((row.get("SourceControlBMPNote")!.value as string) ?? "").trim();
+            if (isPresent == null && !note) continue;
+
+            dtos.push(new SourceControlBMPUpsertDto({
+                SourceControlBMPAttributeID: row.get("SourceControlBMPAttributeID")!.value as number,
+                SourceControlBMPAttributeCategoryID: row.get("SourceControlBMPAttributeCategoryID")!.value as number,
+                SourceControlBMPAttributeCategoryName: row.get("SourceControlBMPAttributeCategoryName")!.value as string,
+                SourceControlBMPAttributeName: row.get("SourceControlBMPAttributeName")!.value as string,
+                IsPresent: isPresent,
+                SourceControlBMPNote: note || null,
+            }));
+        }
+
+        this.wqmpService.mergeSourceControlBMPsWaterQualityManagementPlan(this.waterQualityManagementPlanID, dtos).pipe(
+            finalize(() => this.savingSection.set(null)),
+        ).subscribe({
+            next: () => {
+                this.alertService.pushAlert(new Alert("Source Control BMPs saved.", AlertContext.Success));
+                this.sourceControlDirty.set(false);
+            },
+            error: (err: HttpErrorResponse) => this.handleSectionSaveError(err, "Source Control BMPs"),
+        });
+    }
+
     // Builds an UpsertDto seeded with every field on the live WQMP, then overlays the
     // accepted/edited/pending values for the keys in `sectionKeys`. Rejected and
     // out-of-section fields fall through to the live value untouched.
@@ -1411,6 +1668,11 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                     }
                 });
             }
+
+            // NPT-1054 Step 4: extract the SourceControlBMPs[] map for downstream FormArray
+            // hydration (handled in buildSourceControlRowsFromParsed). Done here so the same
+            // parse pass that drives Steps 1/2/3 also captures SC evidence.
+            this.buildSourceControlRowsFromParsed(parsed);
 
             // Jurisdiction + WQMP Name are user-entered in the upload modal — they are
             // authoritative and don't need review. Override the AI-extracted values, mark

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -518,31 +518,40 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
             const extractedEntry = extractedByName.get(attr.SourceControlBMPAttributeName?.toLowerCase() ?? "");
             const isPresentExtracted = extractedEntry?.IsPresent;
             const noteExtracted = extractedEntry?.SourceControlBMPNote;
+            const saved = this.existingSourceControlByAttributeID.get(attr.SourceControlBMPAttributeID);
 
             // Coerce "Yes"/"No"/true/false from Claude to the boolean | null shape the
             // form-field Radio + isPresentOptions expect.
-            let isPresentValue: boolean | null = null;
+            let extractedIsPresentValue: boolean | null = null;
             const rawIsPresent = isPresentExtracted?.Value;
             if (typeof rawIsPresent === "boolean") {
-                isPresentValue = rawIsPresent;
+                extractedIsPresentValue = rawIsPresent;
             } else if (typeof rawIsPresent === "string") {
                 const lc = rawIsPresent.trim().toLowerCase();
-                isPresentValue = lc === "yes" || lc === "true" ? true
+                extractedIsPresentValue = lc === "yes" || lc === "true" ? true
                     : lc === "no" || lc === "false" ? false
                     : null;
             }
 
-            // Step 4 is the AI-review surface: only AI-extracted values prefill the form.
-            // Previously-saved-but-not-AI values live on the WQMP record (visible from the
-            // standalone edit page) and intentionally do NOT bleed into the wizard so the
-            // user is always reviewing AI suggestions, not their own prior edits.
+            // Saved-first prefill (NPT-1054): the form reflects what's currently on the WQMP
+            // record so the replace-all save endpoint can't silently drop untouched attributes.
+            // AI-extracted values fill gaps for attributes the user hasn't saved yet. AI badges
+            // mark cells the AI extracted (see sourceControlIsPresentEvidence /
+            // sourceControlNoteEvidence Maps) regardless of which source supplied the value.
+            const isPresentValue: boolean | null = saved
+                ? (saved.IsPresent ?? null)
+                : extractedIsPresentValue;
+            const noteValue: string = saved
+                ? (saved.SourceControlBMPNote ?? "")
+                : (noteExtracted?.Value ?? "");
+
             const row = new FormGroup({
                 SourceControlBMPAttributeID: new FormControl<number>(attr.SourceControlBMPAttributeID),
                 SourceControlBMPAttributeName: new FormControl<string>(attr.SourceControlBMPAttributeName ?? null),
                 SourceControlBMPAttributeCategoryID: new FormControl<number>(attr.SourceControlBMPAttributeCategoryID),
                 SourceControlBMPAttributeCategoryName: new FormControl<string>(attr.SourceControlBMPAttributeCategoryName ?? null),
                 IsPresent: new FormControl<boolean | null>(isPresentValue),
-                SourceControlBMPNote: new FormControl<string>(noteExtracted?.Value ?? "", { validators: [Validators.maxLength(200)] }),
+                SourceControlBMPNote: new FormControl<string>(noteValue, { validators: [Validators.maxLength(200)] }),
             });
             this.sourceControlRows.push(row, { emitEvent: false });
 
@@ -626,6 +635,25 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
         return out;
     }
 
+    /**
+     * Per-row origin pill for Step 4. Mirrors the AI-extracted / User-entered / Blank /
+     * Edited labelling on the Steps 1–3 field cards so users can see provenance at a glance.
+     *  - "edited"  → user changed this row in the current session (FormGroup is dirty)
+     *  - "record"  → row prefilled from the WQMP record (saved value, regardless of AI)
+     *  - "ai"      → AI extracted a value and there's no saved value on the record
+     *  - "blank"   → nothing on record and AI didn't extract anything
+     */
+    public getSourceControlRowOrigin(row: FormGroup): "ai" | "record" | "edited" | "blank" {
+        if (row.dirty) return "edited";
+        const attrID = row.get("SourceControlBMPAttributeID")!.value as number;
+        const saved = this.existingSourceControlByAttributeID.get(attrID);
+        const isPresent = saved?.IsPresent ?? null;
+        const note = (saved?.SourceControlBMPNote ?? "").trim();
+        if (saved && (isPresent != null || note)) return "record";
+        if (this.sourceControlIsPresentEvidence.has(attrID) || this.sourceControlNoteEvidence.has(attrID)) return "ai";
+        return "blank";
+    }
+
     private formatSavedSourceControlValue(saved: SourceControlBMPDto | undefined): string | null {
         if (!saved) return null;
         const note = (saved.SourceControlBMPNote ?? "").trim();
@@ -633,6 +661,7 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
         const presentDisplay = saved.IsPresent === true ? "Yes" : saved.IsPresent === false ? "No" : "—";
         return note ? `${presentDisplay} — ${note}` : presentDisplay;
     }
+
 
     get summaryLookupOptionsByKey(): Record<string, SelectDropdownOption[]> {
         const map: Record<string, SelectDropdownOption[]> = {};


### PR DESCRIPTION
## Summary
- Adds **Step 4: Source Control BMPs** between BMPs and Review in the WQMP AI review wizard. All 36 attributes are shown across the three category panels with inline AI badges on AI-extracted cells.
- **Saved-first prefill** on Step 4: the FormArray seeds from the WQMP record, with AI extraction filling gaps for attributes the record doesn't have yet. Avoids silent data loss on the replace-all merge save when the user only edits a subset of attributes.
- Per-row provenance pill on Step 4 (`On record` / `AI-extracted` / `Edited` / `Blank`) so the user can see where each row's current value came from at a glance. Dirty rows flip to Edited.
- **Step 5 (Review) reframed as a diff dashboard** per Kathleen's intent. Workflow Value column carries an inline AI pill when the AI extracted anything for that field, and renders `(rejected)` in muted red to signal rejection intent. Status column collapses to three diff states: **Saved** (workflow == record), **Pending save** (workflow != record, including unsaved rejections), and **Empty** (both blank). Old provenance-flavored Status values (AI-pending, User-entered, Blank in source) dropped.
- **Evidence panel polish** (shared across Steps 1–3): page-link moved out of the collapsed body and onto the same row as the Evidence toggle so users can jump to the PDF page without expanding. Toggle is suppressed entirely when there's no extracted snippet to show.

## Test plan
- [ ] Open a WQMP with an extraction that included Source Control BMPs — Step 4 shows the AI-extracted values with `fa-magic` badges; pill says `AI-extracted`.
- [ ] Open a WQMP with manually-saved SC values (e.g. WQMP 1114) — Step 4 prefills from the record; pill says `On record`. Save Step 4 with no edits → record unchanged.
- [ ] Edit a row → pill flips to `Edited`. Save → reload wizard → pill says `On record` with the new value.
- [ ] Reject a field on Steps 1–3 → Review shows `(rejected)` in muted red under Workflow Value, Status reads `Pending save`. Save the section → Status flips to `Empty`.
- [ ] Verify Status column reads `Saved` (green) when Workflow Value matches WQMP Record on rows you've already saved.
- [ ] Evidence: on any field card across Steps 1–3, the page-link (e.g. "page 3") now sits on the same row as the Evidence toggle. Click it without expanding — PDF viewer jumps to that page. Fields with no extracted snippet have no toggle button, just the inline page-link.
- [ ] No-extraction case: open the wizard for a WQMP without an extraction result yet — Step 4 renders 36 blank rows under the three categories; no errors.