### PR TITLE
NPT-1054: Source Control BMP extraction (v3 prompt, MaxTokens bump, 2003-era support)

### DIFF
--- a/Neptune.API/Services/AI/PromptTemplateService.cs
+++ b/Neptune.API/Services/AI/PromptTemplateService.cs
@@ -30,7 +30,7 @@ public sealed class PromptTemplateService : IPromptTemplateService
         [PromptTemplate.ExtractWqmpFields] = "v2",
         [PromptTemplate.ExtractParcels] = "v2",
         [PromptTemplate.ExtractQuickBMPs] = "v3",
-        [PromptTemplate.ExtractSourceControlBMPs] = "v2",
+        [PromptTemplate.ExtractSourceControlBMPs] = "v3",
     };
 
     private readonly string _promptsDirectory;

--- a/Neptune.API/Services/AI/Prompts/ExtractQuickBMPs_v3.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractQuickBMPs_v3.md
@@ -26,6 +26,8 @@ Footnotes attached to a BMP table count as part of that table's content — extr
 
 **Variant templates exist.** The "North OC Priority WQMP Template August 2011" omits the free-form treatment-control table and describes structural treatment BMPs directly in the Biotreatment section. Some other templates use entirely custom numbering or merge categories. In any layout, prioritize content semantics — *is this site committing to this BMP?* — over the document's organizational scheme.
 
