### PR TITLE
NPT-984: Allow JMs to use the AI review wizard (extract + extraction-…

### DIFF
--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -603,8 +603,12 @@ namespace Neptune.API.Controllers
             });
         }
 
+        // NPT-984: Run AI extraction — Manager-level. The Manager created the WQMP via the
+        // upload flow (also [JurisdictionManageFeature]); they need to run extractions on
+        // their own WQMPs. Was [AdminFeature] which left JMs unable to use the wizard they
+        // just opened.
         [HttpPost("{waterQualityManagementPlanID}/extract")]
-        [AdminFeature]
+        [JurisdictionManageFeature]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         public async Task<ActionResult<WaterQualityManagementPlanExtractionResultDto>> RunExtraction(
             [FromRoute] int waterQualityManagementPlanID)
@@ -714,8 +718,10 @@ namespace Neptune.API.Controllers
             return rawMessage;
         }
 
+        // NPT-984: Manager-level — the review wizard loads this on mount to show the AI's
+        // suggestions; JMs need access to review their own WQMPs.
         [HttpGet("{waterQualityManagementPlanID}/extraction-result")]
-        [AdminFeature]
+        [JurisdictionManageFeature]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         public async Task<ActionResult<WaterQualityManagementPlanExtractionResultDto>> GetExtractionResult(
             [FromRoute] int waterQualityManagementPlanID)

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -369,7 +369,9 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     }
 
     runExtraction(): void {
-        // Caller (template) gates this on isAdmin + confirm-dialog when a result already exists.
+        // NPT-984: backend endpoint is [JurisdictionManageFeature], same as the upload flow
+        // that landed the user here. No frontend role gate — the wizard route itself is
+        // only reachable via paths that already require manage permission.
         this.isExtracting.set(true);
         this.alertService.clearAlerts();
         this.wqmpService.runExtractionWaterQualityManagementPlan(this.waterQualityManagementPlanID)


### PR DESCRIPTION
…result)

Two endpoints in the WQMP AI review flow were still [AdminFeature] (Admin + SitkaAdmin only), blocking the JurisdictionManagers we just opened the upload flow to:

- POST {wqmpID}/extract — runs AI extraction
- GET {wqmpID}/extraction-result — wizard fetches this on mount

JMs created the WQMP via the now-Manager-gated upload flow and got routed to the review wizard, only to hit 403s on every load. Switched both to [JurisdictionManageFeature] to match the upload entry point.

The wizard's other save endpoints (saveLocation, saveBasics, saveBmps, mergeSourceControlBMPs) are already [JurisdictionEditFeature] which includes JM, and the document/quick-bmps/source-control-bmps reads are [AllowAnonymous], so no other changes needed.

AIController.ExtractAll + Ask remain [AdminFeature] — those serve the /ai playground (Admin-only debug surface), not the per-WQMP workflow.

Also dropped a stale "Caller (template) gates this on isAdmin" comment in wqmp-review.component — template never had that gate; the route guard's the only frontend boundary.