### PR TITLE
NPT-995: Fix 401 on verification supporting-doc download

### DIFF
--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-detail/verification-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-detail/verification-detail.component.ts
@@ -8,7 +8,7 @@ import { AuthenticationService } from "src/app/services/authentication.service";
 import { WaterQualityManagementPlanService } from "src/app/shared/generated/api/water-quality-management-plan.service";
 import { WaterQualityManagementPlanDto } from "src/app/shared/generated/model/water-quality-management-plan-dto";
 import { WaterQualityManagementPlanVerifyDetailDto } from "src/app/shared/generated/model/water-quality-management-plan-verify-detail-dto";
-import { environment } from "src/environments/environment";
+import { fileResourceUrl } from "src/app/shared/helpers/file-resource-url";
 
 @Component({
     selector: "verification-detail",
@@ -39,10 +39,7 @@ export class VerificationDetailComponent {
         return this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission();
     }
 
-    // NPT-995 Round 5: FileResource download URL — same pattern as the supporting-documentation step.
-    public getDownloadUrl(guid: string): string {
-        return `${environment.mainAppApiUrl}/FileResource/DisplayResource/${guid}`;
-    }
+    public getDownloadUrl = fileResourceUrl;
 
     public groupSourceControlsByCategory(rows: WaterQualityManagementPlanVerifyDetailDto["SourceControlBMPs"]): { category: string; items: WaterQualityManagementPlanVerifyDetailDto["SourceControlBMPs"] }[] {
         const map = new Map<string, WaterQualityManagementPlanVerifyDetailDto["SourceControlBMPs"]>();

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/steps/supporting-documentation-step.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/steps/supporting-documentation-step.component.ts
@@ -9,8 +9,8 @@ import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
 import { WaterQualityManagementPlanService } from "src/app/shared/generated/api/water-quality-management-plan.service";
 import { WqmpVerificationWorkflowService } from "src/app/shared/services/wqmp-verification-workflow.service";
-import { environment } from "src/environments/environment";
 import { escapeHtml } from "src/app/shared/helpers/html-escape";
+import { fileResourceUrl } from "src/app/shared/helpers/file-resource-url";
 
 /**
  * NPT-995 Round 5: Supporting Documentation step. Mirrors the legacy MVC panel —
@@ -58,10 +58,7 @@ export class SupportingDocumentationStepComponent implements OnInit {
         return this.isUploading() || this.service.isSaving();
     }
 
-    getDownloadUrl(guid: string): string {
-        // FileResource.GetFileResourceUrl pattern, same path the legacy MVC + other SPA pages use.
-        return `${environment.mainAppApiUrl}/FileResource/DisplayResource/${guid}`;
-    }
+    getDownloadUrl = fileResourceUrl;
 
     private upload(file: File): void {
         const wqmpID = this.service.waterQualityManagementPlanID();

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
@@ -390,7 +390,7 @@
                                 @for (doc of docGroup.documents; track doc.WaterQualityManagementPlanDocumentID) {
                                     <div class="document-entry">
                                         @if (doc.FileResource?.FileResourceGUID) {
-                                            <a [href]="apiBaseUrl + '/file-resources/' + doc.FileResource.FileResourceGUID" target="_blank">
+                                            <a [href]="fileResourceUrl(doc.FileResource.FileResourceGUID)" target="_blank">
                                                 {{ doc.DisplayName }} <i class="fa fa-download"></i>
                                             </a>
                                         } @else {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
@@ -26,6 +26,7 @@ import { Alert } from "src/app/shared/models/alert";
 import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 import { MarkerHelper } from "src/app/shared/helpers/marker-helper";
 import { escapeHtml } from "src/app/shared/helpers/html-escape";
+import { fileResourceUrl } from "src/app/shared/helpers/file-resource-url";
 import { WaterQualityManagementPlanService } from "src/app/shared/generated/api/water-quality-management-plan.service";
 import { WaterQualityManagementPlanDto } from "src/app/shared/generated/model/water-quality-management-plan-dto";
 import { WaterQualityManagementPlanDocumentDto } from "src/app/shared/generated/model/water-quality-management-plan-document-dto";
@@ -85,7 +86,7 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
     public WaterQualityManagementPlanModelingApproachEnum = WaterQualityManagementPlanModelingApproachEnum;
     public WaterQualityManagementPlanStatusEnum = WaterQualityManagementPlanStatusEnum;
     public aboutModelingBMPPerformanceUrl = `${environment.ocStormwaterToolsBaseUrl}/Home/AboutModelingBMPPerformance`;
-    public apiBaseUrl = environment.mainAppApiUrl;
+    public fileResourceUrl = fileResourceUrl;
 
     // NPT-1051: wqmp$ is a stable observable driven by reload$ so the AsyncPipe stays
     // subscribed to one reference. Modal saves call reload$.next() to refetch — this is

--- a/Neptune.Web/src/app/shared/helpers/file-resource-url.ts
+++ b/Neptune.Web/src/app/shared/helpers/file-resource-url.ts
@@ -1,0 +1,12 @@
+import { environment } from "src/environments/environment";
+
+/**
+ * Builds the SPA API URL for downloading a FileResource by GUID. The `/file-resources/{guid}`
+ * endpoint is `[AllowAnonymous]`, so a plain `<a [href]>` works and no Bearer token plumbing
+ * is needed. Centralized here so callers don't duplicate the path (which historically led to
+ * wrong routes — e.g. the legacy MVC `FileResource/DisplayResource/{guid}` returning 401 from
+ * the API origin — NPT-995 Round 6).
+ */
+export function fileResourceUrl(guid: string): string {
+    return `${environment.mainAppApiUrl}/file-resources/${guid}`;
+}


### PR DESCRIPTION
## Summary
Rework item from Kathleen's 5/14/26 testing — the file-resource download link on the WQMP O&M Detail page was returning 401 / "This page isn't working" when she tried to download a supporting document.

**Root cause**: \`verification-detail\` and the \`supporting-documentation\` wizard step were building download URLs against the legacy MVC route (\`\${mainAppApiUrl}/FileResource/DisplayResource/{guid}\`). That route only exists on the WebMvc process — hitting it on the SPA API origin returns 401 because the gateway can't resolve the path against the JWT auth pipeline. \`wqmp-detail\`'s documents card was already using the correct SPA API path (\`\${mainAppApiUrl}/file-resources/{guid}\`, which is \`[AllowAnonymous]\` on FileResourceController).

**Fix**: centralized the URL into a single shared helper (\`fileResourceUrl\` in \`src/app/shared/helpers/file-resource-url.ts\`) so we have one source of truth for future callers and don't repeat the mistake. Routed all three existing call sites through it (verification detail, supporting-doc wizard step, wqmp detail's documents card).

## Test plan
- [ ] Open a WQMP O&M Detail page for a verification that has a supporting document — click the file link, the document downloads (no 401).
- [ ] Re-run the verification wizard, upload a supporting doc, then return to the wizard's Supporting Documentation step — the "View existing file" link downloads cleanly.
- [ ] WQMP Detail page → Documents card → click a document link — still works (regression check on the third caller that already worked but was inlining the URL).