+**Older "South-OC 2003" templates** use a flat S-code numbering (S1 – S20) that mixes Source Controls and Treatment Controls. **S-codes roughly S1 – S14 are Source Controls** (Site Design + Structural Source Controls — trash enclosures, fueling areas, vehicle wash, etc.) and are extracted by the SourceControlBMPs tool, **not by this one**. Skip them here. Only S-codes ≥ S15 (typically Inlet Trash Racks, Water Quality Inlets, Hydrodynamic Separators, and other treatment devices) are QuickBMPs and should be extracted here.
+
 **Non-standard or unrecognized BMPs.** If the document selects a BMP that doesn't fit any vendor alias or canonical category cleanly, extract it anyway: put the document's name verbatim in `QuickBMPName`, put your best canonical guess (or the document's own type label if it gave one) in `TreatmentBMPType`, and leave staff to remap during review. Do not skip a BMP because it doesn't fit the template — a missed BMP is worse than a mis-typed one.
 
 Other supporting evidence: BMP fact sheets / cut-sheets in WQMP appendices, sizing calculation pages, treatment train diagrams, Section V (Operation & Maintenance) narratives that enumerate the project's BMPs. These often disambiguate which checkboxes were marked when a scanned page is unclear.

--- a/Neptune.API/Services/AI/Prompts/ExtractSourceControlBMPs_v3.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractSourceControlBMPs_v3.md
@@ -1,0 +1,30 @@
+{{EvidenceInstructions}}
+
+<task>
+Extract all **Source Control BMPs** from the uploaded Water Quality Management Plan PDF (Orange County, CA).
+
+Source Control BMPs in OC WQMPs fall into three categories. Look for evidence of ALL of them:
+
+1. **Hydrologic Source Control and Site Design BMPs** — Low-Impact Development (LID) features that reduce runoff at the source. Examples: Impervious Area Dispersion, Localized On-lot Infiltration, Street Trees, Residential Rain Barrels, Harvest and Use Systems.
+
+2. **Applicable Routine Non-Structural Source Control BMPs** — operational / programmatic practices the property's owner/operator commits to perform. Examples: storm-drain stenciling, employee training, trash management procedures, spill response plans, sweeping schedules.
+
+3. **Applicable Routine Structural Source Control BMPs** — fixed structures that prevent pollutants from entering the storm-drain system. Examples: trash enclosures with roofs, fueling area canopies, designated vehicle wash areas, dock-loading containment.
+
+WQMPs typically present Source Control BMPs as a **checklist table** where each attribute is listed alongside a "Yes/No" / "Applicable / Not Applicable" / checked / unchecked indicator and an optional note. Extract every row of every such checklist you find — both items marked YES and items explicitly marked NO. Treat each row as a separate `SourceControlBMPAttribute`.
+
+When you cannot find an attribute mentioned at all in the document, do **not** emit a row for it. Only emit attributes the document explicitly addresses (either as present, absent, or with a note).
+</task>
+
+For each emitted item:
+
+- `SourceControlBMPAttribute.Value` — the attribute name. Match to a name from DomainContext's `SourceControlBMPAttributes` (grouped by category) when a close match exists; otherwise emit the document's wording verbatim.
+- `IsPresent.Value` — `"Yes"` if the document indicates the attribute is implemented / applicable / checked. `"No"` if the document explicitly indicates the attribute is NOT implemented / NOT applicable / unchecked. `null` only if the document mentions the attribute but is genuinely silent on its presence.
+- `SourceControlBMPNote.Value` — any explanatory note or condition the document associates with the attribute. `null` if there is no note.
+
+When a field's Value is null, also set its `ExtractionEvidence`, `DocumentSource`, and `BoundingBox` to null.
+
+The schema for each emitted item:
+{{Schema}}
+
+Return a JSON object containing an `"items"` array (empty only if no Source Control BMP checklist or discussion is present in this document).

--- a/Neptune.API/Services/AI/Prompts/ExtractSourceControlBMPs_v3.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractSourceControlBMPs_v3.md
@@ -1,30 +1,118 @@
 {{EvidenceInstructions}}
 
 <task>
-Extract all **Source Control BMPs** from the uploaded Water Quality Management Plan PDF (Orange County, CA).
-
-Source Control BMPs in OC WQMPs fall into three categories. Look for evidence of ALL of them:
-
-1. **Hydrologic Source Control and Site Design BMPs** — Low-Impact Development (LID) features that reduce runoff at the source. Examples: Impervious Area Dispersion, Localized On-lot Infiltration, Street Trees, Residential Rain Barrels, Harvest and Use Systems.
-
-2. **Applicable Routine Non-Structural Source Control BMPs** — operational / programmatic practices the property's owner/operator commits to perform. Examples: storm-drain stenciling, employee training, trash management procedures, spill response plans, sweeping schedules.
-
-3. **Applicable Routine Structural Source Control BMPs** — fixed structures that prevent pollutants from entering the storm-drain system. Examples: trash enclosures with roofs, fueling area canopies, designated vehicle wash areas, dock-loading containment.
-
-WQMPs typically present Source Control BMPs as a **checklist table** where each attribute is listed alongside a "Yes/No" / "Applicable / Not Applicable" / checked / unchecked indicator and an optional note. Extract every row of every such checklist you find — both items marked YES and items explicitly marked NO. Treat each row as a separate `SourceControlBMPAttribute`.
-
-When you cannot find an attribute mentioned at all in the document, do **not** emit a row for it. Only emit attributes the document explicitly addresses (either as present, absent, or with a note).
+Extract all **Source Control BMPs** that this Water Quality Management Plan (WQMP) describes — operational practices, site-design features, and structural elements that prevent pollutants from entering the storm-drain system. This is **not** the global Source Control inventory; scope each extraction to the practices this document commits to for this specific Orange County, CA site.
 </task>
 
-For each emitted item:
+<where_to_look>
+OC WQMPs present Source Control BMPs in one or more of these layouts. Read all of them — they often appear in the same document.
 
-- `SourceControlBMPAttribute.Value` — the attribute name. Match to a name from DomainContext's `SourceControlBMPAttributes` (grouped by category) when a close match exists; otherwise emit the document's wording verbatim.
-- `IsPresent.Value` — `"Yes"` if the document indicates the attribute is implemented / applicable / checked. `"No"` if the document explicitly indicates the attribute is NOT implemented / NOT applicable / unchecked. `null` only if the document mentions the attribute but is genuinely silent on its presence.
-- `SourceControlBMPNote.Value` — any explanatory note or condition the document associates with the attribute. `null` if there is no note.
+**Pre-printed checklist sections** — typically **Section IV.3.6** in the modern (2013+) OC Model WQMP template. Recognize by structure: three sub-tables (one per category) where each row is a fixed attribute name with an "Included? Yes / No / N/A" indicator and a "Conditions if Yes" note column. A marked Yes or No is positive evidence — extract every marked row from every category sub-table. Skip rows marked N/A or left blank.
 
-When a field's Value is null, also set its `ExtractionEvidence`, `DocumentSource`, and `BoundingBox` to null.
+The checklist covers three categories, in standard order:
+
+- **Hydrologic Source Control and Site Design BMPs** — LID measures that reduce runoff at the source. Examples: Impervious Area Dispersion, Localized On-lot Infiltration, Street Trees, Harvest and Use Systems, Conserved Natural Areas, Buffer Zones for Natural Water Bodies, Minimized Impervious Areas, Maintained or Restored Natural Drainage Patterns, Distributed Permeable Pavement in Low Traffic Areas, Green Roof / Brown Roof, Absorbent Landscaping with Drought Tolerant Species.
+- **Applicable Routine Non-Structural Source Control BMPs** — operational / programmatic practices the owner/operator commits to. Examples: Education for Property Owners/Tenants/Occupants, Activity Restrictions, Landscape Management, BMP Maintenance, Title 22 CCR Compliance, Local Water Quality Permit Compliance, Spill Contingency Plan, Underground Storage Tank Compliance, Hazardous Materials Disclosure Compliance, Uniform Fire Code Implementation, Litter Control, Employee Training, Housekeeping of Loading Docks, Catch Basin Inspection, Street Sweeping Private Streets and Parking Lots, Retail Gasoline Outlets.
+- **Applicable Routine Structural Source Control BMPs** — fixed structures. Examples: Provide Storm Drain System Stenciling and Signage, Design Outdoor Hazardous Material Storage Areas, Design Trash Enclosures, Use Efficient Irrigation Systems and Landscape Design, Protect Slopes and Channels, Maintenance Bays, Vehicle Wash Areas, Outdoor Processing Areas, Equipment Wash Areas, Loading Dock Areas, Fueling Areas, Wash Water Controls for Food Preparation Areas, Community Car Wash Racks.
+
+**Older OC BMP Manual templates** (2003-era South-OC and similar) — Source Controls described by code letters in narrative form. Common code schemes across older templates:
+
+- **South-OC 2003 template** uses a flat **S-code** numbering (S1 through ~S20) that mixes Source Controls and Treatment Controls in the same list. **Low-numbered S-codes (roughly S1 – S14) are Source Controls** (Site Design + Structural Source Controls); high-numbered S-codes (≥ S15) are Treatment Controls and are NOT your responsibility — the QuickBMPs extraction handles those.
+
+  Known South-OC 2003 S-code mappings to DomainContext attributes:
+
+  - **S3. Common Area Runoff-Minimizing Landscape Design** → *Maintained or Restored Natural Drainage Patterns* (Site Design)
+  - **S6. Trash Container Areas** → *Design Trash Enclosures to Reduce Pollutant Introduction* (Structural)
+  - **S9. Concrete Fuel Dispensing Area** / **S10. Motor Fuel Dispensing Area Canopy** → *Fueling Areas* (Structural) — both codes describe parts of the same fueling-area BMP; emit once.
+  - **S11. Outdoor Material Storage Area** → *Design Outdoor Hazardous Material Storage Areas to Reduce Pollutant Introduction* (Structural)
+  - **S12. Vehicle Wash Area** → *Vehicle Wash Areas* (Structural)
+  - Any S-code below S15 with "landscape", "irrigation", "drainage", "trash", "fuel", "vehicle", "material storage", "hazardous", or "wash" in its title is almost certainly a Source Control and you should emit it.
+
+- **Other older templates** sometimes use letter-prefixed codes: **N1 – N16** for Routine Non-Structural Source Controls (e.g., "N1. Education for Property Owners and Tenants"; "N7. Catch Basin Inspection"); **SD-1 to SD-32** for Site Design BMPs (e.g., "SD-12. Efficient Irrigation"); **SC-10 to SC-44** for Structural Source Controls (e.g., "SC-15. Outdoor Material Storage Areas"; "SC-30. Fueling Areas"; "SC-32. Trash Storage Areas").
+
+When a code appears as a section heading with an implementation description (even one sentence), treat it as committed and extract `IsPresent: "Yes"`. Put the code in the `SourceControlBMPNote` for traceability if helpful, but map `SourceControlBMPAttribute.Value` to the matching DomainContext name — not to the code.
+
+**Narrative O&M / BMP sections** — some WQMPs lack any structured checklist or code list and only describe Source Controls inside an Operation & Maintenance, Best Management Practices, or Pollution Prevention narrative. Pull each practice the document describes as implemented on this site. Common narrative phrasings and the DomainContext attribute they map to:
+
+- "storm drain stenciling", "no-dumping markers", "drain marking" → **Provide Storm Drain System Stenciling and Signage**
+- "trash enclosure", "trash storage area", "roofed dumpster" → **Design Trash Enclosures to Reduce Pollutant Introduction**
+- "fueling area canopy", "fuel dispenser island", "spill containment at fuel pumps" → **Fueling Areas**
+- "vehicle wash area", "car wash bay" → **Vehicle Wash Areas**
+- "equipment wash area" → **Equipment Wash Areas**
+- "maintenance bay", "service bay containment" → **Maintenance Bays**
+- "loading dock containment" → **Loading Dock Areas**
+- "hazardous material storage", "chemical storage area" → **Design Outdoor Hazardous Material Storage Areas to Reduce Pollutant Introduction**
+- "underground storage tank", "UST" → **Underground Storage Tank Compliance**
+- "spill plan", "spill response", "spill kit" → **Spill Contingency Plan**
+- "employee training", "operator training" → **Employee Training**
+- "tenant education", "property owner pamphlet" → **Education for Property Owners, Tenants and Occupants**
+- "catch basin inspection", "drainage facility inspection" → **Catch Basin Inspection**
+- "street sweeping", "parking lot sweeping" → **Street Sweeping Private Streets and Parking Lots**
+- "efficient irrigation", "drip irrigation", "smart controller" → **Use Efficient Irrigation Systems and Landscape Design**
+- "retail gasoline outlet practices", "Chevron / Shell / 76 / Mobil service station SOPs" → **Retail Gasoline Outlets**
+- "hazardous materials business plan", "HMDC" → **Hazardous Materials Disclosure Compliance**
+- "Uniform Fire Code compliance", "UFC" → **Uniform Fire Code Implementation**
+- "Title 22 hazardous waste compliance" → **Title 22 CCR Compliance**
+- "drought-tolerant landscaping", "absorbent soil amendments" → **Absorbent Landscaping with Drought Tolerant Species**
+
+For each extracted item, set `SourceControlBMPAttribute.Value` to the matching DomainContext attribute name (see DomainContext's grouped `SourceControlBMPAttributes`) when a close conceptual match exists. If no match, emit the document's wording verbatim — staff will remap during review.
+</where_to_look>
+
+<positive_selection_rule>
+Emit a Source Control BMP when at least one positive signal is present:
+
+- A checked / Yes-marked row in a Section IV.3.6 checklist.
+- An explicitly No-marked row (extract as `IsPresent: "No"`).
+- A BMP code (N1, SD-x, SC-x) appearing as a section heading or list entry with an implementation description.
+- A narrative paragraph in an O&M / BMP / Pollution Prevention section describing implementation of a practice that maps to a DomainContext attribute.
+
+Do **not** emit when:
+
+- The row is marked N/A or left blank.
+- The document references a practice only as "could apply" without committing to it.
+- The mention appears only in a generic glossary or appendix without project-specific commitment.
+
+**Be permissive on narrative-style matches.** A missed Source Control is worse than a mismapped one — staff reviews and corrects every extraction. If a document describes a practice that fits a DomainContext attribute even loosely, extract it.
+</positive_selection_rule>
+
+<example>
+Modern checklist row (Section IV.3.6.a): "Localized On-lot Infiltration … [✓] Yes  [ ] No  [ ] N/A     Conditions if Yes: Bioretention area at SW corner". Emit one item with `SourceControlBMPAttribute.Value = "Localized On-lot Infiltration"`, `IsPresent.Value = "Yes"`, `SourceControlBMPNote.Value = "Bioretention area at SW corner"`.
+</example>
+
+<example>
+Modern checklist row marked No: "Street Trees … [ ] Yes  [✓] No  [ ] N/A". Emit one item with `SourceControlBMPAttribute.Value = "Street Trees"`, `IsPresent.Value = "No"`, `SourceControlBMPNote.Value = null`.
+</example>
+
+<example>
+Older BMP-code style: "N1. Education for Property Owners and Tenants. Tenants will receive a stormwater pollution prevention pamphlet at lease signing." Emit one item with `SourceControlBMPAttribute.Value = "Education for Property Owners, Tenants and Occupants"`, `IsPresent.Value = "Yes"`, `SourceControlBMPNote.Value = "Pamphlet at lease signing"`.
+</example>
+
+<example>
+Older BMP-code style: "SC-32. Trash Storage Areas. Trash enclosure to be roofed with side walls on three sides." Emit one item with `SourceControlBMPAttribute.Value = "Design Trash Enclosures to Reduce Pollutant Introduction"`, `IsPresent.Value = "Yes"`, `SourceControlBMPNote.Value = "Roofed with side walls on three sides"`.
+</example>
+
+<example>
+Narrative O&M paragraph: "Storm drain inlets on the property are stenciled with 'No Dumping — Flows to Ocean'." Emit one item with `SourceControlBMPAttribute.Value = "Provide Storm Drain System Stenciling and Signage"`, `IsPresent.Value = "Yes"`, `SourceControlBMPNote.Value = "'No Dumping - Flows to Ocean' stencils"`. (Likewise: "Catch basins inspected monthly during the rainy season" → `Catch Basin Inspection`; "Spill kits at fueling islands" → `Spill Contingency Plan`; "Underground storage tanks inspected per CUPA" → `Underground Storage Tank Compliance`.)
+</example>
+
+<output_fields>
+For each Source Control BMP found, emit one object containing the following ExtractedValue fields:
+
+| Field | Guidance |
+|---|---|
+| `SourceControlBMPAttribute` | The attribute name. Prefer a name from DomainContext's grouped `SourceControlBMPAttributes` when a close conceptual match exists; otherwise emit the document's wording verbatim. |
+| `IsPresent` | `"Yes"` if the document indicates the attribute is implemented / applicable / checked / committed-to. `"No"` if the document explicitly indicates the attribute is NOT implemented / NOT applicable / unchecked. `null` only when the document mentions the attribute but is genuinely silent on its presence. |
+| `SourceControlBMPNote` | Free-form note (≤200 chars) — the document's "Conditions if Yes" entry, a brief description, sizing detail, or any qualifier. `null` if there is no note. |
+</output_fields>
+
+<edge_cases>
+- The same attribute mentioned in multiple sections → emit once.
+- BMP codes like "N7" or "SC-32" should NOT appear in `SourceControlBMPAttribute.Value` — map them to the DomainContext attribute name. Codes can appear in the note if helpful.
+- When a field's `Value` is null, also set `ExtractionEvidence`, `DocumentSource`, and `BoundingBox` to null.
+- If a BMP only appears in a generic glossary or template appendix without project-specific commitment, do not extract.
+</edge_cases>
 
 The schema for each emitted item:
 {{Schema}}
 
-Return a JSON object containing an `"items"` array (empty only if no Source Control BMP checklist or discussion is present in this document).
+Return a JSON object containing an `"items"` array (empty only if no Source Control BMP discussion is present anywhere in the document).

--- a/Neptune.API/Services/AI/WqmpExtractionService.cs
+++ b/Neptune.API/Services/AI/WqmpExtractionService.cs
@@ -310,7 +310,22 @@ public class WqmpExtractionService
             WaterQualityManagementPlanDevelopmentType = WaterQualityManagementPlanDevelopmentType.All.Select(x => x.WaterQualityManagementPlanDevelopmentTypeDisplayName),
             WaterQualityManagementPlanPermitTerm = WaterQualityManagementPlanPermitTerm.All.Select(x => x.WaterQualityManagementPlanPermitTermDisplayName),
             TrashCaptureStatusType = TrashCaptureStatusType.All.Select(x => x.TrashCaptureStatusTypeDisplayName),
-            SourceControlBMPAttributes = await _dbContext.SourceControlBMPAttributes.AsNoTracking().Select(x => x.SourceControlBMPAttributeName).ToListAsync(),
+            // NPT-1054: send SC attribute names grouped by their category so Claude has the
+            // three-bucket taxonomy when matching extracted attribute wording. The v3 prompt
+            // explicitly enumerates the three categories with examples — the categorized
+            // DomainContext lets Claude resolve fuzzy PDF wording against the right bucket.
+            SourceControlBMPAttributes = (await _dbContext.SourceControlBMPAttributes
+                .AsNoTracking()
+                .Select(x => new { x.SourceControlBMPAttributeName, x.SourceControlBMPAttributeCategoryID })
+                .ToListAsync())
+                .GroupBy(x => x.SourceControlBMPAttributeCategoryID)
+                .Select(g => new
+                {
+                    Category = SourceControlBMPAttributeCategory.AllLookupDictionary[g.Key].SourceControlBMPAttributeCategoryName,
+                    Attributes = g.Select(a => a.SourceControlBMPAttributeName).OrderBy(n => n).ToList(),
+                })
+                .OrderBy(g => g.Category)
+                .ToList(),
         };
         return $"SCHEMA_VERSION: {SchemaVersion}\nDOMAIN TABLES: {JsonSerializer.Serialize(domainTables)}\n";
     }

