### PR TITLE
NPT-984: BMP Field Visits — Round 4 rework (16 items + Manager-gate on AI WQMP create)

### DIFF
--- a/Neptune.API/Controllers/FieldVisit/FieldVisitController.cs
+++ b/Neptune.API/Controllers/FieldVisit/FieldVisitController.cs
@@ -70,8 +70,11 @@ public class FieldVisitController(NeptuneDbContext dbContext, ILogger<FieldVisit
         return Ok(result);
     }
 
+    // NPT-984: Verify / Mark Provisional / Return to Edit are Manager-only attestation actions
+    // — they signal the field visit's regulatory record is finalized. JurisdictionEditor can
+    // perform field visits and edit them while in progress but cannot attest to the result.
     [HttpPost("{fieldVisitID}/verify")]
-    [JurisdictionEditFeature]
+    [JurisdictionManageFeature]
     [EntityNotFound(typeof(FieldVisit), "fieldVisitID")]
     public async Task<ActionResult<FieldVisitDto>> Verify([FromRoute] int fieldVisitID)
     {
@@ -80,7 +83,7 @@ public class FieldVisitController(NeptuneDbContext dbContext, ILogger<FieldVisit
     }
 
     [HttpPost("{fieldVisitID}/mark-provisional")]
-    [JurisdictionEditFeature]
+    [JurisdictionManageFeature]
     [EntityNotFound(typeof(FieldVisit), "fieldVisitID")]
     public async Task<ActionResult<FieldVisitDto>> MarkProvisional([FromRoute] int fieldVisitID)
     {
@@ -89,7 +92,7 @@ public class FieldVisitController(NeptuneDbContext dbContext, ILogger<FieldVisit
     }
 
     [HttpPost("{fieldVisitID}/return-to-edit")]
-    [JurisdictionEditFeature]
+    [JurisdictionManageFeature]
     [EntityNotFound(typeof(FieldVisit), "fieldVisitID")]
     public async Task<ActionResult<FieldVisitDto>> ReturnToEdit([FromRoute] int fieldVisitID)
     {
@@ -97,6 +100,9 @@ public class FieldVisitController(NeptuneDbContext dbContext, ILogger<FieldVisit
         return Ok(dto);
     }
 
+    // Save & Wrap Up — Editor performs the visit and wraps it up themselves; only the
+    // post-wrap-up attestation actions (Verify / Mark Provisional / Return to Edit) need the
+    // Manager gate.
     [HttpPost("{fieldVisitID}/finalize")]
     [JurisdictionEditFeature]
     [EntityNotFound(typeof(FieldVisit), "fieldVisitID")]
@@ -106,8 +112,9 @@ public class FieldVisitController(NeptuneDbContext dbContext, ILogger<FieldVisit
         return Ok(dto);
     }
 
+    // NPT-984: Delete Field Visit is Manager-only — destructive, removes the field record.
     [HttpDelete("{fieldVisitID}")]
-    [JurisdictionEditFeature]
+    [JurisdictionManageFeature]
     [EntityNotFound(typeof(FieldVisit), "fieldVisitID")]
     public async Task<IActionResult> Delete([FromRoute] int fieldVisitID)
     {

--- a/Neptune.API/Controllers/FieldVisit/MaintenanceRecordController.cs
+++ b/Neptune.API/Controllers/FieldVisit/MaintenanceRecordController.cs
@@ -62,8 +62,11 @@ public class MaintenanceRecordController(NeptuneDbContext dbContext, ILogger<Mai
         return Ok(dto);
     }
 
+    // NPT-984: Delete Maintenance Record is Manager-only — destructive against a regulatory
+    // record. Editors can create/update maintenance records on visits they're performing but
+    // can't delete them.
     [HttpDelete("{maintenanceRecordID}")]
-    [JurisdictionEditFeature]
+    [JurisdictionManageFeature]
     [EntityNotFound(typeof(MaintenanceRecord), "maintenanceRecordID")]
     public async Task<IActionResult> Delete([FromRoute] int maintenanceRecordID)
     {

--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -488,8 +488,12 @@ namespace Neptune.API.Controllers
             return Ok(response);
         }
 
+        // NPT-984: Create-via-AI is a Manager-level entry point. Previously [AdminFeature]
+        // (Admin + SitkaAdmin only) which locked out Jurisdiction Managers even though they
+        // own WQMP records for their jurisdictions. Editors stay excluded — creating a new
+        // WQMP record is an attestation action above performing field work on an existing one.
         [HttpPost("upload")]
-        [AdminFeature]
+        [JurisdictionManageFeature]
         [Consumes("multipart/form-data")]
         [RequestSizeLimit(200 * 1024 * 1024)]
         [RequestFormLimits(MultipartBodyLengthLimit = 200 * 1024 * 1024)]

--- a/Neptune.API/Services/Authorization/JurisdictionManageFeature.cs
+++ b/Neptune.API/Services/Authorization/JurisdictionManageFeature.cs
@@ -1,0 +1,19 @@
+using Neptune.EFModels.Entities;
+
+namespace Neptune.API.Services.Authorization
+{
+    /// <summary>
+    /// NPT-984: Manager-only authorization. Tighter than JurisdictionEditFeature — excludes
+    /// JurisdictionEditor. Mirrors the frontend's
+    /// AuthenticationService.doesCurrentUserHaveJurisdictionManagePermission() role set.
+    /// Used to gate destructive / attestation actions on Field Visits and Maintenance Records
+    /// (Delete, Verify, Mark Provisional, Return to Edit) so only Jurisdiction Managers (plus
+    /// Admin / SitkaAdmin) can call them.
+    /// </summary>
+    public class JurisdictionManageFeature : BaseAuthorizationAttribute
+    {
+        public JurisdictionManageFeature() : base(new[] { RoleEnum.JurisdictionManager, RoleEnum.Admin, RoleEnum.SitkaAdmin })
+        {
+        }
+    }
+}

--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -19503,6 +19503,10 @@
           "ObservationData": {
             "type": "string",
             "nullable": true
+          },
+          "ObservationScore": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -18195,6 +18195,10 @@
             "type": "string",
             "nullable": true,
             "readOnly": true
+          },
+          "FailureNotes": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/Neptune.EFModels/Entities/FieldVisits.cs
+++ b/Neptune.EFModels/Entities/FieldVisits.cs
@@ -123,7 +123,15 @@ public static class FieldVisits
 
         if (existing != null && createDto.ContinueExistingInProgress == false)
         {
+            // NPT-984: the FieldVisit table has a unique filtered index
+            // (CK_AtMostOneFieldVisitMayBeInProgressAtAnyTimePerBMP — at most one InProgress
+            // visit per BMP). If we batched the update + insert into a single SaveChangesAsync,
+            // EF Core sometimes ordered the insert before the update and tripped the constraint
+            // (the "Start new field visit" path in the Begin Field Visit modal was returning a
+            // generic "failure to start" message). Flush the Unresolved update first so the
+            // unique-InProgress slot is free before inserting the new visit.
             existing.FieldVisitStatusID = FieldVisitStatus.Unresolved.FieldVisitStatusID;
+            await dbContext.SaveChangesAsync();
         }
 
         var fieldVisit = new FieldVisit

--- a/Neptune.EFModels/Entities/TreatmentBMPAssessments.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPAssessments.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using Neptune.Common.DesignByContract;
-using Neptune.Common.GeoSpatial;
 using Neptune.Models.DataTransferObjects;
 
 namespace Neptune.EFModels.Entities;
@@ -181,19 +180,31 @@ public static class TreatmentBMPAssessments
         // deserialize each ObservationData blob, and concatenate notes per observation type.
         // ObservationData is JSON text so the filter has to materialize in-memory; the IN
         // clause is bounded by jurisdiction-scope so the row count stays manageable.
+        // Use the PassFail-specific deserialize helper and tolerate null/non-bool values so
+        // a single malformed payload doesn't 500 the whole page (Copilot PR #507 #1, #2).
+        static bool IsFailingPassFailValue(object? observationValue)
+        {
+            return observationValue switch
+            {
+                bool b => !b,
+                string s when bool.TryParse(s, out var parsed) => !parsed,
+                _ => false,
+            };
+        }
+
         var failingObservations = dbContext.TreatmentBMPObservations.AsNoTracking()
             .Include(x => x.TreatmentBMPAssessmentObservationType)
             .Where(x => mostRecentAssessmentIDs.Contains(x.TreatmentBMPAssessmentID))
             .ToList()
             .Where(x => x.TreatmentBMPAssessmentObservationType.ObservationTypeSpecification.ObservationTypeCollectionMethodID == (int)ObservationTypeCollectionMethodEnum.PassFail
-                        && x.GetPassFailObservationData().SingleValueObservations.Any(y => !bool.Parse(y.ObservationValue.ToString()!)))
+                        && x.GetPassFailObservationData().SingleValueObservations.Any(y => IsFailingPassFailValue(y.ObservationValue)))
             .ToList();
 
         var failureNotesByAssessment = failingObservations
             .GroupBy(x => x.TreatmentBMPAssessmentID)
             .ToDictionary(g => g.Key, g => string.Join("; ", g.Select(x =>
             {
-                var noteParts = GeoJsonSerializer.Deserialize<DiscreteObservationSchema>(x.ObservationData)
+                var noteParts = x.GetPassFailObservationData()
                     .SingleValueObservations
                     .Select(y => y.Notes)
                     .Where(s => !string.IsNullOrWhiteSpace(s));

--- a/Neptune.EFModels/Entities/TreatmentBMPAssessments.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPAssessments.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Neptune.Common.DesignByContract;
+using Neptune.Common.GeoSpatial;
 using Neptune.Models.DataTransferObjects;
 
 namespace Neptune.EFModels.Entities;
@@ -127,11 +128,50 @@ public static class TreatmentBMPAssessments
 
     public static List<TreatmentBMPAssessmentGridDto> ListAsGridDtoForJurisdictions(NeptuneDbContext dbContext, IEnumerable<int> stormwaterJurisdictionIDsPersonCanView)
     {
-        return dbContext.vTreatmentBMPAssessmentDetaileds.AsNoTracking()
-            .Where(x => stormwaterJurisdictionIDsPersonCanView.Contains(x.StormwaterJurisdictionID))
+        var jurisdictionIDs = stormwaterJurisdictionIDsPersonCanView.ToList();
+
+        // NPT-984: Latest BMP Assessments page should show one row per TreatmentBMP — the
+        // most-recent assessment from a wrapped-up (FieldVisitStatusID = Complete) visit.
+        // Mirror the legacy MVC pattern (TreatmentBMPController.TreatmentBMPAssessmentSummaryGridJsonData)
+        // by filtering on vMostRecentTreatmentBMPAssessment.LastAssessmentID. Previously the
+        // SPA returned every assessment ever recorded which over-counted vs. the MVC page.
+        var mostRecentAssessmentIDs = dbContext.vMostRecentTreatmentBMPAssessments.AsNoTracking()
+            .Where(x => jurisdictionIDs.Contains(x.StormwaterJurisdictionID))
+            .Select(x => x.LastAssessmentID)
+            .ToList();
+
+        var rows = dbContext.vTreatmentBMPAssessmentDetaileds.AsNoTracking()
+            .Where(x => mostRecentAssessmentIDs.Contains(x.TreatmentBMPAssessmentID))
             .OrderByDescending(x => x.VisitDate)
+            .ToList();
+
+        // NPT-984: assemble the "Failure Notes" column the same way MVC does — load the
+        // PassFail observations whose recorded value was false for the in-scope assessments,
+        // deserialize each ObservationData blob, and concatenate notes per observation type.
+        // ObservationData is JSON text so the filter has to materialize in-memory; the IN
+        // clause is bounded by jurisdiction-scope so the row count stays manageable.
+        var failingObservations = dbContext.TreatmentBMPObservations.AsNoTracking()
+            .Include(x => x.TreatmentBMPAssessmentObservationType)
+            .Where(x => mostRecentAssessmentIDs.Contains(x.TreatmentBMPAssessmentID))
             .ToList()
-            .Select(x => new TreatmentBMPAssessmentGridDto
+            .Where(x => x.TreatmentBMPAssessmentObservationType.ObservationTypeSpecification.ObservationTypeCollectionMethodID == (int)ObservationTypeCollectionMethodEnum.PassFail
+                        && x.GetPassFailObservationData().SingleValueObservations.Any(y => !bool.Parse(y.ObservationValue.ToString()!)))
+            .ToList();
+
+        var failureNotesByAssessment = failingObservations
+            .GroupBy(x => x.TreatmentBMPAssessmentID)
+            .ToDictionary(g => g.Key, g => string.Join("; ", g.Select(x =>
+            {
+                var noteParts = GeoJsonSerializer.Deserialize<DiscreteObservationSchema>(x.ObservationData)
+                    .SingleValueObservations
+                    .Select(y => y.Notes)
+                    .Where(s => !string.IsNullOrWhiteSpace(s));
+                var joined = string.Join(". ", noteParts);
+                if (string.IsNullOrWhiteSpace(joined)) joined = "[None provided]";
+                return $"{x.TreatmentBMPAssessmentObservationType.TreatmentBMPAssessmentObservationTypeName} Failure Notes: {joined}";
+            }).OrderBy(s => s)));
+
+        return rows.Select(x => new TreatmentBMPAssessmentGridDto
             {
                 TreatmentBMPAssessmentID = x.TreatmentBMPAssessmentID,
                 FieldVisitID = x.FieldVisitID,
@@ -151,6 +191,7 @@ public static class TreatmentBMPAssessments
                 IsAssessmentComplete = x.IsAssessmentComplete,
                 AssessmentScore = x.AssessmentScore,
                 IsFieldVisitVerified = x.IsFieldVisitVerified,
+                FailureNotes = failureNotesByAssessment.GetValueOrDefault(x.TreatmentBMPAssessmentID),
             })
             .ToList();
     }

--- a/Neptune.EFModels/Entities/TreatmentBMPAssessments.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPAssessments.cs
@@ -113,7 +113,10 @@ public static class TreatmentBMPAssessments
             .Where(x => x.TreatmentBMPAssessmentID == treatmentBMPAssessmentID)
             .Select(TreatmentBMPAssessmentProjections.AsDetailDto)
             .SingleOrDefaultAsync();
-        return dto == null ? null : ResolveLookupDisplayNames(dto);
+        if (dto == null) return null;
+        ResolveLookupDisplayNames(dto);
+        await PopulateObservationScoresAsync(dbContext, dto);
+        return dto;
     }
 
     public static async Task<TreatmentBMPAssessmentDetailDto?> GetByFieldVisitIDAndTypeAsDetailDtoAsync(NeptuneDbContext dbContext, int fieldVisitID, TreatmentBMPAssessmentTypeEnum treatmentBMPAssessmentTypeEnum)
@@ -123,7 +126,35 @@ public static class TreatmentBMPAssessments
             .Where(x => x.FieldVisitID == fieldVisitID && x.TreatmentBMPAssessmentTypeID == (int)treatmentBMPAssessmentTypeEnum)
             .Select(TreatmentBMPAssessmentProjections.AsDetailDto)
             .SingleOrDefaultAsync();
-        return dto == null ? null : ResolveLookupDisplayNames(dto);
+        if (dto == null) return null;
+        ResolveLookupDisplayNames(dto);
+        await PopulateObservationScoresAsync(dbContext, dto);
+        return dto;
+    }
+
+    /// <summary>
+    /// NPT-984: post-materialize, compute the per-observation score by loading the assessment
+    /// entity (with the BMP + benchmark/threshold tree) and calling FormattedObservationScore()
+    /// on each TreatmentBMPObservation. The Expression projection can't do this because
+    /// CalculateObservationScore walks the static ObservationTypeCollectionMethod lookup tree
+    /// and needs the BMP entity for benchmark context. Stamps the formatted score back onto
+    /// each observation DTO by matching on TreatmentBMPObservationID.
+    /// </summary>
+    private static async Task PopulateObservationScoresAsync(NeptuneDbContext dbContext, TreatmentBMPAssessmentDetailDto dto)
+    {
+        if (dto.Observations == null || dto.Observations.Count == 0) return;
+        var assessment = await GetImpl(dbContext).AsNoTracking()
+            .SingleOrDefaultAsync(x => x.TreatmentBMPAssessmentID == dto.TreatmentBMPAssessmentID);
+        if (assessment == null) return;
+        var scoreByObservationID = assessment.TreatmentBMPObservations
+            .ToDictionary(o => o.TreatmentBMPObservationID, o => o.FormattedObservationScore());
+        foreach (var observationDto in dto.Observations)
+        {
+            if (scoreByObservationID.TryGetValue(observationDto.TreatmentBMPObservationID, out var score))
+            {
+                observationDto.ObservationScore = score;
+            }
+        }
     }
 
     public static List<TreatmentBMPAssessmentGridDto> ListAsGridDtoForJurisdictions(NeptuneDbContext dbContext, IEnumerable<int> stormwaterJurisdictionIDsPersonCanView)

--- a/Neptune.EFModels/Entities/TreatmentBMPImages.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPImages.cs
@@ -37,11 +37,19 @@ public static class TreatmentBMPImages
 
     /// <summary>
     /// Carousel feed: inventory <see cref="TreatmentBMPImage"/> rows UNION assessment photos from
-    /// the BMP's verified field visits. Used by the BMP detail page so a user can browse all of a
-    /// BMP's photos in one place once the visit's been signed off, while the edit-images page
+    /// the BMP's wrapped-up field visits. Used by the BMP detail page so a user can browse all of
+    /// a BMP's photos in one place once the visit's been wrapped up, while the edit-images page
     /// (which has delete / caption-update affordances) keeps using <see cref="ListAsync"/> so it
     /// only shows rows backed by the TreatmentBMPImage table.
     /// </summary>
+    /// <remarks>
+    /// NPT-984: filter on <c>FieldVisitStatusID == Complete</c> rather than the previous
+    /// <c>IsFieldVisitVerified</c> flag. Verification is a separate Manager-only attestation
+    /// (Verify / Mark Provisional / Return to Edit); Kathleen's expectation is that wrap-up
+    /// alone surfaces the visit's photos in the BMP detail carousel, since the field
+    /// technician has already saved them with the visit and there's no editorial gate before
+    /// browsing.
+    /// </remarks>
     public static async Task<List<TreatmentBMPImageDto>> ListForCarouselAsync(NeptuneDbContext dbContext, int treatmentBMPID)
     {
         var inventoryDtos = await dbContext.TreatmentBMPImages.AsNoTracking()
@@ -51,7 +59,7 @@ public static class TreatmentBMPImages
 
         var assessmentDtos = await dbContext.TreatmentBMPAssessmentPhotos.AsNoTracking()
             .Where(x => x.TreatmentBMPAssessment.TreatmentBMPID == treatmentBMPID
-                        && x.TreatmentBMPAssessment.FieldVisit.IsFieldVisitVerified)
+                        && x.TreatmentBMPAssessment.FieldVisit.FieldVisitStatusID == (int)FieldVisitStatusEnum.Complete)
             .Select(TreatmentBMPImageProjections.AssessmentPhotoAsCarouselDto(treatmentBMPID))
             .ToListAsync();
 

--- a/Neptune.Models/DataTransferObjects/FieldVisit/TreatmentBMPAssessmentGridDto.cs
+++ b/Neptune.Models/DataTransferObjects/FieldVisit/TreatmentBMPAssessmentGridDto.cs
@@ -23,4 +23,10 @@ public class TreatmentBMPAssessmentGridDto
     public double? AssessmentScore { get; set; }
     public bool IsFieldVisitVerified { get; set; }
     public string Status => IsAssessmentComplete ? "Complete" : "In Progress";
+
+    // NPT-984: comma-separated list of failure notes from the assessment's PassFail
+    // observations whose recorded value was false. Mirrors the legacy MVC
+    // `TreatmentBMPController.TreatmentBMPAssessmentSummaryGridJsonData` "Failure Notes" column.
+    // Per-observation chunks look like "{ObservationTypeName} Failure Notes: {notes or [None provided]}".
+    public string? FailureNotes { get; set; }
 }

--- a/Neptune.Models/DataTransferObjects/FieldVisit/TreatmentBMPObservationDto.cs
+++ b/Neptune.Models/DataTransferObjects/FieldVisit/TreatmentBMPObservationDto.cs
@@ -5,4 +5,11 @@ public class TreatmentBMPObservationDto
     public int TreatmentBMPObservationID { get; set; }
     public int TreatmentBMPAssessmentObservationTypeID { get; set; }
     public string? ObservationData { get; set; }
+
+    // NPT-984: per-observation calculated score (e.g. "3.0", or "-" if benchmarks/thresholds
+    // missing). Mirrors the legacy MVC AssessmentDetail view which shows a numeric score
+    // per non-PassFail observation. PassFail observations return "-" since the value itself
+    // IS the score signal. Populated post-materialize in TreatmentBMPAssessments by walking
+    // the tracked entities and calling FormattedObservationScore().
+    public string? ObservationScore { get; set; }
 }

--- a/Neptune.Web/src/app/app.routes.ts
+++ b/Neptune.Web/src/app/app.routes.ts
@@ -454,6 +454,19 @@ export const routes: Routes = [
                 loadComponent: () => import("./pages/field-records/field-records.component").then((m) => m.FieldRecordsComponent),
             },
             {
+                // NPT-984: dedicated read-only Field Visit detail page. The Field Records grid
+                // routes here for any visit not in InProgress; the workflow outlet's Wrap Up
+                // handler navigates here after finalize. Keeps editable workflow pages and the
+                // locked-down summary view as separate routes so wrap-up actually wraps up.
+                path: `field-visits/:${routeParams.fieldVisitID}/view`,
+                title: "Field Visit",
+                loadComponent: () =>
+                    import("./pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component").then(
+                        (m) => m.FieldVisitDetailReadOnlyComponent
+                    ),
+                canActivate: [JurisdictionManagerOrEditorOnlyGuard],
+            },
+            {
                 path: `field-visits/:${routeParams.fieldVisitID}`,
                 title: "Field Visit",
                 loadComponent: () =>

--- a/Neptune.Web/src/app/pages/field-records/field-records.component.html
+++ b/Neptune.Web/src/app/pages/field-records/field-records.component.html
@@ -4,7 +4,7 @@
 
 <div class="page-body">
     <div class="record-tabs">
-        <btn-group-radio-input [options]="tabOptions" [default]="activeTab" (change)="onTabChange($event)"></btn-group-radio-input>
+        <btn-group-radio-input [options]="tabOptions" [default]="activeTabLabel" (change)="onTabChange($event)"></btn-group-radio-input>
     </div>
 
     @switch (activeTab) {

--- a/Neptune.Web/src/app/pages/field-records/field-records.component.ts
+++ b/Neptune.Web/src/app/pages/field-records/field-records.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, inject, OnInit } from "@angular/core";
 import { AsyncPipe } from "@angular/common";
 import { ActivatedRoute, Router, RouterModule } from "@angular/router";
 import { ColDef } from "ag-grid-community";
@@ -38,17 +38,27 @@ type ActiveTab = "field-visits" | "assessments" | "maintenance-records";
     styleUrl: "./field-records.component.scss",
 })
 export class FieldRecordsComponent implements OnInit {
-    // NPT-984: wire the three grids' observables through a class-level reload trigger so the
-    // `| async` pipes have a real Observable to subscribe to at template-init time. Previously
-    // the fields were declared without a value and assigned inside refresh() during ngOnInit;
-    // on lazy-loaded routes in zoneless mode that race led to the page rendering empty until
-    // the user clicked somewhere to force a CD pass (Kathleen's "page does not load until I
-    // click it myself" report). The reload$ trigger replaces the prior reassignment pattern
-    // while still letting refresh() re-fetch after deletes.
+    // NPT-984: services injected via `inject()` so field initializers can reference them.
+    // Lazy-loaded zoneless routes complete their first CD pass *before* ngOnInit runs, so
+    // observables assigned in ngOnInit (the previous attempt) raced the template's first
+    // `| async` subscription — the page rendered empty until the user clicked to force a
+    // second CD pass. Wiring the observables in field initializers means they exist before
+    // the component is ever rendered, and the async pipe sees a live Observable on its
+    // first check.
+    private fieldVisitService = inject(FieldVisitService);
+    private assessmentService = inject(TreatmentBMPAssessmentService);
+    private maintenanceRecordService = inject(MaintenanceRecordService);
+    private utility = inject(UtilityFunctionsService);
+    private confirmService = inject(ConfirmService);
+    private alertService = inject(AlertService);
+    private authenticationService = inject(AuthenticationService);
+    private router = inject(Router);
+    private route = inject(ActivatedRoute);
+
     private reload$ = new BehaviorSubject<void>(undefined);
-    public fieldVisits$: Observable<FieldVisitDto[]>;
-    public assessments$: Observable<TreatmentBMPAssessmentGridDto[]>;
-    public maintenanceRecords$: Observable<MaintenanceRecordGridDto[]>;
+    public fieldVisits$: Observable<FieldVisitDto[]> = this.reload$.pipe(switchMap(() => this.fieldVisitService.listFieldVisit()));
+    public assessments$: Observable<TreatmentBMPAssessmentGridDto[]> = this.reload$.pipe(switchMap(() => this.assessmentService.listTreatmentBMPAssessment()));
+    public maintenanceRecords$: Observable<MaintenanceRecordGridDto[]> = this.reload$.pipe(switchMap(() => this.maintenanceRecordService.listMaintenanceRecord()));
 
     public fieldVisitColumnDefs: ColDef[];
     public assessmentColumnDefs: ColDef[];
@@ -64,18 +74,6 @@ export class FieldRecordsComponent implements OnInit {
         { label: "Maintenance Records", value: "maintenance-records" },
     ];
 
-    constructor(
-        private fieldVisitService: FieldVisitService,
-        private assessmentService: TreatmentBMPAssessmentService,
-        private maintenanceRecordService: MaintenanceRecordService,
-        private utility: UtilityFunctionsService,
-        private confirmService: ConfirmService,
-        private alertService: AlertService,
-        private authenticationService: AuthenticationService,
-        private router: Router,
-        private route: ActivatedRoute
-    ) {}
-
     ngOnInit(): void {
         this.canManage = this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission();
 
@@ -87,12 +85,6 @@ export class FieldRecordsComponent implements OnInit {
         this.fieldVisitColumnDefs = this.buildFieldVisitColumnDefs();
         this.assessmentColumnDefs = this.buildAssessmentColumnDefs();
         this.maintenanceRecordColumnDefs = this.buildMaintenanceRecordColumnDefs();
-
-        // Pipe each grid feed off the shared reload trigger so `refresh()` re-fetches all three
-        // and the async pipes never see an undefined observable.
-        this.fieldVisits$ = this.reload$.pipe(switchMap(() => this.fieldVisitService.listFieldVisit()));
-        this.assessments$ = this.reload$.pipe(switchMap(() => this.assessmentService.listTreatmentBMPAssessment()));
-        this.maintenanceRecords$ = this.reload$.pipe(switchMap(() => this.maintenanceRecordService.listMaintenanceRecord()));
     }
 
     public onTabChange(value: string): void {

--- a/Neptune.Web/src/app/pages/field-records/field-records.component.ts
+++ b/Neptune.Web/src/app/pages/field-records/field-records.component.ts
@@ -74,6 +74,16 @@ export class FieldRecordsComponent implements OnInit {
         { label: "Maintenance Records", value: "maintenance-records" },
     ];
 
+    // NPT-984: BtnGroupRadioInputComponent's `[default]` input is matched against `label`
+    // (not value) in its ngOnInit — passing the kebab-case `activeTab` value caused
+    // `options.find(...)` to return undefined, then `.value` threw "Cannot read properties
+    // of undefined" and the whole template render aborted. (This was the real root cause of
+    // Kathleen's "field records page is blank until I click" report.) Map the active value
+    // back to its label so the radio group highlights the right tab.
+    public get activeTabLabel(): string {
+        return this.tabOptions.find((o) => o.value === this.activeTab)?.label ?? "";
+    }
+
     ngOnInit(): void {
         this.canManage = this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission();
 

--- a/Neptune.Web/src/app/pages/field-records/field-records.component.ts
+++ b/Neptune.Web/src/app/pages/field-records/field-records.component.ts
@@ -14,6 +14,7 @@ import {
 } from "src/app/shared/components/inputs/btn-group-radio-input/btn-group-radio-input.component";
 
 import { FieldVisitService } from "src/app/shared/generated/api/field-visit.service";
+import { FieldVisitStatusEnum } from "src/app/shared/generated/enum/field-visit-status-enum";
 import { TreatmentBMPAssessmentService } from "src/app/shared/generated/api/treatment-bmp-assessment.service";
 import { MaintenanceRecordService } from "src/app/shared/generated/api/maintenance-record.service";
 import { FieldVisitDto } from "src/app/shared/generated/model/field-visit-dto";
@@ -118,17 +119,19 @@ export class FieldRecordsComponent implements OnInit {
         cols.push(
             this.utility.createActionsColumnDef((params: any) => {
                 const visit: FieldVisitDto = params.data;
-                const inProgress = visit.FieldVisitStatusID === 1; // FieldVisitStatusEnum.InProgress
-                // NPT-984: route in-progress visits to the editable workflow outlet and
-                // wrapped-up / unresolved / returned visits to the new read-only detail page.
-                // The read-only page provides a fully locked-down summary view with
-                // MVC-style observation tables, photos, and Manager-only Mark Provisional
-                // action that flips back to the editable workflow.
+                // NPT-984: route InProgress + ReturnedToEdit to the editable workflow outlet
+                // (the latter is the post-MarkProvisional state — the visit is meant to be
+                // editable again). Complete + Unresolved route to the locked-down read-only
+                // detail page. Pre-Copilot review this only checked InProgress, which left
+                // Editors stranded after a Manager Returned-to-Edit their visit (Copilot PR
+                // #507 #3).
+                const editable = visit.FieldVisitStatusID === FieldVisitStatusEnum.InProgress
+                    || visit.FieldVisitStatusID === FieldVisitStatusEnum.ReturnedToEdit;
                 const actions: { ActionName: string; ActionIcon?: string; ActionHandler: () => void }[] = [
                     {
-                        ActionName: inProgress ? "Continue" : "View",
+                        ActionName: editable ? "Continue" : "View",
                         ActionHandler: () => this.router.navigate(
-                            inProgress
+                            editable
                                 ? ["/field-visits", visit.FieldVisitID]
                                 : ["/field-visits", visit.FieldVisitID, "view"],
                         ),

--- a/Neptune.Web/src/app/pages/field-records/field-records.component.ts
+++ b/Neptune.Web/src/app/pages/field-records/field-records.component.ts
@@ -2,7 +2,8 @@ import { Component, OnInit } from "@angular/core";
 import { AsyncPipe } from "@angular/common";
 import { ActivatedRoute, Router, RouterModule } from "@angular/router";
 import { ColDef } from "ag-grid-community";
-import { Observable } from "rxjs";
+import { BehaviorSubject, Observable } from "rxjs";
+import { switchMap } from "rxjs/operators";
 
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
@@ -37,6 +38,14 @@ type ActiveTab = "field-visits" | "assessments" | "maintenance-records";
     styleUrl: "./field-records.component.scss",
 })
 export class FieldRecordsComponent implements OnInit {
+    // NPT-984: wire the three grids' observables through a class-level reload trigger so the
+    // `| async` pipes have a real Observable to subscribe to at template-init time. Previously
+    // the fields were declared without a value and assigned inside refresh() during ngOnInit;
+    // on lazy-loaded routes in zoneless mode that race led to the page rendering empty until
+    // the user clicked somewhere to force a CD pass (Kathleen's "page does not load until I
+    // click it myself" report). The reload$ trigger replaces the prior reassignment pattern
+    // while still letting refresh() re-fetch after deletes.
+    private reload$ = new BehaviorSubject<void>(undefined);
     public fieldVisits$: Observable<FieldVisitDto[]>;
     public assessments$: Observable<TreatmentBMPAssessmentGridDto[]>;
     public maintenanceRecords$: Observable<MaintenanceRecordGridDto[]>;
@@ -79,7 +88,11 @@ export class FieldRecordsComponent implements OnInit {
         this.assessmentColumnDefs = this.buildAssessmentColumnDefs();
         this.maintenanceRecordColumnDefs = this.buildMaintenanceRecordColumnDefs();
 
-        this.refresh();
+        // Pipe each grid feed off the shared reload trigger so `refresh()` re-fetches all three
+        // and the async pipes never see an undefined observable.
+        this.fieldVisits$ = this.reload$.pipe(switchMap(() => this.fieldVisitService.listFieldVisit()));
+        this.assessments$ = this.reload$.pipe(switchMap(() => this.assessmentService.listTreatmentBMPAssessment()));
+        this.maintenanceRecords$ = this.reload$.pipe(switchMap(() => this.maintenanceRecordService.listMaintenanceRecord()));
     }
 
     public onTabChange(value: string): void {
@@ -95,9 +108,7 @@ export class FieldRecordsComponent implements OnInit {
     }
 
     private refresh(): void {
-        this.fieldVisits$ = this.fieldVisitService.listFieldVisit();
-        this.assessments$ = this.assessmentService.listTreatmentBMPAssessment();
-        this.maintenanceRecords$ = this.maintenanceRecordService.listMaintenanceRecord();
+        this.reload$.next();
     }
 
     private buildFieldVisitColumnDefs(): ColDef[] {

--- a/Neptune.Web/src/app/pages/field-records/field-records.component.ts
+++ b/Neptune.Web/src/app/pages/field-records/field-records.component.ts
@@ -117,10 +117,19 @@ export class FieldRecordsComponent implements OnInit {
             this.utility.createActionsColumnDef((params: any) => {
                 const visit: FieldVisitDto = params.data;
                 const inProgress = visit.FieldVisitStatusID === 1; // FieldVisitStatusEnum.InProgress
+                // NPT-984: route in-progress visits to the editable workflow outlet and
+                // wrapped-up / unresolved / returned visits to the new read-only detail page.
+                // The read-only page provides a fully locked-down summary view with
+                // MVC-style observation tables, photos, and Manager-only Mark Provisional
+                // action that flips back to the editable workflow.
                 const actions: { ActionName: string; ActionIcon?: string; ActionHandler: () => void }[] = [
                     {
                         ActionName: inProgress ? "Continue" : "View",
-                        ActionHandler: () => this.router.navigate(["/field-visits", visit.FieldVisitID]),
+                        ActionHandler: () => this.router.navigate(
+                            inProgress
+                                ? ["/field-visits", visit.FieldVisitID]
+                                : ["/field-visits", visit.FieldVisitID, "view"],
+                        ),
                     },
                 ];
                 if (this.canManage) {

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
@@ -169,7 +169,7 @@
             }
 
             @if (data.postMaintenance) {
-                <div class="card mt-3">
+                <div class="card" [class.mt-3]="!!data.initial">
                     <div class="card-header">
                         <span class="card-title">Post-Maintenance Assessment</span>
                         <span class="card-actions">

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
@@ -1,0 +1,196 @@
+@if (data$ | async; as data) {
+    <page-header [pageTitle]="(data.workflow.TreatmentBMPName ?? 'Field Visit') + ' — ' + (data.workflow.FieldVisitStatusDisplayName ?? '')"></page-header>
+
+    <app-alert-display></app-alert-display>
+
+    <div class="readonly-visit-detail">
+        <p class="alert alert-info readonly-banner">
+            <i class="fa fa-lock mr-2"></i>
+            This Field Visit has been wrapped up and is shown in read-only view.
+            @if (canManage) {
+                Use <strong>Mark Provisional</strong> to return it to an editable state.
+            }
+        </p>
+
+        <!--
+            NPT-984: visit metadata panel — BMP, visit date, type, performed by. Mirrors the
+            sidebar shown by the editable workflow outlet, but as a single header strip since
+            there's no step navigation here.
+        -->
+        <section class="card readonly-section">
+            <div class="card-header">
+                <h3>Visit Information</h3>
+            </div>
+            <div class="card-body">
+                <dl class="readonly-grid">
+                    <dt>Treatment BMP</dt>
+                    <dd>
+                        <a [routerLink]="['/treatment-bmps', data.workflow.TreatmentBMPID]">{{ data.workflow.TreatmentBMPName }}</a>
+                        <span class="readonly-grid__meta">({{ data.workflow.TreatmentBMPTypeName }})</span>
+                    </dd>
+                    <dt>Visit Date</dt>
+                    <dd>{{ data.workflow.VisitDate | date: "MM/dd/yyyy" : "UTC" }}</dd>
+                    <dt>Visit Type</dt>
+                    <dd>{{ data.workflow.FieldVisitTypeDisplayName }}</dd>
+                    <dt>Performed By</dt>
+                    <dd>{{ data.workflow.PerformedByPersonName }}</dd>
+                    <dt>Status</dt>
+                    <dd>{{ data.workflow.FieldVisitStatusDisplayName }}</dd>
+                    <dt>Verified</dt>
+                    <dd>{{ data.workflow.IsFieldVisitVerified ? "Yes" : "No" }}</dd>
+                    <dt>Inventory Updated</dt>
+                    <dd>{{ data.workflow.InventoryUpdated ? "Yes" : "No" }}</dd>
+                    @if (data.workflow.InitialAssessmentScore != null) {
+                        <dt>Initial Assessment Score</dt>
+                        <dd>{{ data.workflow.InitialAssessmentScore | number: "1.1-1" }}</dd>
+                    }
+                    @if (data.workflow.PostMaintenanceAssessmentScore != null) {
+                        <dt>Post-Maintenance Score</dt>
+                        <dd>{{ data.workflow.PostMaintenanceAssessmentScore | number: "1.1-1" }}</dd>
+                    }
+                </dl>
+            </div>
+        </section>
+
+        <!-- Initial Assessment — observation table + score + photos -->
+        @if (data.initial) {
+            <section class="card readonly-section">
+                <div class="card-header card-header__split">
+                    <h3>Initial Assessment</h3>
+                    <span class="readonly-score">
+                        Score: <strong>{{ data.initial.AssessmentScore != null ? (data.initial.AssessmentScore | number: "1.1-1") : "—" }}</strong>
+                    </span>
+                </div>
+                <div class="card-body">
+                    @if (data.initial.ObservationTypes && data.initial.ObservationTypes.length) {
+                        <table class="readonly-obs-table">
+                            <thead>
+                                <tr>
+                                    <th>Observation Type</th>
+                                    <th>Value</th>
+                                    <th>Notes</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @for (ot of data.initial.ObservationTypes; track ot.TreatmentBMPAssessmentObservationTypeID) {
+                                    @let obs = (data.initial.Observations ?? []).find(o => o.TreatmentBMPAssessmentObservationTypeID === ot.TreatmentBMPAssessmentObservationTypeID);
+                                    <tr>
+                                        <td>{{ ot.TreatmentBMPAssessmentObservationTypeName }}</td>
+                                        <td>{{ formatObservationValue(obs?.ObservationData, ot.ObservationTypeCollectionMethodName) }}</td>
+                                        <td>{{ formatObservationNotes(obs?.ObservationData) || "—" }}</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    } @else {
+                        <p class="text-muted">No observation types defined for this BMP.</p>
+                    }
+                    @if (data.initialPhotos.length) {
+                        <h4 class="mt-3">Photos</h4>
+                        <image-carousel [images]="data.initialPhotos"></image-carousel>
+                    }
+                </div>
+            </section>
+        }
+
+        <!-- Maintenance Record — type + description + attribute table -->
+        @if (data.maintenance) {
+            <section class="card readonly-section">
+                <div class="card-header">
+                    <h3>Maintenance Record</h3>
+                </div>
+                <div class="card-body">
+                    <dl class="readonly-grid">
+                        <dt>Maintenance Type</dt>
+                        <dd>{{ data.maintenance.MaintenanceRecordTypeDisplayName || "—" }}</dd>
+                        <dt>Description</dt>
+                        <dd>{{ data.maintenance.MaintenanceRecordDescription || "—" }}</dd>
+                    </dl>
+                    @if (data.maintenanceAttributes.length) {
+                        <h4 class="mt-3">Attributes</h4>
+                        <table class="readonly-obs-table">
+                            <thead>
+                                <tr>
+                                    <th>Attribute</th>
+                                    <th>Value</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @for (attr of data.maintenanceAttributes; track attr.CustomAttributeType?.CustomAttributeTypeID) {
+                                    <tr>
+                                        <td>{{ attr.CustomAttributeType?.CustomAttributeTypeName }}</td>
+                                        <td>{{ maintenanceAttributeValue(attr, data.maintenance) }}</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                </div>
+            </section>
+        }
+
+        <!-- Post-Maintenance Assessment -->
+        @if (data.postMaintenance) {
+            <section class="card readonly-section">
+                <div class="card-header card-header__split">
+                    <h3>Post-Maintenance Assessment</h3>
+                    <span class="readonly-score">
+                        Score: <strong>{{ data.postMaintenance.AssessmentScore != null ? (data.postMaintenance.AssessmentScore | number: "1.1-1") : "—" }}</strong>
+                    </span>
+                </div>
+                <div class="card-body">
+                    @if (data.postMaintenance.ObservationTypes && data.postMaintenance.ObservationTypes.length) {
+                        <table class="readonly-obs-table">
+                            <thead>
+                                <tr>
+                                    <th>Observation Type</th>
+                                    <th>Value</th>
+                                    <th>Notes</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @for (ot of data.postMaintenance.ObservationTypes; track ot.TreatmentBMPAssessmentObservationTypeID) {
+                                    @let obs = (data.postMaintenance.Observations ?? []).find(o => o.TreatmentBMPAssessmentObservationTypeID === ot.TreatmentBMPAssessmentObservationTypeID);
+                                    <tr>
+                                        <td>{{ ot.TreatmentBMPAssessmentObservationTypeName }}</td>
+                                        <td>{{ formatObservationValue(obs?.ObservationData, ot.ObservationTypeCollectionMethodName) }}</td>
+                                        <td>{{ formatObservationNotes(obs?.ObservationData) || "—" }}</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    @if (data.postMaintenancePhotos.length) {
+                        <h4 class="mt-3">Photos</h4>
+                        <image-carousel [images]="data.postMaintenancePhotos"></image-carousel>
+                    }
+                </div>
+            </section>
+        }
+
+        <!--
+            Footer actions. Verify / Mark Provisional are Manager-only and the backend rejects
+            non-Manager calls — keep the frontend gate to avoid showing actions that would 403.
+        -->
+        <div class="readonly-footer">
+            <button type="button" class="btn btn-secondary" (click)="backToFieldRecords()">
+                <i class="fa fa-arrow-left mr-1"></i> Back to Field Records
+            </button>
+            <button type="button" class="btn btn-secondary" (click)="backToBMP(data.workflow)">
+                <i class="fa fa-arrow-left mr-1"></i> Back to BMP
+            </button>
+            @if (canManage) {
+                @if (!data.workflow.IsFieldVisitVerified) {
+                    <button type="button" class="btn btn-primary" (click)="verify(data.workflow)">
+                        <i class="fa fa-check mr-1"></i> Verify
+                    </button>
+                }
+                <button type="button" class="btn btn-warning" (click)="markProvisional(data.workflow)">
+                    <i class="fa fa-undo mr-1"></i> Mark Provisional
+                </button>
+            }
+        </div>
+    </div>
+} @else {
+    <div [loadingSpinner]="{ isLoading: isLoading }"></div>
+}

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
@@ -1,193 +1,208 @@
 @if (data$ | async; as data) {
-    <page-header [pageTitle]="(data.workflow.TreatmentBMPName ?? 'Field Visit') + ' — ' + (data.workflow.FieldVisitStatusDisplayName ?? '')"></page-header>
-
-    <app-alert-display></app-alert-display>
-
-    <div class="readonly-visit-detail">
-        <p class="alert alert-info readonly-banner">
-            <i class="fa fa-lock mr-2"></i>
-            This Field Visit has been wrapped up and is shown in read-only view.
-            @if (canManage) {
-                Use <strong>Mark Provisional</strong> to return it to an editable state.
-            }
-        </p>
-
-        <!--
-            NPT-984: visit metadata panel — BMP, visit date, type, performed by. Mirrors the
-            sidebar shown by the editable workflow outlet, but as a single header strip since
-            there's no step navigation here.
-        -->
-        <section class="card readonly-section">
-            <div class="card-header">
-                <h3>Visit Information</h3>
+    <page-header
+        [pageTitle]="(data.workflow.TreatmentBMPName ?? 'Field Visit') + ' — Field Visit'"
+        [templateAbove]="backLink"
+        [templateRight]="headerActions">
+        <ng-template #backLink>
+            <div class="back">
+                <a [routerLink]="['/field-records']" class="back__link"><i class="fa fa-arrow-left"></i> Back to Field Records</a>
             </div>
-            <div class="card-body">
-                <dl class="readonly-grid">
-                    <dt>Treatment BMP</dt>
-                    <dd>
-                        <a [routerLink]="['/treatment-bmps', data.workflow.TreatmentBMPID]">{{ data.workflow.TreatmentBMPName }}</a>
-                        <span class="readonly-grid__meta">({{ data.workflow.TreatmentBMPTypeName }})</span>
-                    </dd>
-                    <dt>Visit Date</dt>
-                    <dd>{{ data.workflow.VisitDate | date: "MM/dd/yyyy" : "UTC" }}</dd>
-                    <dt>Visit Type</dt>
-                    <dd>{{ data.workflow.FieldVisitTypeDisplayName }}</dd>
-                    <dt>Performed By</dt>
-                    <dd>{{ data.workflow.PerformedByPersonName }}</dd>
-                    <dt>Status</dt>
-                    <dd>{{ data.workflow.FieldVisitStatusDisplayName }}</dd>
-                    <dt>Verified</dt>
-                    <dd>{{ data.workflow.IsFieldVisitVerified ? "Yes" : "No" }}</dd>
-                    <dt>Inventory Updated</dt>
-                    <dd>{{ data.workflow.InventoryUpdated ? "Yes" : "No" }}</dd>
-                    @if (data.workflow.InitialAssessmentScore != null) {
-                        <dt>Initial Assessment Score</dt>
-                        <dd>{{ data.workflow.InitialAssessmentScore | number: "1.1-1" }}</dd>
-                    }
-                    @if (data.workflow.PostMaintenanceAssessmentScore != null) {
-                        <dt>Post-Maintenance Score</dt>
-                        <dd>{{ data.workflow.PostMaintenanceAssessmentScore | number: "1.1-1" }}</dd>
-                    }
-                </dl>
-            </div>
-        </section>
-
-        <!-- Initial Assessment — observation table + score + photos -->
-        @if (data.initial) {
-            <section class="card readonly-section">
-                <div class="card-header card-header__split">
-                    <h3>Initial Assessment</h3>
-                    <span class="readonly-score">
-                        Score: <strong>{{ data.initial.AssessmentScore != null ? (data.initial.AssessmentScore | number: "1.1-1") : "—" }}</strong>
-                    </span>
-                </div>
-                <div class="card-body">
-                    @if (data.initial.ObservationTypes && data.initial.ObservationTypes.length) {
-                        <table class="readonly-obs-table">
-                            <thead>
-                                <tr>
-                                    <th>Observation Type</th>
-                                    <th>Value</th>
-                                    <th>Notes</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @for (ot of data.initial.ObservationTypes; track ot.TreatmentBMPAssessmentObservationTypeID) {
-                                    @let obs = (data.initial.Observations ?? []).find(o => o.TreatmentBMPAssessmentObservationTypeID === ot.TreatmentBMPAssessmentObservationTypeID);
-                                    <tr>
-                                        <td>{{ ot.TreatmentBMPAssessmentObservationTypeName }}</td>
-                                        <td>{{ formatObservationValue(obs?.ObservationData, ot.ObservationTypeCollectionMethodName) }}</td>
-                                        <td>{{ formatObservationNotes(obs?.ObservationData) || "—" }}</td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                    } @else {
-                        <p class="text-muted">No observation types defined for this BMP.</p>
-                    }
-                    @if (data.initialPhotos.length) {
-                        <h4 class="mt-3">Photos</h4>
-                        <image-carousel [images]="data.initialPhotos"></image-carousel>
-                    }
-                </div>
-            </section>
-        }
-
-        <!-- Maintenance Record — type + description + attribute table -->
-        @if (data.maintenance) {
-            <section class="card readonly-section">
-                <div class="card-header">
-                    <h3>Maintenance Record</h3>
-                </div>
-                <div class="card-body">
-                    <dl class="readonly-grid">
-                        <dt>Maintenance Type</dt>
-                        <dd>{{ data.maintenance.MaintenanceRecordTypeDisplayName || "—" }}</dd>
-                        <dt>Description</dt>
-                        <dd>{{ data.maintenance.MaintenanceRecordDescription || "—" }}</dd>
-                    </dl>
-                    @if (data.maintenanceAttributes.length) {
-                        <h4 class="mt-3">Attributes</h4>
-                        <table class="readonly-obs-table">
-                            <thead>
-                                <tr>
-                                    <th>Attribute</th>
-                                    <th>Value</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @for (attr of data.maintenanceAttributes; track attr.CustomAttributeType?.CustomAttributeTypeID) {
-                                    <tr>
-                                        <td>{{ attr.CustomAttributeType?.CustomAttributeTypeName }}</td>
-                                        <td>{{ maintenanceAttributeValue(attr, data.maintenance) }}</td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                    }
-                </div>
-            </section>
-        }
-
-        <!-- Post-Maintenance Assessment -->
-        @if (data.postMaintenance) {
-            <section class="card readonly-section">
-                <div class="card-header card-header__split">
-                    <h3>Post-Maintenance Assessment</h3>
-                    <span class="readonly-score">
-                        Score: <strong>{{ data.postMaintenance.AssessmentScore != null ? (data.postMaintenance.AssessmentScore | number: "1.1-1") : "—" }}</strong>
-                    </span>
-                </div>
-                <div class="card-body">
-                    @if (data.postMaintenance.ObservationTypes && data.postMaintenance.ObservationTypes.length) {
-                        <table class="readonly-obs-table">
-                            <thead>
-                                <tr>
-                                    <th>Observation Type</th>
-                                    <th>Value</th>
-                                    <th>Notes</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @for (ot of data.postMaintenance.ObservationTypes; track ot.TreatmentBMPAssessmentObservationTypeID) {
-                                    @let obs = (data.postMaintenance.Observations ?? []).find(o => o.TreatmentBMPAssessmentObservationTypeID === ot.TreatmentBMPAssessmentObservationTypeID);
-                                    <tr>
-                                        <td>{{ ot.TreatmentBMPAssessmentObservationTypeName }}</td>
-                                        <td>{{ formatObservationValue(obs?.ObservationData, ot.ObservationTypeCollectionMethodName) }}</td>
-                                        <td>{{ formatObservationNotes(obs?.ObservationData) || "—" }}</td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                    }
-                    @if (data.postMaintenancePhotos.length) {
-                        <h4 class="mt-3">Photos</h4>
-                        <image-carousel [images]="data.postMaintenancePhotos"></image-carousel>
-                    }
-                </div>
-            </section>
-        }
-
-        <!--
-            Footer actions. Verify / Mark Provisional are Manager-only and the backend rejects
-            non-Manager calls — keep the frontend gate to avoid showing actions that would 403.
-        -->
-        <div class="readonly-footer">
-            <button type="button" class="btn btn-secondary" (click)="backToFieldRecords()">
-                <i class="fa fa-arrow-left mr-1"></i> Back to Field Records
-            </button>
-            <button type="button" class="btn btn-secondary" (click)="backToBMP(data.workflow)">
+        </ng-template>
+        <ng-template #headerActions>
+            <a [routerLink]="['/treatment-bmps', data.workflow.TreatmentBMPID]" class="btn btn-secondary-outline mr-2">
                 <i class="fa fa-arrow-left mr-1"></i> Back to BMP
-            </button>
+            </a>
             @if (canManage) {
                 @if (!data.workflow.IsFieldVisitVerified) {
-                    <button type="button" class="btn btn-primary" (click)="verify(data.workflow)">
+                    <button type="button" class="btn btn-primary mr-2" (click)="verify(data.workflow)">
                         <i class="fa fa-check mr-1"></i> Verify
                     </button>
                 }
                 <button type="button" class="btn btn-warning" (click)="markProvisional(data.workflow)">
                     <i class="fa fa-undo mr-1"></i> Mark Provisional
                 </button>
+            }
+        </ng-template>
+    </page-header>
+
+    <app-alert-display></app-alert-display>
+
+    <!--
+        Read-only banner — surfaces the wrap-up status + (for Managers) the path back to editing.
+        Sits above the cards so the user knows what to expect before scanning the data.
+    -->
+    <div class="alert alert-info">
+        <i class="fa fa-lock mr-2"></i>
+        This Field Visit has been wrapped up and is shown in read-only view.
+        @if (canManage) {
+            Use <strong>Mark Provisional</strong> to return it to an editable state.
+        }
+    </div>
+
+    <div class="grid-12">
+        <!--
+            Left column: visit-level + maintenance record. Visit Info card is the index of the
+            page (BMP, date, type, performer, status, scores) so it's first. Maintenance sits
+            below since it's a single-action narrative (type / description / attributes) and
+            usually shorter than the assessment cards.
+        -->
+        <div class="g-col-6">
+            <div class="card">
+                <div class="card-header">
+                    <span class="card-title">Visit Information</span>
+                </div>
+                <div class="card-body">
+                    <dl class="grid-12">
+                        <dt class="g-col-5">Treatment BMP</dt>
+                        <dd class="g-col-7">
+                            <a [routerLink]="['/treatment-bmps', data.workflow.TreatmentBMPID]">{{ data.workflow.TreatmentBMPName }}</a>
+                            <div class="text-muted">{{ data.workflow.TreatmentBMPTypeName }}</div>
+                        </dd>
+                        <dt class="g-col-5">Visit Date</dt>
+                        <dd class="g-col-7">{{ data.workflow.VisitDate | date: "MM/dd/yyyy" : "UTC" }}</dd>
+                        <dt class="g-col-5">Visit Type</dt>
+                        <dd class="g-col-7">{{ data.workflow.FieldVisitTypeDisplayName }}</dd>
+                        <dt class="g-col-5">Performed By</dt>
+                        <dd class="g-col-7">{{ data.workflow.PerformedByPersonName }}</dd>
+                        <dt class="g-col-5">Status</dt>
+                        <dd class="g-col-7">{{ data.workflow.FieldVisitStatusDisplayName }}</dd>
+                        <dt class="g-col-5">Verified</dt>
+                        <dd class="g-col-7">{{ data.workflow.IsFieldVisitVerified ? "Yes" : "No" }}</dd>
+                        <dt class="g-col-5">Inventory Updated</dt>
+                        <dd class="g-col-7">{{ data.workflow.InventoryUpdated ? "Yes" : "No" }}</dd>
+                        @if (data.workflow.InitialAssessmentScore != null) {
+                            <dt class="g-col-5">Initial Assessment Score</dt>
+                            <dd class="g-col-7">{{ data.workflow.InitialAssessmentScore | number: "1.1-1" }}</dd>
+                        }
+                        @if (data.workflow.PostMaintenanceAssessmentScore != null) {
+                            <dt class="g-col-5">Post-Maintenance Score</dt>
+                            <dd class="g-col-7">{{ data.workflow.PostMaintenanceAssessmentScore | number: "1.1-1" }}</dd>
+                        }
+                    </dl>
+                </div>
+            </div>
+
+            @if (data.maintenance) {
+                <div class="card mt-3">
+                    <div class="card-header">
+                        <span class="card-title">Maintenance Record</span>
+                    </div>
+                    <div class="card-body">
+                        <dl class="grid-12">
+                            <dt class="g-col-5">Maintenance Type</dt>
+                            <dd class="g-col-7">{{ data.maintenance.MaintenanceRecordTypeDisplayName || "—" }}</dd>
+                            <dt class="g-col-5">Description</dt>
+                            <dd class="g-col-7">{{ data.maintenance.MaintenanceRecordDescription || "—" }}</dd>
+                        </dl>
+                        @if (data.maintenanceAttributes.length) {
+                            <h4 class="mt-3">Attributes</h4>
+                            <table class="readonly-obs-table">
+                                <thead>
+                                    <tr>
+                                        <th>Attribute</th>
+                                        <th>Value</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @for (attr of data.maintenanceAttributes; track attr.CustomAttributeType?.CustomAttributeTypeID) {
+                                        <tr>
+                                            <td>{{ attr.CustomAttributeType?.CustomAttributeTypeName }}</td>
+                                            <td>{{ maintenanceAttributeValue(attr, data.maintenance) }}</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        }
+                    </div>
+                </div>
+            }
+        </div>
+
+        <!--
+            Right column: the two assessments side-by-side with the visit-info column. Each
+            assessment is its own card so their observation tables + photos stay grouped.
+        -->
+        <div class="g-col-6">
+            @if (data.initial) {
+                <div class="card">
+                    <div class="card-header">
+                        <span class="card-title">Initial Assessment</span>
+                        <span class="card-actions">
+                            <span class="readonly-score">
+                                Score: <strong>{{ data.initial.AssessmentScore != null ? (data.initial.AssessmentScore | number: "1.1-1") : "—" }}</strong>
+                            </span>
+                        </span>
+                    </div>
+                    <div class="card-body">
+                        @if (data.initial.ObservationTypes && data.initial.ObservationTypes.length) {
+                            <table class="readonly-obs-table">
+                                <thead>
+                                    <tr>
+                                        <th>Observation Type</th>
+                                        <th>Value</th>
+                                        <th>Notes</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @for (ot of data.initial.ObservationTypes; track ot.TreatmentBMPAssessmentObservationTypeID) {
+                                        @let obs = (data.initial.Observations ?? []).find(o => o.TreatmentBMPAssessmentObservationTypeID === ot.TreatmentBMPAssessmentObservationTypeID);
+                                        <tr>
+                                            <td>{{ ot.TreatmentBMPAssessmentObservationTypeName }}</td>
+                                            <td>{{ formatObservationValue(obs?.ObservationData, ot.ObservationTypeCollectionMethodName) }}</td>
+                                            <td>{{ formatObservationNotes(obs?.ObservationData) || "—" }}</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        } @else {
+                            <p class="text-muted">No observation types defined for this BMP.</p>
+                        }
+                        @if (data.initialPhotos.length) {
+                            <h4 class="mt-3">Photos</h4>
+                            <image-carousel [images]="data.initialPhotos"></image-carousel>
+                        }
+                    </div>
+                </div>
+            }
+
+            @if (data.postMaintenance) {
+                <div class="card mt-3">
+                    <div class="card-header">
+                        <span class="card-title">Post-Maintenance Assessment</span>
+                        <span class="card-actions">
+                            <span class="readonly-score">
+                                Score: <strong>{{ data.postMaintenance.AssessmentScore != null ? (data.postMaintenance.AssessmentScore | number: "1.1-1") : "—" }}</strong>
+                            </span>
+                        </span>
+                    </div>
+                    <div class="card-body">
+                        @if (data.postMaintenance.ObservationTypes && data.postMaintenance.ObservationTypes.length) {
+                            <table class="readonly-obs-table">
+                                <thead>
+                                    <tr>
+                                        <th>Observation Type</th>
+                                        <th>Value</th>
+                                        <th>Notes</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @for (ot of data.postMaintenance.ObservationTypes; track ot.TreatmentBMPAssessmentObservationTypeID) {
+                                        @let obs = (data.postMaintenance.Observations ?? []).find(o => o.TreatmentBMPAssessmentObservationTypeID === ot.TreatmentBMPAssessmentObservationTypeID);
+                                        <tr>
+                                            <td>{{ ot.TreatmentBMPAssessmentObservationTypeName }}</td>
+                                            <td>{{ formatObservationValue(obs?.ObservationData, ot.ObservationTypeCollectionMethodName) }}</td>
+                                            <td>{{ formatObservationNotes(obs?.ObservationData) || "—" }}</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        }
+                        @if (data.postMaintenancePhotos.length) {
+                            <h4 class="mt-3">Photos</h4>
+                            <image-carousel [images]="data.postMaintenancePhotos"></image-carousel>
+                        }
+                    </div>
+                </div>
             }
         </div>
     </div>

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
@@ -143,6 +143,7 @@
                                     <tr>
                                         <th>Observation Type</th>
                                         <th>Value</th>
+                                        <th>Score</th>
                                         <th>Notes</th>
                                     </tr>
                                 </thead>
@@ -152,6 +153,7 @@
                                         <tr>
                                             <td>{{ ot.TreatmentBMPAssessmentObservationTypeName }}</td>
                                             <td>{{ formatObservationValue(obs?.ObservationData, ot.ObservationTypeCollectionMethodName) }}</td>
+                                            <td>{{ obs?.ObservationScore || "—" }}</td>
                                             <td>{{ formatObservationNotes(obs?.ObservationData) || "—" }}</td>
                                         </tr>
                                     }
@@ -185,6 +187,7 @@
                                     <tr>
                                         <th>Observation Type</th>
                                         <th>Value</th>
+                                        <th>Score</th>
                                         <th>Notes</th>
                                     </tr>
                                 </thead>
@@ -194,6 +197,7 @@
                                         <tr>
                                             <td>{{ ot.TreatmentBMPAssessmentObservationTypeName }}</td>
                                             <td>{{ formatObservationValue(obs?.ObservationData, ot.ObservationTypeCollectionMethodName) }}</td>
+                                            <td>{{ obs?.ObservationScore || "—" }}</td>
                                             <td>{{ formatObservationNotes(obs?.ObservationData) || "—" }}</td>
                                         </tr>
                                     }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
@@ -9,9 +9,6 @@
             </div>
         </ng-template>
         <ng-template #headerActions>
-            <a [routerLink]="['/treatment-bmps', data.workflow.TreatmentBMPID]" class="btn btn-secondary-outline mr-2">
-                <i class="fa fa-arrow-left mr-1"></i> Back to BMP
-            </a>
             @if (canManage) {
                 @if (!data.workflow.IsFieldVisitVerified) {
                     <button type="button" class="btn btn-primary mr-2" (click)="verify(data.workflow)">

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.html
@@ -30,13 +30,19 @@
     <!--
         Read-only banner — surfaces the wrap-up status + (for Managers) the path back to editing.
         Sits above the cards so the user knows what to expect before scanning the data.
+        `.alert` is flex+space-between so the content needs to live inside one .alert-content
+        flex item; otherwise the message gets spread across the full width.
     -->
     <div class="alert alert-info">
-        <i class="fa fa-lock mr-2"></i>
-        This Field Visit has been wrapped up and is shown in read-only view.
-        @if (canManage) {
-            Use <strong>Mark Provisional</strong> to return it to an editable state.
-        }
+        <div class="alert-content">
+            <i class="fa fa-lock"></i>
+            <span>
+                This Field Visit has been wrapped up and is shown in read-only view.
+                @if (canManage) {
+                    Use <strong>Mark Provisional</strong> to return it to an editable state.
+                }
+            </span>
+        </div>
     </div>
 
     <div class="grid-12">

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.scss
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.scss
@@ -1,41 +1,9 @@
 @use "/src/scss/abstracts" as *;
 
-.readonly-visit-detail {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    padding: 1rem;
-}
-
-.readonly-banner {
-    margin-bottom: 0;
-}
-
-.readonly-section {
-    background: #fff;
-
-    .card-header {
-        background: $gray-100;
-        border-bottom: 1px solid $gray-200;
-
-        h3 {
-            margin: 0;
-            font-size: $type-size-400;
-            color: $teal-800;
-        }
-
-        &__split {
-            display: flex;
-            justify-content: space-between;
-            align-items: baseline;
-            gap: 1rem;
-        }
-    }
-
-    .card-body {
-        padding: 1rem 1.25rem;
-    }
-}
+// NPT-984: read-only Field Visit detail page leans on the global `.card` / `.card-header` /
+// `.card-body` styles from the shared abstracts (same as BMP / WQMP detail). Only need a
+// handful of overrides for the score chip and the MVC-style observation table that lives
+// inside the assessment cards' bodies.
 
 .readonly-score {
     font-size: $type-size-300;
@@ -46,34 +14,8 @@
     }
 }
 
-// dl-style key/value grid for the simple metadata sections (visit info, maintenance record).
-// Two-column layout: label on the left, value on the right.
-.readonly-grid {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    column-gap: 1.25rem;
-    row-gap: 0.4rem;
-    margin: 0;
-
-    dt {
-        font-weight: 600;
-        color: $gray-700;
-    }
-
-    dd {
-        margin: 0;
-        color: $gray-800;
-    }
-
-    &__meta {
-        color: $gray-600;
-        margin-left: 0.4rem;
-        font-size: $type-size-200;
-    }
-}
-
 // MVC-style observation summary table — Type | Value | Notes columns. Mirrors
-// AssessmentDetail.cshtml. Compact rows, subtle row separators, no Bootstrap chrome.
+// AssessmentDetail.cshtml. Compact rows, subtle separators, no Bootstrap chrome.
 .readonly-obs-table {
     width: 100%;
     border-collapse: collapse;
@@ -98,12 +40,4 @@
     tbody tr:last-child td {
         border-bottom: 0;
     }
-}
-
-.readonly-footer {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-top: 0.5rem;
-    padding: 0.75rem 0;
 }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.scss
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.scss
@@ -5,12 +5,14 @@
 // handful of overrides for the score chip and the MVC-style observation table that lives
 // inside the assessment cards' bodies.
 
+// Score chip sits inside `.card-header` (white-on-teal). Inherit color rather than
+// re-declaring so the "Score:" label + value both read white over the teal background.
 .readonly-score {
     font-size: $type-size-300;
-    color: $gray-700;
+    font-weight: 600;
 
     strong {
-        color: $teal-800;
+        font-weight: 700;
     }
 }
 

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.scss
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.scss
@@ -1,0 +1,109 @@
+@use "/src/scss/abstracts" as *;
+
+.readonly-visit-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+}
+
+.readonly-banner {
+    margin-bottom: 0;
+}
+
+.readonly-section {
+    background: #fff;
+
+    .card-header {
+        background: $gray-100;
+        border-bottom: 1px solid $gray-200;
+
+        h3 {
+            margin: 0;
+            font-size: $type-size-400;
+            color: $teal-800;
+        }
+
+        &__split {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 1rem;
+        }
+    }
+
+    .card-body {
+        padding: 1rem 1.25rem;
+    }
+}
+
+.readonly-score {
+    font-size: $type-size-300;
+    color: $gray-700;
+
+    strong {
+        color: $teal-800;
+    }
+}
+
+// dl-style key/value grid for the simple metadata sections (visit info, maintenance record).
+// Two-column layout: label on the left, value on the right.
+.readonly-grid {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 1.25rem;
+    row-gap: 0.4rem;
+    margin: 0;
+
+    dt {
+        font-weight: 600;
+        color: $gray-700;
+    }
+
+    dd {
+        margin: 0;
+        color: $gray-800;
+    }
+
+    &__meta {
+        color: $gray-600;
+        margin-left: 0.4rem;
+        font-size: $type-size-200;
+    }
+}
+
+// MVC-style observation summary table — Type | Value | Notes columns. Mirrors
+// AssessmentDetail.cshtml. Compact rows, subtle row separators, no Bootstrap chrome.
+.readonly-obs-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: $type-size-200;
+
+    th, td {
+        text-align: left;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid $gray-100;
+        vertical-align: top;
+    }
+
+    thead th {
+        font-size: $type-size-100;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: $gray-600;
+        border-bottom: 1px solid $gray-300;
+        font-weight: 700;
+    }
+
+    tbody tr:last-child td {
+        border-bottom: 0;
+    }
+}
+
+.readonly-footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    padding: 0.75rem 0;
+}

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, Input, OnInit } from "@angular/core";
 import { AsyncPipe, DatePipe, DecimalPipe } from "@angular/common";
-import { ActivatedRoute, Router, RouterLink } from "@angular/router";
+import { Router, RouterLink } from "@angular/router";
 import { BehaviorSubject, forkJoin, Observable, of, switchMap } from "rxjs";
 
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
@@ -60,7 +60,6 @@ export class FieldVisitDetailReadOnlyComponent implements OnInit {
     private confirmService = inject(ConfirmService);
     private alertService = inject(AlertService);
     private router = inject(Router);
-    private route = inject(ActivatedRoute);
 
     private reload$ = new BehaviorSubject<void>(undefined);
 
@@ -145,7 +144,11 @@ export class FieldVisitDetailReadOnlyComponent implements OnInit {
             const value = first.ObservationValue;
             if (value == null || value === "") return "—";
             if (collectionMethod === "PassFail") {
-                return value === true || value === "true" ? "Pass" : "Fail";
+                // NPT-984: explicit fallback to "—" for unknown PassFail payloads (typo'd
+                // value, etc.) instead of silently rendering "Fail" — Copilot PR #507 #6.
+                if (value === true || value === "true") return "Pass";
+                if (value === false || value === "false") return "Fail";
+                return "—";
             }
             if (collectionMethod === "Percentage") {
                 return `${value}%`;

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
@@ -1,7 +1,7 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, inject, Input, OnInit } from "@angular/core";
 import { AsyncPipe, DatePipe, DecimalPipe } from "@angular/common";
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
-import { forkJoin, Observable, of, switchMap } from "rxjs";
+import { BehaviorSubject, forkJoin, Observable, of, switchMap } from "rxjs";
 
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
@@ -46,6 +46,24 @@ import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
     styleUrl: "./field-visit-detail-readonly.component.scss",
 })
 export class FieldVisitDetailReadOnlyComponent implements OnInit {
+    // NPT-984: services injected via `inject()` so the data$ pipeline can be wired up as a
+    // field initializer (see data$ below). Lazy-loaded zoneless routes complete the first
+    // CD pass before ngOnInit runs, so observables assigned in ngOnInit raced the template's
+    // `| async` subscription. Field initializers run at class instantiation time — well
+    // before the first CD — so the async pipe sees a live observable on its first check.
+    private fieldVisitService = inject(FieldVisitService);
+    private assessmentService = inject(TreatmentBMPAssessmentService);
+    private assessmentPhotoService = inject(TreatmentBMPAssessmentPhotoService);
+    private maintenanceRecordService = inject(MaintenanceRecordService);
+    private treatmentBMPTypeService = inject(TreatmentBMPTypeService);
+    private authenticationService = inject(AuthenticationService);
+    private confirmService = inject(ConfirmService);
+    private alertService = inject(AlertService);
+    private router = inject(Router);
+    private route = inject(ActivatedRoute);
+
+    private reload$ = new BehaviorSubject<void>(undefined);
+
     @Input() fieldVisitID!: number;
 
     public data$: Observable<{
@@ -56,69 +74,57 @@ export class FieldVisitDetailReadOnlyComponent implements OnInit {
         postMaintenancePhotos: ImageCarouselItem[];
         maintenance: MaintenanceRecordDetailDto | null;
         maintenanceAttributes: TreatmentBMPTypeCustomAttributeTypeDto[];
-    } | null>;
+    } | null> = this.reload$.pipe(
+        switchMap(() => this.fieldVisitService.getByIDFieldVisit(this.fieldVisitID)),
+        switchMap((workflow) => {
+            const initialAssessment$ = workflow.InitialAssessmentID
+                ? this.assessmentService.getByIDTreatmentBMPAssessment(workflow.InitialAssessmentID)
+                : of(null as TreatmentBMPAssessmentDetailDto | null);
+            const postMaintenanceAssessment$ = workflow.PostMaintenanceAssessmentID
+                ? this.assessmentService.getByIDTreatmentBMPAssessment(workflow.PostMaintenanceAssessmentID)
+                : of(null as TreatmentBMPAssessmentDetailDto | null);
+            const initialPhotos$ = workflow.InitialAssessmentID
+                ? this.assessmentPhotoService.listTreatmentBMPAssessmentPhoto(workflow.InitialAssessmentID)
+                : of([]);
+            const postMaintenancePhotos$ = workflow.PostMaintenanceAssessmentID
+                ? this.assessmentPhotoService.listTreatmentBMPAssessmentPhoto(workflow.PostMaintenanceAssessmentID)
+                : of([]);
+            const maintenance$ = this.maintenanceRecordService.getByFieldVisitMaintenanceRecord(this.fieldVisitID);
+            const attributes$ = this.treatmentBMPTypeService.listCustomAttributeTypesTreatmentBMPType(workflow.TreatmentBMPTypeID);
+            return forkJoin({
+                workflow: of(workflow),
+                initial: initialAssessment$,
+                initialPhotos: initialPhotos$,
+                postMaintenance: postMaintenanceAssessment$,
+                postMaintenancePhotos: postMaintenancePhotos$,
+                maintenance: maintenance$,
+                maintenanceAttributes: attributes$,
+            });
+        }),
+        switchMap((payload) => {
+            this.isLoading = false;
+            const toCarouselItems = (rows: { FileResourceGUID?: string | null; Caption?: string | null }[]): ImageCarouselItem[] =>
+                rows.map((p) => ({ FileResourceGUID: p.FileResourceGUID ?? undefined, Caption: p.Caption ?? null }));
+            const filteredMaintenanceAttributes = (payload.maintenanceAttributes ?? []).filter(
+                (t) => t.CustomAttributeType?.CustomAttributeTypePurposeID === CustomAttributeTypePurposeEnum.Maintenance,
+            );
+            return of({
+                workflow: payload.workflow,
+                initial: payload.initial,
+                initialPhotos: toCarouselItems(payload.initialPhotos ?? []),
+                postMaintenance: payload.postMaintenance,
+                postMaintenancePhotos: toCarouselItems(payload.postMaintenancePhotos ?? []),
+                maintenance: payload.maintenance,
+                maintenanceAttributes: filteredMaintenanceAttributes,
+            });
+        }),
+    );
 
     public isLoading = true;
 
-    constructor(
-        private fieldVisitService: FieldVisitService,
-        private assessmentService: TreatmentBMPAssessmentService,
-        private assessmentPhotoService: TreatmentBMPAssessmentPhotoService,
-        private maintenanceRecordService: MaintenanceRecordService,
-        private treatmentBMPTypeService: TreatmentBMPTypeService,
-        private authenticationService: AuthenticationService,
-        private confirmService: ConfirmService,
-        private alertService: AlertService,
-        private router: Router,
-        private route: ActivatedRoute,
-    ) {}
-
     ngOnInit(): void {
-        this.data$ = this.fieldVisitService.getByIDFieldVisit(this.fieldVisitID).pipe(
-            switchMap((workflow) => {
-                const initialAssessment$ = workflow.InitialAssessmentID
-                    ? this.assessmentService.getByIDTreatmentBMPAssessment(workflow.InitialAssessmentID)
-                    : of(null as TreatmentBMPAssessmentDetailDto | null);
-                const postMaintenanceAssessment$ = workflow.PostMaintenanceAssessmentID
-                    ? this.assessmentService.getByIDTreatmentBMPAssessment(workflow.PostMaintenanceAssessmentID)
-                    : of(null as TreatmentBMPAssessmentDetailDto | null);
-                const initialPhotos$ = workflow.InitialAssessmentID
-                    ? this.assessmentPhotoService.listTreatmentBMPAssessmentPhoto(workflow.InitialAssessmentID)
-                    : of([]);
-                const postMaintenancePhotos$ = workflow.PostMaintenanceAssessmentID
-                    ? this.assessmentPhotoService.listTreatmentBMPAssessmentPhoto(workflow.PostMaintenanceAssessmentID)
-                    : of([]);
-                const maintenance$ = this.maintenanceRecordService.getByFieldVisitMaintenanceRecord(this.fieldVisitID);
-                const attributes$ = this.treatmentBMPTypeService.listCustomAttributeTypesTreatmentBMPType(workflow.TreatmentBMPTypeID);
-                return forkJoin({
-                    workflow: of(workflow),
-                    initial: initialAssessment$,
-                    initialPhotos: initialPhotos$,
-                    postMaintenance: postMaintenanceAssessment$,
-                    postMaintenancePhotos: postMaintenancePhotos$,
-                    maintenance: maintenance$,
-                    maintenanceAttributes: attributes$,
-                });
-            }),
-            // Use the loaded payload to flip the loading flag, then map to the same shape.
-            switchMap((payload) => {
-                this.isLoading = false;
-                const toCarouselItems = (rows: { FileResourceGUID?: string | null; Caption?: string | null }[]): ImageCarouselItem[] =>
-                    rows.map((p) => ({ FileResourceGUID: p.FileResourceGUID ?? undefined, Caption: p.Caption ?? null }));
-                const filteredMaintenanceAttributes = (payload.maintenanceAttributes ?? []).filter(
-                    (t) => t.CustomAttributeType?.CustomAttributeTypePurposeID === CustomAttributeTypePurposeEnum.Maintenance,
-                );
-                return of({
-                    workflow: payload.workflow,
-                    initial: payload.initial,
-                    initialPhotos: toCarouselItems(payload.initialPhotos ?? []),
-                    postMaintenance: payload.postMaintenance,
-                    postMaintenancePhotos: toCarouselItems(payload.postMaintenancePhotos ?? []),
-                    maintenance: payload.maintenance,
-                    maintenanceAttributes: filteredMaintenanceAttributes,
-                });
-            }),
-        );
+        // Nothing required here — data$ is wired via field initializer and subscribes lazily
+        // through the template's `| async`. Kept on the class for future per-route work.
     }
 
     public get canManage(): boolean {
@@ -226,9 +232,9 @@ export class FieldVisitDetailReadOnlyComponent implements OnInit {
                 if (!confirmed) return;
                 this.fieldVisitService.verifyFieldVisit(workflow.FieldVisitID!).subscribe(() => {
                     this.alertService.pushAlert(new Alert("Field Visit verified.", AlertContext.Success));
-                    // Refresh by re-fetching — stay on the read-only page; the verified pill
-                    // flips and the Manager actions reflect the new state.
-                    this.ngOnInit();
+                    // Re-fire the reload trigger to re-fetch the workflow + child data so the
+                    // verified pill flips and the Manager actions reflect the new state.
+                    this.reload$.next();
                 });
             });
     }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
@@ -187,14 +187,6 @@ export class FieldVisitDetailReadOnlyComponent implements OnInit {
         return values.length > 0 ? values.join(", ") : "—";
     }
 
-    public backToFieldRecords(): void {
-        this.router.navigate(["/field-records"]);
-    }
-
-    public backToBMP(workflow: FieldVisitWorkflowDto): void {
-        this.router.navigate(["/treatment-bmps", workflow.TreatmentBMPID]);
-    }
-
     /**
      * Mark Provisional returns the visit to an editable state. Manager-only, gated both on
      * the frontend (`canManage`) and on the backend (`[JurisdictionManageFeature]` on the

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
@@ -184,7 +184,12 @@ export class FieldVisitDetailReadOnlyComponent implements OnInit {
         const values = (obs?.Values ?? [])
             .map((v) => (v?.ObservationValue ?? "").trim())
             .filter((s) => s.length > 0);
-        return values.length > 0 ? values.join(", ") : "—";
+        if (values.length === 0) return "—";
+        // NPT-984: append the attribute's measurement unit (e.g., "cu ft", "gal", "%") when
+        // one is configured. Mirrors the legacy MVC unit-suffix pattern on attribute values.
+        const joined = values.join(", ");
+        const unit = attribute.CustomAttributeType?.MeasurementUnitDisplayName?.trim();
+        return unit ? `${joined} ${unit}` : joined;
     }
 
     /**

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
@@ -186,10 +186,13 @@ export class FieldVisitDetailReadOnlyComponent implements OnInit {
             .filter((s) => s.length > 0);
         if (values.length === 0) return "—";
         // NPT-984: append the attribute's measurement unit (e.g., "cu ft", "gal", "%") when
-        // one is configured. Mirrors the legacy MVC unit-suffix pattern on attribute values.
+        // one is configured. Mirrors the legacy MVC unit-suffix pattern. Skip when the unit
+        // is "None" (the placeholder DataTransferObject value for unitless attributes, e.g.,
+        // boolean "Mechanical Repair Conducted") so we don't render "No None".
         const joined = values.join(", ");
         const unit = attribute.CustomAttributeType?.MeasurementUnitDisplayName?.trim();
-        return unit ? `${joined} ${unit}` : joined;
+        const hasMeaningfulUnit = !!unit && unit.toLowerCase() !== "none";
+        return hasMeaningfulUnit ? `${joined} ${unit}` : joined;
     }
 
     /**

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-detail-readonly/field-visit-detail-readonly.component.ts
@@ -1,0 +1,235 @@
+import { Component, Input, OnInit } from "@angular/core";
+import { AsyncPipe, DatePipe, DecimalPipe } from "@angular/common";
+import { ActivatedRoute, Router, RouterLink } from "@angular/router";
+import { forkJoin, Observable, of, switchMap } from "rxjs";
+
+import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
+import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
+import { LoadingDirective } from "src/app/shared/directives/loading.directive";
+import { ImageCarouselComponent, ImageCarouselItem } from "src/app/shared/components/image-carousel/image-carousel.component";
+
+import { FieldVisitService } from "src/app/shared/generated/api/field-visit.service";
+import { TreatmentBMPAssessmentPhotoService } from "src/app/shared/generated/api/treatment-bmp-assessment-photo.service";
+import { TreatmentBMPAssessmentService } from "src/app/shared/generated/api/treatment-bmp-assessment.service";
+import { MaintenanceRecordService } from "src/app/shared/generated/api/maintenance-record.service";
+import { TreatmentBMPTypeService } from "src/app/shared/generated/api/treatment-bmp-type.service";
+import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visit-workflow-dto";
+import { TreatmentBMPAssessmentDetailDto } from "src/app/shared/generated/model/treatment-bmp-assessment-detail-dto";
+import { MaintenanceRecordDetailDto } from "src/app/shared/generated/model/maintenance-record-detail-dto";
+import { TreatmentBMPTypeCustomAttributeTypeDto } from "src/app/shared/generated/model/treatment-bmp-type-custom-attribute-type-dto";
+import { CustomAttributeTypePurposeEnum } from "src/app/shared/generated/enum/custom-attribute-type-purpose-enum";
+
+import { AlertService } from "src/app/shared/services/alert.service";
+import { AuthenticationService } from "src/app/services/authentication.service";
+import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
+import { Alert } from "src/app/shared/models/alert";
+import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
+
+/**
+ * NPT-984: read-only "View" surface for a wrapped-up Field Visit. Mirrors the legacy MVC
+ * `FieldVisit/Detail.cshtml` + `AssessmentDetail.cshtml` layouts. Routed to from the
+ * Field Records grid when a visit is **not** in-progress, and from the workflow outlet's
+ * Wrap Up handler after `finalizeFieldVisit` succeeds. Existing editable workflow pages
+ * (under `/field-visits/:id/inventory|assessment|maintenance|…`) stay as edit-only — this
+ * page replaces them once the visit is wrapped.
+ *
+ * Sections rendered top-to-bottom: visit header, Inventory summary, Initial Assessment
+ * (observation table + photos + score), Maintenance Record (type / description / attribute
+ * values), Post-Maintenance Assessment (same as initial). Manager-only footer actions
+ * (Mark Provisional / Return to Edit) live below the sections.
+ */
+@Component({
+    selector: "field-visit-detail-readonly",
+    standalone: true,
+    imports: [AsyncPipe, DatePipe, DecimalPipe, RouterLink, PageHeaderComponent, AlertDisplayComponent, LoadingDirective, ImageCarouselComponent],
+    templateUrl: "./field-visit-detail-readonly.component.html",
+    styleUrl: "./field-visit-detail-readonly.component.scss",
+})
+export class FieldVisitDetailReadOnlyComponent implements OnInit {
+    @Input() fieldVisitID!: number;
+
+    public data$: Observable<{
+        workflow: FieldVisitWorkflowDto;
+        initial: TreatmentBMPAssessmentDetailDto | null;
+        initialPhotos: ImageCarouselItem[];
+        postMaintenance: TreatmentBMPAssessmentDetailDto | null;
+        postMaintenancePhotos: ImageCarouselItem[];
+        maintenance: MaintenanceRecordDetailDto | null;
+        maintenanceAttributes: TreatmentBMPTypeCustomAttributeTypeDto[];
+    } | null>;
+
+    public isLoading = true;
+
+    constructor(
+        private fieldVisitService: FieldVisitService,
+        private assessmentService: TreatmentBMPAssessmentService,
+        private assessmentPhotoService: TreatmentBMPAssessmentPhotoService,
+        private maintenanceRecordService: MaintenanceRecordService,
+        private treatmentBMPTypeService: TreatmentBMPTypeService,
+        private authenticationService: AuthenticationService,
+        private confirmService: ConfirmService,
+        private alertService: AlertService,
+        private router: Router,
+        private route: ActivatedRoute,
+    ) {}
+
+    ngOnInit(): void {
+        this.data$ = this.fieldVisitService.getByIDFieldVisit(this.fieldVisitID).pipe(
+            switchMap((workflow) => {
+                const initialAssessment$ = workflow.InitialAssessmentID
+                    ? this.assessmentService.getByIDTreatmentBMPAssessment(workflow.InitialAssessmentID)
+                    : of(null as TreatmentBMPAssessmentDetailDto | null);
+                const postMaintenanceAssessment$ = workflow.PostMaintenanceAssessmentID
+                    ? this.assessmentService.getByIDTreatmentBMPAssessment(workflow.PostMaintenanceAssessmentID)
+                    : of(null as TreatmentBMPAssessmentDetailDto | null);
+                const initialPhotos$ = workflow.InitialAssessmentID
+                    ? this.assessmentPhotoService.listTreatmentBMPAssessmentPhoto(workflow.InitialAssessmentID)
+                    : of([]);
+                const postMaintenancePhotos$ = workflow.PostMaintenanceAssessmentID
+                    ? this.assessmentPhotoService.listTreatmentBMPAssessmentPhoto(workflow.PostMaintenanceAssessmentID)
+                    : of([]);
+                const maintenance$ = this.maintenanceRecordService.getByFieldVisitMaintenanceRecord(this.fieldVisitID);
+                const attributes$ = this.treatmentBMPTypeService.listCustomAttributeTypesTreatmentBMPType(workflow.TreatmentBMPTypeID);
+                return forkJoin({
+                    workflow: of(workflow),
+                    initial: initialAssessment$,
+                    initialPhotos: initialPhotos$,
+                    postMaintenance: postMaintenanceAssessment$,
+                    postMaintenancePhotos: postMaintenancePhotos$,
+                    maintenance: maintenance$,
+                    maintenanceAttributes: attributes$,
+                });
+            }),
+            // Use the loaded payload to flip the loading flag, then map to the same shape.
+            switchMap((payload) => {
+                this.isLoading = false;
+                const toCarouselItems = (rows: { FileResourceGUID?: string | null; Caption?: string | null }[]): ImageCarouselItem[] =>
+                    rows.map((p) => ({ FileResourceGUID: p.FileResourceGUID ?? undefined, Caption: p.Caption ?? null }));
+                const filteredMaintenanceAttributes = (payload.maintenanceAttributes ?? []).filter(
+                    (t) => t.CustomAttributeType?.CustomAttributeTypePurposeID === CustomAttributeTypePurposeEnum.Maintenance,
+                );
+                return of({
+                    workflow: payload.workflow,
+                    initial: payload.initial,
+                    initialPhotos: toCarouselItems(payload.initialPhotos ?? []),
+                    postMaintenance: payload.postMaintenance,
+                    postMaintenancePhotos: toCarouselItems(payload.postMaintenancePhotos ?? []),
+                    maintenance: payload.maintenance,
+                    maintenanceAttributes: filteredMaintenanceAttributes,
+                });
+            }),
+        );
+    }
+
+    public get canManage(): boolean {
+        return this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission();
+    }
+
+    /**
+     * Parses ObservationData JSON and returns the single observed value formatted for
+     * display. Matches the legacy MVC behavior of showing "Pass"/"Fail" for PassFail,
+     * the raw number with "%" suffix for Percentage, and the raw number for DiscreteValue.
+     */
+    public formatObservationValue(observationData: string | null | undefined, collectionMethod: string | null | undefined): string {
+        if (!observationData) return "—";
+        try {
+            const parsed = JSON.parse(observationData);
+            const first = parsed?.SingleValueObservations?.[0];
+            if (first == null) return "—";
+            const value = first.ObservationValue;
+            if (value == null || value === "") return "—";
+            if (collectionMethod === "PassFail") {
+                return value === true || value === "true" ? "Pass" : "Fail";
+            }
+            if (collectionMethod === "Percentage") {
+                return `${value}%`;
+            }
+            return String(value);
+        } catch {
+            return "—";
+        }
+    }
+
+    public formatObservationNotes(observationData: string | null | undefined): string {
+        if (!observationData) return "";
+        try {
+            const parsed = JSON.parse(observationData);
+            const notes = (parsed?.SingleValueObservations ?? [])
+                .map((s: any) => (s?.Notes ?? "").trim())
+                .filter((s: string) => s.length > 0);
+            return notes.join("; ");
+        } catch {
+            return "";
+        }
+    }
+
+    /**
+     * For maintenance attributes the MVC summary shows the attribute name + the recorded
+     * observation value (or "—" if not recorded). The observation list lives on the
+     * MaintenanceRecordDetailDto under `Observations` keyed by CustomAttributeTypeID.
+     */
+    public maintenanceAttributeValue(
+        attribute: TreatmentBMPTypeCustomAttributeTypeDto,
+        maintenance: MaintenanceRecordDetailDto | null,
+    ): string {
+        const customAttributeTypeID = attribute.CustomAttributeType?.CustomAttributeTypeID;
+        if (customAttributeTypeID == null || !maintenance?.Observations?.length) return "—";
+        const obs = maintenance.Observations.find((o) => o.CustomAttributeTypeID === customAttributeTypeID);
+        const values = (obs?.Values ?? [])
+            .map((v) => (v?.ObservationValue ?? "").trim())
+            .filter((s) => s.length > 0);
+        return values.length > 0 ? values.join(", ") : "—";
+    }
+
+    public backToFieldRecords(): void {
+        this.router.navigate(["/field-records"]);
+    }
+
+    public backToBMP(workflow: FieldVisitWorkflowDto): void {
+        this.router.navigate(["/treatment-bmps", workflow.TreatmentBMPID]);
+    }
+
+    /**
+     * Mark Provisional returns the visit to an editable state. Manager-only, gated both on
+     * the frontend (`canManage`) and on the backend (`[JurisdictionManageFeature]` on the
+     * endpoint). After flipping the status, navigate back to the workflow outlet so the
+     * user can edit.
+     */
+    public markProvisional(workflow: FieldVisitWorkflowDto): void {
+        this.confirmService
+            .confirm({
+                title: "Mark Provisional",
+                message: "Return this Field Visit to an editable state? Status will change to Returned to Edit and edit actions become available again.",
+                buttonClassYes: "btn btn-warning",
+                buttonTextYes: "Mark Provisional",
+                buttonTextNo: "Cancel",
+            })
+            .then((confirmed) => {
+                if (!confirmed) return;
+                this.fieldVisitService.markProvisionalFieldVisit(workflow.FieldVisitID!).subscribe(() => {
+                    this.alertService.pushAlert(new Alert("Field Visit returned to provisional / editable state.", AlertContext.Success));
+                    this.router.navigate(["/field-visits", workflow.FieldVisitID]);
+                });
+            });
+    }
+
+    public verify(workflow: FieldVisitWorkflowDto): void {
+        this.confirmService
+            .confirm({
+                title: "Verify Field Visit",
+                message: "Attest that this Field Visit's record is final.",
+                buttonClassYes: "btn btn-primary",
+                buttonTextYes: "Verify",
+                buttonTextNo: "Cancel",
+            })
+            .then((confirmed) => {
+                if (!confirmed) return;
+                this.fieldVisitService.verifyFieldVisit(workflow.FieldVisitID!).subscribe(() => {
+                    this.alertService.pushAlert(new Alert("Field Visit verified.", AlertContext.Success));
+                    // Refresh by re-fetching — stay on the read-only page; the verified pill
+                    // flips and the Manager actions reflect the new state.
+                    this.ngOnInit();
+                });
+            });
+    }
+}

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.html
@@ -14,9 +14,11 @@
                             <button type="button" class="btn-icon" (click)="openChangeDateAndTypeModal(workflow)" title="Change visit date or type">
                                 <i class="fa fa-pencil"></i>
                             </button>
-                            <button type="button" class="btn-icon btn-icon-danger" (click)="deleteVisit(workflow)" title="Delete visit">
-                                <i class="fa fa-trash"></i>
-                            </button>
+                            @if (canManage) {
+                                <button type="button" class="btn-icon btn-icon-danger" (click)="deleteVisit(workflow)" title="Delete visit">
+                                    <i class="fa fa-trash"></i>
+                                </button>
+                            }
                         </p>
                         <p class="visit-status">Status: {{ workflow.FieldVisitStatusDisplayName }}</p>
                     </div>

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.ts
@@ -113,7 +113,11 @@ export class FieldVisitWorkflowOutletComponent implements OnInit, OnDestroy {
                 if (!confirmed) return;
                 this.fieldVisitService.finalizeFieldVisit(workflow.FieldVisitID).subscribe(() => {
                     this.alertService.pushAlert(new Alert("Field Visit marked Complete.", AlertContext.Success));
-                    this.router.navigate(["/treatment-bmps", workflow.TreatmentBMPID]);
+                    // NPT-984: navigate to the new read-only detail page rather than the BMP
+                    // detail. Wrap Up flips the visit to Complete; the read-only page surfaces
+                    // the locked-down summary (scores, observations, photos) and the
+                    // Manager-only Mark Provisional flow that returns it to edit.
+                    this.router.navigate(["/field-visits", workflow.FieldVisitID, "view"]);
                 });
             });
     }

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/field-visit-workflow-outlet.component.ts
@@ -16,6 +16,7 @@ import { FieldVisitWorkflowDto } from "src/app/shared/generated/model/field-visi
 import { FieldVisitService } from "src/app/shared/generated/api/field-visit.service";
 import { FieldVisitWorkflowService } from "../services/field-visit-workflow.service";
 import { AlertService } from "src/app/shared/services/alert.service";
+import { AuthenticationService } from "src/app/services/authentication.service";
 import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
 import { Alert } from "src/app/shared/models/alert";
 import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
@@ -39,9 +40,17 @@ export class FieldVisitWorkflowOutletComponent implements OnInit, OnDestroy {
         private fieldVisitService: FieldVisitService,
         private dialogService: DialogService,
         private alertService: AlertService,
+        private authenticationService: AuthenticationService,
         private confirmService: ConfirmService,
         private router: Router
     ) {}
+
+    // NPT-984: Delete Field Visit is Manager-only (tightened backend to JurisdictionManageFeature).
+    // The frontend gate has to match — Editors performing visits should not see the destructive
+    // header-level delete icon.
+    public get canManage(): boolean {
+        return this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission();
+    }
 
     ngOnInit(): void {
         this.workflow$ = this.workflowService.workflow$;

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.html
@@ -1,7 +1,7 @@
 @if (workflow$ | async; as workflow) {
     <page-header [pageTitle]="isReadOnly() ? 'View Maintenance Record' : 'Edit Maintenance Record'" [templateRight]="headerActions"></page-header>
     <ng-template #headerActions>
-        @if (maintenanceRecord() && !isReadOnly()) {
+        @if (maintenanceRecord() && !isReadOnly() && canManage) {
             <button type="button" class="btn btn-danger btn-sm" (click)="deleteRecord(workflow)">
                 <i class="fa fa-trash mr-1"></i> Delete Record
             </button>

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.ts
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.ts
@@ -21,6 +21,7 @@ import { MaintenanceRecordTypes, MaintenanceRecordTypesAsSelectDropdownOptions }
 
 import { FieldVisitWorkflowService } from "../../services/field-visit-workflow.service";
 import { AlertService } from "src/app/shared/services/alert.service";
+import { AuthenticationService } from "src/app/services/authentication.service";
 import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
 import { Alert } from "src/app/shared/models/alert";
 import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
@@ -76,9 +77,16 @@ export class FieldVisitMaintenanceEditStepComponent implements OnInit {
         private maintenanceRecordService: MaintenanceRecordService,
         private treatmentBMPTypeService: TreatmentBMPTypeService,
         private alertService: AlertService,
+        private authenticationService: AuthenticationService,
         private confirmService: ConfirmService,
         private router: Router
     ) {}
+
+    // NPT-984: Delete Maintenance Record is Manager-only (backend tightened to
+    // JurisdictionManageFeature). Editor performs the maintenance; only Manager can delete it.
+    public get canManage(): boolean {
+        return this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission();
+    }
 
     ngOnInit(): void {
         this.workflow$ = this.workflowService.workflow$;

--- a/Neptune.Web/src/app/pages/latest-bmp-assessments/latest-bmp-assessments.component.ts
+++ b/Neptune.Web/src/app/pages/latest-bmp-assessments/latest-bmp-assessments.component.ts
@@ -43,6 +43,9 @@ export class LatestBmpAssessmentsComponent implements OnInit {
             this.utility.createBasicColumnDef("Assessment Type", "TreatmentBMPAssessmentTypeDisplayName", { UseCustomDropdownFilter: true }),
             this.utility.createBasicColumnDef("Status", "Status", { UseCustomDropdownFilter: true }),
             this.utility.createDecimalColumnDef("Score", "AssessmentScore"),
+            // NPT-984: comma-separated failure notes from the assessment's PassFail observations.
+            // Mirrors the legacy MVC "Failure Notes" column on the same page.
+            this.utility.createBasicColumnDef("Failure Notes", "FailureNotes"),
         ];
         this.assessments$ = this.assessmentService.listTreatmentBMPAssessment();
     }

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/begin-field-visit-modal/begin-field-visit-modal.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/begin-field-visit-modal/begin-field-visit-modal.component.ts
@@ -1,6 +1,8 @@
 import { Component, inject, OnInit } from "@angular/core";
+import { HttpErrorResponse } from "@angular/common/http";
 import { FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
 import { DialogRef } from "@ngneat/dialog";
+import { escapeHtml } from "src/app/shared/helpers/html-escape";
 
 import { FormFieldComponent, FormFieldType } from "src/app/shared/components/forms/form-field/form-field.component";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
@@ -102,10 +104,19 @@ export class BeginFieldVisitModalComponent implements OnInit {
                 this.alertService.pushAlert(new Alert("Field Visit started.", AlertContext.Success));
                 this.ref.close(result);
             },
-            error: (err) => {
+            error: (err: HttpErrorResponse) => {
                 this.isSaving = false;
-                const message = typeof err?.error === "string" ? err.error : "Failed to start the Field Visit. Please try again.";
-                this.alertService.pushAlert(new Alert(message, AlertContext.Danger));
+                // NPT-984: server failures (DB constraint hits, 4xx from the API) were being
+                // swallowed as a generic "Failed to start" message — Kathleen's 5/14 retest
+                // couldn't see why the "Start new field visit" path was failing. Prefer the
+                // structured ProblemDetails / message fields, then string error bodies, then
+                // the generic fallback. Alerts render via [innerHTML] so escape any server text.
+                const raw = (err?.error?.detail as string | undefined)
+                    ?? (err?.error?.title as string | undefined)
+                    ?? (err?.error?.message as string | undefined)
+                    ?? (typeof err?.error === "string" ? (err.error as string) : null)
+                    ?? "Failed to start the Field Visit. Please try again.";
+                this.alertService.pushAlert(new Alert(escapeHtml(raw), AlertContext.Danger));
             },
         });
     }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
@@ -83,7 +83,9 @@
         </div>
 
         <!-- Review Panel -->
-        <div class="review-panel" [class.review-panel--full-width]="currentStep() === 5">
+        <div class="review-panel"
+             [class.review-panel--full-width]="currentStep() === 5"
+             [class.review-panel--wide-table]="currentStep() === 4">
             <div class="review-panel__header">
                 <div class="review-panel__header-text">
                     <h2>{{ steps[currentStep() - 1].title }}</h2>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.scss
@@ -225,10 +225,10 @@
 
 // Review Panel
 .review-panel {
-    // NPT-984: default panel width returned to 620 so Steps 1-3 (and Step 5) leave more room
-    // for the PDF viewer. Step 4's Source Control table needs more horizontal room for long
-    // attribute names — it overrides via .review-panel--wide-table below.
-    width: 620px;
+    // NPT-984: default panel width narrowed (was 720 → 540) so Steps 1-3 (and Step 5) leave
+    // the PDF viewer the most room. Step 4's Source Control table needs more horizontal room
+    // for long attribute names — it overrides via .review-panel--wide-table below.
+    width: 540px;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.scss
@@ -225,10 +225,10 @@
 
 // Review Panel
 .review-panel {
-    // NPT-1054: bumped from 420 to 720 so Step 4's 3-column Source Control table has room
-    // for long attribute names (e.g. "Design Outdoor Hazardous Material Storage Areas...")
-    // without wrapping. Other steps absorb the extra space cleanly (fields are flex anyway).
-    width: 720px;
+    // NPT-984: default panel width returned to 620 so Steps 1-3 (and Step 5) leave more room
+    // for the PDF viewer. Step 4's Source Control table needs more horizontal room for long
+    // attribute names — it overrides via .review-panel--wide-table below.
+    width: 620px;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
@@ -242,6 +242,13 @@
         width: auto;
         flex: 1;
         max-width: none;
+    }
+
+    // NPT-984: Source Control BMPs (Step 4) renders a 3-column table with long attribute
+    // names (e.g., "Design Outdoor Hazardous Material Storage Areas to Reduce Pollutant
+    // Introduction"). Boost the panel back to 720 there so the table doesn't wrap badly.
+    &--wide-table {
+        width: 720px;
     }
 
     &__header {

--- a/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
@@ -1,11 +1,18 @@
 <ng-template #addButton>
-    @if (currentPersonCanEdit$ | async) {
-        <!-- NPT-1051: Create from PDF promoted to a primary action — AI extraction is the
-             expected entry point for new WQMPs going forward. The new WQMP lands in Draft
-             status; the reviewer wizard auto-opens for transcription review. -->
+    <!--
+        NPT-1051: Create from PDF promoted to a primary action — AI extraction is the
+        expected entry point for new WQMPs going forward. The new WQMP lands in Draft
+        status; the reviewer wizard auto-opens for transcription review.
+        NPT-984: Manager-only gate — backend upload endpoint is [JurisdictionManageFeature].
+        Editors keep access to the Actions dropdown (Add WQMP + bulk uploads) but cannot
+        kick off the AI workflow.
+    -->
+    @if (currentPersonCanManage$ | async) {
         <button type="button" class="btn btn-primary" style="margin-right: 0.5rem" (click)="openCreateFromPdfModal()">
             <i class="fa fa-magic"></i> Create from PDF
         </button>
+    }
+    @if (currentPersonCanEdit$ | async) {
         <a href="javascript:void(0);" [dropdownToggle]="actionsMenu" class="btn btn-primary-outline dropdown-toggle ml-2" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Actions <i class="fas fa-chevron-down"></i>
         </a>

--- a/Neptune.Web/src/app/pages/wqmps/wqmps.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmps.component.ts
@@ -47,6 +47,10 @@ export class WqmpsComponent {
     public wqmpJurisdictionIDs: number[];
     public siteUrl = environment.ocStormwaterToolsBaseUrl;
     public currentPersonCanEdit$: Observable<boolean>;
+    // NPT-984: Create-from-PDF (the AI workflow entry point) is Manager-level — the backend
+    // upload endpoint is gated on [JurisdictionManageFeature]. Editor-level users see the
+    // rest of the Actions menu (Add WQMP, Bulk Uploads via legacy MVC) but not Create from PDF.
+    public currentPersonCanManage$: Observable<boolean>;
     private wqmps: WaterQualityManagementPlanGridDto[] = [];
     private static NO_BOUNDARY_ALERT = "WqmpNoBoundary";
 
@@ -88,6 +92,9 @@ export class WqmpsComponent {
 
         this.currentPersonCanEdit$ = currentUser$.pipe(
             map(() => this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission())
+        );
+        this.currentPersonCanManage$ = currentUser$.pipe(
+            map(() => this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission())
         );
 
         this.wqmps$ = this.loadWqmps$();

--- a/Neptune.Web/src/app/services/utility-functions.service.ts
+++ b/Neptune.Web/src/app/services/utility-functions.service.ts
@@ -325,6 +325,11 @@ export class UtilityFunctionsService {
             headerName: headerName,
             valueGetter: (params) => this.defaultValueGetter(params, fieldName),
             valueFormatter: (params) => this.booleanValueGetter(params.value),
+            // NPT-984: ag-grid's filter pipeline reads the raw cell value (the boolean) rather
+            // than the formatted display value, so the custom-dropdown filter rendered chips
+            // labeled "true" / "false". Surface the "Yes" / "No" string to the filter via
+            // filterValueGetter so the filter chips match what the grid cell shows.
+            filterValueGetter: (params: any) => this.booleanValueGetter(this.defaultValueGetter(params, fieldName)),
             filter: true,
         };
         this.applyDefaultQanatColumnDefParams(colDef, linkColumnDefParams);

--- a/Neptune.Web/src/app/shared/components/image-editor/image-editor.component.html
+++ b/Neptune.Web/src/app/shared/components/image-editor/image-editor.component.html
@@ -44,14 +44,21 @@
             }
         </div>
         @if (useCaptionModal) {
-            <div class="g-col-8 caption-readonly">
+            <div class="g-col-6 caption-readonly">
                 <label class="field-label">Caption</label>
                 <div class="caption-row">
                     <span class="caption-text">{{ image.Caption || "(no caption)" }}</span>
-                    <button type="button" class="btn-icon" [disabled]="isLoadingSubmit" (click)="requestEditCaption(image)" title="Edit caption" aria-label="Edit caption">
-                        <i class="fa fa-pencil"></i>
-                    </button>
                 </div>
+            </div>
+            <!--
+                NPT-984: the caption-edit affordance was a bare pencil glyph next to a full
+                "Delete Photo" button — visually mismatched and confusing. Render the edit
+                action as a real button labeled "Edit" so the pair reads consistently.
+            -->
+            <div class="g-col-2">
+                <button type="button" class="btn btn-secondary mt-4" [disabled]="isLoadingSubmit" (click)="requestEditCaption(image)">
+                    <i class="fa fa-pencil mr-1"></i> Edit
+                </button>
             </div>
         } @else {
             <div class="g-col-8">

--- a/Neptune.Web/src/app/shared/components/inputs/btn-group-radio-input/btn-group-radio-input.component.ts
+++ b/Neptune.Web/src/app/shared/components/inputs/btn-group-radio-input/btn-group-radio-input.component.ts
@@ -58,8 +58,13 @@ export class BtnGroupRadioInputComponent implements OnInit {
     }
 
     ngOnInit(): void {
+        // NPT-984: `default` matches against `label`. If a caller passes a value that no
+        // option's label matches, the find() returns undefined — previously we then read
+        // `.value` on undefined and threw, aborting the host page's template render with no
+        // useful error. Bail safely instead — the radio group renders with no selection.
         if (this.default) {
-            this.val = this.options.find((x) => x.label == this.default).value;
+            const match = this.options?.find((x) => x.label == this.default);
+            if (match) this.val = match.value;
         }
     }
 }

--- a/Neptune.Web/src/app/shared/generated/model/treatment-bmp-assessment-grid-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/treatment-bmp-assessment-grid-dto.ts
@@ -30,6 +30,7 @@ export class TreatmentBMPAssessmentGridDto {
     AssessmentScore?: number | null;
     IsFieldVisitVerified?: boolean;
     readonly Status?: string | null;
+    FailureNotes?: string | null;
     constructor(obj?: any) {
         Object.assign(this, obj);
     }
@@ -55,6 +56,7 @@ export interface TreatmentBMPAssessmentGridDtoForm {
     AssessmentScore?: FormControl<number>;
     IsFieldVisitVerified?: FormControl<boolean>;
     Status?: FormControl<string>;
+    FailureNotes?: FormControl<string>;
 }
 
 export class TreatmentBMPAssessmentGridDtoFormControls { 
@@ -239,6 +241,16 @@ export class TreatmentBMPAssessmentGridDtoFormControls {
         }
     );
     public static Status = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static FailureNotes = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
         value,
         formControlOptions ?? 
         {

--- a/Neptune.Web/src/app/shared/generated/model/treatment-bmp-observation-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/treatment-bmp-observation-dto.ts
@@ -14,6 +14,7 @@ export class TreatmentBMPObservationDto {
     TreatmentBMPObservationID?: number;
     TreatmentBMPAssessmentObservationTypeID?: number;
     ObservationData?: string | null;
+    ObservationScore?: string | null;
     constructor(obj?: any) {
         Object.assign(this, obj);
     }
@@ -23,6 +24,7 @@ export interface TreatmentBMPObservationDtoForm {
     TreatmentBMPObservationID?: FormControl<number>;
     TreatmentBMPAssessmentObservationTypeID?: FormControl<number>;
     ObservationData?: FormControl<string>;
+    ObservationScore?: FormControl<string>;
 }
 
 export class TreatmentBMPObservationDtoFormControls { 
@@ -47,6 +49,16 @@ export class TreatmentBMPObservationDtoFormControls {
         }
     );
     public static ObservationData = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static ObservationScore = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
         value,
         formControlOptions ?? 
         {


### PR DESCRIPTION
## Summary

Round 4 rework of the BMP Field Visits SPA migration based on Kathleen's 5/14/26 retest — 16 red status lozenges on the AC. All addressed in this branch. One extra item folded in: the AI-Create-from-PDF entry point is now gated to Jurisdiction Managers (was Admin-only).

## What changed

### Backend
- **New `JurisdictionManageFeature` authorization attribute** (`JurisdictionManager + Admin + SitkaAdmin`). Mirrors the frontend's `doesCurrentUserHaveJurisdictionManagePermission()`. Pre-existing attributes either included Editor (too broad) or excluded Manager entirely.
- **Field-visit destructive actions tightened**: `Delete` / `Verify` / `Mark Provisional` / `Return to Edit` on `FieldVisitController` + `Delete` on `MaintenanceRecordController` now `[JurisdictionManageFeature]`. `Finalize` (Save & Wrap Up) stays `[JurisdictionEditFeature]` — Editor performs the visit and wraps it up themselves.
- **`UploadDocument` (Create WQMP via AI) tightened from `[AdminFeature]` to `[JurisdictionManageFeature]`** — opens up to Managers (was Admin-only), still excludes Editors.
- **`FieldVisits.CreateAsync` "Start New" fix**: split the existing visit's Unresolved update + new visit's InProgress insert into two `SaveChangesAsync` calls so the filtered unique index `CK_AtMostOneFieldVisitMayBeInProgressAtAnyTimePerBMP` doesn't trip when EF Core orders the INSERT before the UPDATE.
- **Latest BMP Assessments**: projection switched to filter on `vMostRecentTreatmentBMPAssessment.LastAssessmentID` (one row per BMP, most recent wrapped-up visit). New `FailureNotes` column built in C# by deserializing each PassFail observation's `ObservationData` and concatenating notes per type. Mirrors MVC.
- **BMP detail carousel** (`TreatmentBMPImages.ListForCarouselAsync`): filter switched from `IsFieldVisitVerified` to `FieldVisitStatusID = Complete` so wrap-up alone surfaces visit photos (verification is a separate Manager attestation).
- **`TreatmentBMPObservationDto.ObservationScore`**: new field populated post-materialize so the read-only assessment table can show a per-observation score (mirrors MVC `AssessmentDetail.cshtml`).

### Frontend
- **Read-only Field Visit detail page** at `/field-visits/:id/view`. New `FieldVisitDetailReadOnlyComponent` follows the BMP / WQMP detail-page pattern: `page-header` with back-link in `templateAbove` + Manager-only actions in `templateRight` (Verify / Mark Provisional). Two-column `grid-12` of `card` panels: left = Visit Info + Maintenance Record; right = Initial Assessment + Post-Maintenance Assessment. MVC-style observation tables with Type / Value / Score / Notes columns. Photos via the shared `image-carousel` inside each assessment card.
- **Routing**: Field Records grid branches `Continue` (in-progress) → editable workflow vs `View` (wrapped-up) → new read-only route. Workflow outlet's wrap-up handler navigates to the new read-only route after `finalizeFieldVisit` succeeds.
- **Field-records blank-page crash fix**: the `[default]` input on `BtnGroupRadioInputComponent` is matched against `label`, not value. The component was passing the kebab-case `activeTab` value, the find returned undefined, then `.value` threw and aborted the whole page render. Fixed by passing the label via a `activeTabLabel` getter, and defensively guarded the shared component so a bad `[default]` no longer crashes the host page.
- **Field-records observables wired via `inject()` + field initializers** so lazy-loaded zoneless routes have a live observable on the first CD pass (was hitting the same symptom Kathleen described). Same fix applied to the new read-only page.
- **Yes/No filter chips**: `createBooleanColumnDef` now exposes a `filterValueGetter` that surfaces "Yes" / "No" to ag-grid's filter pipeline, matching cell display.
- **Photo caption Edit button**: image-editor in caption-modal mode now renders a real `btn btn-secondary` labeled "Edit", visually consistent with the adjacent "Delete Photo" button.
- **Permission gates**: workflow-outlet header delete + maintenance-edit Delete Record now gated on `canManage`.
- **Begin Field Visit modal error handler**: prefers `ProblemDetails.detail / title / message` over generic fallback, HTML-escapes server text.
- **Manager-gate on Create from PDF** button on the WQMPs index. Other Actions-menu items (Add WQMP, Bulk Uploads) stay at the Editor gate.
- **Read-only page polish**: per-observation Score column, maintenance attribute units appended (suppressed for "None" unit), tight top-alignment fix when Initial Assessment is missing.
- **WQMP review panel narrowed** to 540px default with Step 4 (Source Control table) preserved at 720px via a `--wide-table` modifier.

## Test plan
- [ ] Sign in as JE, hit "View All Field Records" from the nav — page loads on first click; grid populates without clicking anywhere. Filter on "Field Visit Verified" — chips read Yes/No, not True/False.
- [ ] Click "View" on a wrapped-up visit → lands on the new read-only detail page. Visit Information card on the left, Initial Assessment + Post-Maintenance Assessment cards on the right with Score column populated. Photos appear in each assessment card.
- [ ] Click "Continue" on an in-progress visit → lands on the editable workflow outlet.
- [ ] As JE: Delete / Verify / Mark Provisional buttons not visible. As JM: visible and functional. Backend rejects JE attempts (poke the URL with browser dev tools).
- [ ] Begin Field Visit modal: pick a BMP with an in-progress visit, choose "Start New" → old visit becomes Unresolved, new visit created and entered.
- [ ] Complete a Field Visit (inventory + assessment + maintenance + post-maintenance) → Save & Wrap Up → lands on the read-only detail; field-records grid reflects "Complete" status. Assessment photos appear in the BMP detail carousel.
- [ ] Latest BMP Assessments: one row per BMP (most recent), Failure Notes column populated for failing observations.
- [ ] WQMPs index: Create from PDF button visible to JM, hidden from JE. Add WQMP / Bulk Uploads still visible to both.
- [ ] WQMP review wizard: panel is narrower on Steps 1-3 / 5; Step 4 (Source Control) panel stays wider.