--- a/Neptune.API/Services/AI/WqmpExtractionService.cs
+++ b/Neptune.API/Services/AI/WqmpExtractionService.cs
@@ -132,7 +132,12 @@ public class WqmpExtractionService
                 var parameters = new MessageCreateParams
                 {
                     Model = _configuration.ClaudeModelId,
-                    MaxTokens = 8192,
+                    // NPT-1054: bumped from 8192 → 16384. Sonnet 4.5+ uses interleaved thinking
+                    // by default when tool_use is in play; thinking tokens count toward the same
+                    // output budget. On the SourceControlBMPs call with a longer prompt + a
+                    // 65-page PDF, Claude consumed all 8192 tokens on thinking and never reached
+                    // the tool call (stop_reason=max_tokens, no text or input_json captured).
+                    MaxTokens = 16384,
                     // The Files-API source variant (BetaFileDocumentSource) is gated behind
                     // this beta header on the Messages endpoint. Without it the request gets
                     // routed to the standard validator and rejected with
@@ -225,15 +230,61 @@ public class WqmpExtractionService
                 results[i].cachedTokens, $"WQMP Extraction - {keys[i]}");
         }
 
-        // Array categories return { "items": [...] } — unwrap to just the array
+        // Array categories return { "items": [...] } — unwrap to just the array.
+        // NPT-1054: Claude sometimes JSON-encodes `items` as a string instead of emitting a real
+        // array (observed on the SourceControlBMPs call with longer prompts + multi-line array
+        // examples). Detect that shape and parse it back to an array before consolidating;
+        // otherwise the downstream JSON_QUERY consumer sees a string literal where an array
+        // should be.
         string UnwrapItems(string json)
         {
             try
             {
                 using var doc = JsonDocument.Parse(json);
-                if (doc.RootElement.TryGetProperty("items", out var items)) return items.GetRawText();
+                if (doc.RootElement.TryGetProperty("items", out var items))
+                {
+                    if (items.ValueKind == JsonValueKind.String)
+                    {
+                        var innerJson = items.GetString();
+                        if (string.IsNullOrEmpty(innerJson))
+                        {
+                            _logger.LogWarning("Tool output `items` was an empty string — emitting empty array.");
+                            return "[]";
+                        }
+                        try
+                        {
+                            using var innerDoc = JsonDocument.Parse(innerJson);
+                            _logger.LogWarning("Tool output had `items` as a JSON-encoded string ({Len} chars) — unwrapped successfully.", innerJson.Length);
+                            return innerJson;
+                        }
+                        catch (JsonException ex)
+                        {
+                            // The string content failed to parse as JSON. Try a best-effort cleanup:
+                            // strip a stray trailing comma + newline before the closing bracket,
+                            // which is a common Claude foible on long array outputs.
+                            var cleaned = System.Text.RegularExpressions.Regex.Replace(
+                                innerJson, @",\s*([\]\}])", "$1");
+                            try
+                            {
+                                using var cleanedDoc = JsonDocument.Parse(cleaned);
+                                _logger.LogWarning("Tool output `items` was a JSON-encoded string with trailing-comma issues — repaired and unwrapped ({Len} chars).", cleaned.Length);
+                                return cleaned;
+                            }
+                            catch (JsonException ex2)
+                            {
+                                _logger.LogError(ex2, "Tool output `items` was a JSON-encoded string but failed to parse even after cleanup. First error: {FirstErr}. Cleanup error: {CleanupErr}. Inner head: {Head}",
+                                    ex.Message, ex2.Message, innerJson.Length > 500 ? innerJson.Substring(0, 500) : innerJson);
+                                return "[]";
+                            }
+                        }
+                    }
+                    return items.GetRawText();
+                }
             }
-            catch { /* fall through */ }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "UnwrapItems failed to parse tool output JSON; using raw output.");
+            }
             return json;
         }
 


### PR DESCRIPTION
## Summary
Follow-up to PR #504 — the wizard's Step 4 was wired up correctly, but the AI extraction itself was returning empty Source Control arrays on real WQMP PDFs. This PR fixes the extraction pipeline so the AI actually finds and returns SC BMPs.

Three stacked issues were all conspiring to produce `SourceControlBMPs: []` on older South-OC WQMPs (verified on WQMP 1143, a 2003-era 1.4-acre Chevron service station — Kathleen's reference doc):

### 1. Prompt was too narrow
The v2 prompt described Source Controls as "non-structural / operational measures" only. 2003-era South-OC templates use a flat **S-code numbering (S1-S20)** that mixes Source Controls (S1-S14) with Treatment Controls (S15+). Newer prompt now:
- Enumerates all three SC categories with concrete examples per category
- Explicitly recognizes S-code, N/SD/SC-code, and narrative-O&M document formats
- Includes specific mappings for S3/S6/S9-S10/S11/S12 → DomainContext attribute names
- Includes a narrative→attribute mapping table for common phrasings ("storm drain stenciling" → "Provide Storm Drain System Stenciling and Signage", etc.)
- Reframed examples as single-item narrative descriptions (not multi-line array JSON, which was triggering the double-encode in issue #3 below)

QuickBMPs prompt updated in parallel to **skip S1-S14** in older docs so the two extractions don't fight over the same rows.

### 2. MaxTokens 8192 was too small
Sonnet 4.5+ uses interleaved thinking when tool_use is in play, and thinking tokens count against the same output budget. On the SourceControlBMPs call Claude was consuming the entire 8192-token budget on thinking and never reaching the tool call (stop_reason=max_tokens, zero captured output). Bumped to 16384.

### 3. Claude was double-encoding `items` as a JSON string
Multi-line array literals in the prompt's `<example>` blocks were nudging Claude into JSON-encoding the items array as a STRING (`{"items": "[\n  {\n    \"...\"..."}`) instead of emitting a real array. Two-pronged fix:
- Rewrote the prompt examples as narrative single-item descriptions matching the QuickBMPs prompt style.
- Added defensive `UnwrapItems` recovery for the double-encoded case (logs a warning, tries to parse the inner string back to JSON, with a trailing-comma cleanup fallback).

### Verified
End-to-end on WQMP 1143. Extraction now returns **18 Source Control BMPs** across all three categories with N-codes / S-codes preserved in the notes for review traceability. Wizard's Step 4 renders them with AI badges as expected.

## Test plan
- [ ] Re-run extraction on WQMP 1143 (Chevron / Aliso Viejo / South OC 2003) — wizard Step 4 shows ~18 prefilled rows with AI badges.
- [ ] Re-run extraction on a modern (2013+) Model WQMP that has the IV.3.6 checklist — wizard Step 4 prefills from the checklist as expected.
- [ ] Confirm QuickBMPs extraction on 1143 only returns S15 + S16 (treatment controls), not S3/S6/S9/S10/S13 (those are now SC's responsibility).
- [ ] Save Step 4 → check WQMP detail page reflects the saved Source Control BMPs.