### PR TITLE
NPT-1054: Round 3 — AI pill semantics, dates, TCE, SC retry

### DIFF
--- a/Neptune.API/Services/AI/WqmpExtractionService.cs
+++ b/Neptune.API/Services/AI/WqmpExtractionService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -236,7 +237,12 @@ public class WqmpExtractionService
         // examples). Detect that shape and parse it back to an array before consolidating;
         // otherwise the downstream JSON_QUERY consumer sees a string literal where an array
         // should be.
-        string UnwrapItems(string json)
+        //
+        // Returns (Output, FailedFallback). FailedFallback is true ONLY when unwrap fell back to
+        // "[]" because the inner JSON couldn't be parsed; legitimate empty `items` arrays and
+        // successful parses report false so callers can distinguish flaky-model failures from a
+        // genuine empty result and retry accordingly.
+        (string Output, bool FailedFallback) UnwrapItems(string json)
         {
             try
             {
@@ -249,13 +255,13 @@ public class WqmpExtractionService
                         if (string.IsNullOrEmpty(innerJson))
                         {
                             _logger.LogWarning("Tool output `items` was an empty string — emitting empty array.");
-                            return "[]";
+                            return ("[]", false);
                         }
                         try
                         {
                             using var innerDoc = JsonDocument.Parse(innerJson);
                             _logger.LogWarning("Tool output had `items` as a JSON-encoded string ({Len} chars) — unwrapped successfully.", innerJson.Length);
-                            return innerJson;
+                            return (innerJson, false);
                         }
                         catch (JsonException ex)
                         {
@@ -268,27 +274,101 @@ public class WqmpExtractionService
                             {
                                 using var cleanedDoc = JsonDocument.Parse(cleaned);
                                 _logger.LogWarning("Tool output `items` was a JSON-encoded string with trailing-comma issues — repaired and unwrapped ({Len} chars).", cleaned.Length);
-                                return cleaned;
+                                return (cleaned, false);
                             }
                             catch (JsonException ex2)
                             {
-                                _logger.LogError(ex2, "Tool output `items` was a JSON-encoded string but failed to parse even after cleanup. First error: {FirstErr}. Cleanup error: {CleanupErr}. Inner head: {Head}",
-                                    ex.Message, ex2.Message, innerJson.Length > 500 ? innerJson.Substring(0, 500) : innerJson);
-                                return "[]";
+                                // NPT-1054 diagnostics: the head-only truncation was masking the actual
+                                // corruption point in long outputs. Capture head/tail/window-around-error
+                                // and persist the full failing content to /tmp so we can repair offline.
+                                static string Slice(string s, int start, int len)
+                                    => start < 0 || start >= s.Length ? "" : s.Substring(start, Math.Min(len, s.Length - start));
+
+                                // ex.BytePositionInLine is per-line; compute an approximate absolute offset
+                                // by walking lines to ex.LineNumber, then add the in-line position.
+                                int approxOffset = -1;
+                                if (ex.LineNumber.HasValue)
+                                {
+                                    long line = 0, offset = 0;
+                                    foreach (var ch in innerJson)
+                                    {
+                                        if (line == ex.LineNumber.Value) break;
+                                        if (ch == '\n') line++;
+                                        offset++;
+                                    }
+                                    approxOffset = (int)Math.Min(offset + (ex.BytePositionInLine ?? 0), innerJson.Length - 1);
+                                }
+                                var windowStart = Math.Max(0, approxOffset - 200);
+                                var windowAround = approxOffset >= 0 ? Slice(innerJson, windowStart, 400) : "(no position)";
+
+                                string dumpPath = null;
+                                try
+                                {
+                                    dumpPath = Path.Combine(Path.GetTempPath(), $"wqmp-sc-extraction-failure-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}.json");
+                                    File.WriteAllText(dumpPath, innerJson);
+                                }
+                                catch (Exception dumpEx)
+                                {
+                                    _logger.LogWarning(dumpEx, "Failed to write extraction-failure dump file");
+                                }
+
+                                _logger.LogError(ex2,
+                                    "Tool output `items` was a JSON-encoded string but failed to parse even after cleanup. " +
+                                    "First error: {FirstErr}. Cleanup error: {CleanupErr}. Approx offset: {Offset} of {Len}. " +
+                                    "Dump file: {DumpPath}. Head: {Head} | Window around error: {Window} | Tail: {Tail}",
+                                    ex.Message, ex2.Message, approxOffset, innerJson.Length, dumpPath,
+                                    Slice(innerJson, 0, 1000),
+                                    windowAround,
+                                    Slice(innerJson, Math.Max(0, innerJson.Length - 1000), 1000));
+                                return ("[]", true);
                             }
                         }
                     }
-                    return items.GetRawText();
+                    return (items.GetRawText(), false);
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "UnwrapItems failed to parse tool output JSON; using raw output.");
             }
-            return json;
+            return (json, false);
         }
 
-        var finalOutput = $"{{ \"SchemaVersion\": \"{SchemaVersion}\", \"WQMP\": {map["WQMP"]}, \"Parcels\": {UnwrapItems(map["Parcels"])}, \"QuickBMPs\": {UnwrapItems(map["QuickBMPs"])}, \"SourceControlBMPs\": {UnwrapItems(map["SourceControlBMPs"])} }}";
+        // NPT-1054: retry SC once when UnwrapItems falls back to "[]" due to a corrupt inner JSON
+        // (the flaky-model failure mode that captures 25k–30k char tool outputs but emits a
+        // double-encoded `items` string with malformed content the cleanup can't repair). One
+        // retry catches the typical "rolled bad dice" case; legitimate empty arrays don't retry.
+        var parcelsUnwrap = UnwrapItems(map["Parcels"]);
+        var quickBmpsUnwrap = UnwrapItems(map["QuickBMPs"]);
+        var scUnwrap = UnwrapItems(map["SourceControlBMPs"]);
+        if (scUnwrap.FailedFallback)
+        {
+            _logger.LogWarning("SourceControlBMPs unwrap failed — retrying extraction once before giving up.");
+            try
+            {
+                var scConfig = categoryConfigs["SourceControlBMPs"];
+                var scRetry = await ExtractCategoryAsync("SourceControlBMPs", scConfig.template, scConfig.schema, scConfig.expectArray);
+                await LogTokenUsage(personID, scRetry.inputTokens, scRetry.outputTokens, scRetry.cachedTokens,
+                    "WQMP Extraction - SourceControlBMPs (retry)");
+                map["SourceControlBMPs"] = scRetry.output;
+                var scRetryUnwrap = UnwrapItems(scRetry.output);
+                if (!scRetryUnwrap.FailedFallback)
+                {
+                    _logger.LogInformation("SourceControlBMPs retry succeeded ({Chars} chars).", scRetryUnwrap.Output.Length);
+                    scUnwrap = scRetryUnwrap;
+                }
+                else
+                {
+                    _logger.LogWarning("SourceControlBMPs retry also produced a malformed payload; staying with empty fallback.");
+                }
+            }
+            catch (Exception retryEx)
+            {
+                _logger.LogError(retryEx, "SourceControlBMPs retry threw before completing; staying with empty fallback.");
+            }
+        }
+
+        var finalOutput = $"{{ \"SchemaVersion\": \"{SchemaVersion}\", \"WQMP\": {map["WQMP"]}, \"Parcels\": {parcelsUnwrap.Output}, \"QuickBMPs\": {quickBmpsUnwrap.Output}, \"SourceControlBMPs\": {scUnwrap.Output} }}";
 
         if (!IsValidJson(finalOutput))
         {

--- a/Neptune.API/Services/AI/WqmpExtractionService.cs
+++ b/Neptune.API/Services/AI/WqmpExtractionService.cs
@@ -11,6 +11,7 @@ using Anthropic.Exceptions;
 using Anthropic.Models.Beta.Messages;
 using BetaRole = Anthropic.Models.Beta.Messages.Role;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Neptune.EFModels.Entities;
@@ -33,6 +34,7 @@ public class WqmpExtractionService
     private readonly IPromptTemplateService _promptTemplateService;
     private readonly ILogger<WqmpExtractionService> _logger;
     private readonly NeptuneConfiguration _configuration;
+    private readonly IHostEnvironment _environment;
 
     public WqmpExtractionService(
         AnthropicClient anthropic,
@@ -40,7 +42,8 @@ public class WqmpExtractionService
         NeptuneDbContext dbContext,
         IPromptTemplateService promptTemplateService,
         ILogger<WqmpExtractionService> logger,
-        IOptions<NeptuneConfiguration> configuration)
+        IOptions<NeptuneConfiguration> configuration,
+        IHostEnvironment environment)
     {
         _anthropic = anthropic;
         _anthropicFileService = anthropicFileService;
@@ -48,6 +51,7 @@ public class WqmpExtractionService
         _promptTemplateService = promptTemplateService;
         _logger = logger;
         _configuration = configuration.Value;
+        _environment = environment;
     }
 
     public async Task<WaterQualityManagementPlanDocumentExtractionResultDto> ExtractFromDocument(
@@ -301,25 +305,33 @@ public class WqmpExtractionService
                                 var windowStart = Math.Max(0, approxOffset - 200);
                                 var windowAround = approxOffset >= 0 ? Slice(innerJson, windowStart, 400) : "(no position)";
 
+                                // The /tmp dump is a dev-only diagnostic. WQMP content can include
+                                // facility addresses and contacts; QA/prod pods would also accumulate
+                                // dumps on a long-lived volume with no retention. Gating to
+                                // Development keeps the artifact useful for local repro without
+                                // leaking content or filling shared disk in deployed envs.
                                 string dumpPath = null;
-                                try
+                                if (_environment.IsDevelopment())
                                 {
-                                    dumpPath = Path.Combine(Path.GetTempPath(), $"wqmp-sc-extraction-failure-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}.json");
-                                    File.WriteAllText(dumpPath, innerJson);
-                                }
-                                catch (Exception dumpEx)
-                                {
-                                    _logger.LogWarning(dumpEx, "Failed to write extraction-failure dump file");
+                                    try
+                                    {
+                                        dumpPath = Path.Combine(Path.GetTempPath(), $"wqmp-sc-extraction-failure-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}.json");
+                                        File.WriteAllText(dumpPath, innerJson);
+                                    }
+                                    catch (Exception dumpEx)
+                                    {
+                                        _logger.LogWarning(dumpEx, "Failed to write extraction-failure dump file");
+                                    }
                                 }
 
                                 _logger.LogError(ex2,
                                     "Tool output `items` was a JSON-encoded string but failed to parse even after cleanup. " +
                                     "First error: {FirstErr}. Cleanup error: {CleanupErr}. Approx offset: {Offset} of {Len}. " +
                                     "Dump file: {DumpPath}. Head: {Head} | Window around error: {Window} | Tail: {Tail}",
-                                    ex.Message, ex2.Message, approxOffset, innerJson.Length, dumpPath,
-                                    Slice(innerJson, 0, 1000),
+                                    ex.Message, ex2.Message, approxOffset, innerJson.Length, dumpPath ?? "(disabled)",
+                                    Slice(innerJson, 0, 400),
                                     windowAround,
-                                    Slice(innerJson, Math.Max(0, innerJson.Length - 1000), 1000));
+                                    Slice(innerJson, Math.Max(0, innerJson.Length - 400), 400));
                                 return ("[]", true);
                             }
                         }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component.html
@@ -56,7 +56,15 @@
                 </div>
             </div>
         } @else {
-            <span [class.field-card__value--empty]="!currentValue" [class.field-card__value--clickable]="!!documentSource" (click)="goToSource()">{{ fieldType === FormFieldType.Select && currentValue ? getOptionLabel(currentValue) : (currentValue ?? "Not extracted") }}</span>
+            <span [class.field-card__value--empty]="!currentValue" [class.field-card__value--clickable]="!!documentSource" (click)="goToSource()">
+                @if (fieldType === FormFieldType.Date && currentValue) {
+                    {{ currentValue | date: "MM/dd/yyyy" : "+0000" }}
+                } @else if (fieldType === FormFieldType.Select && currentValue) {
+                    {{ getOptionLabel(currentValue) }}
+                } @else {
+                    {{ currentValue ?? "Not extracted" }}
+                }
+            </span>
         }
     </div>
 

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, OnChanges, Output, signal, SimpleChanges } from "@angular/core";
+import { DatePipe } from "@angular/common";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { FormFieldComponent, FormFieldType, FormInputOption } from "src/app/shared/components/forms/form-field/form-field.component";
 
@@ -23,7 +24,7 @@ export interface SourceNavigation {
 @Component({
     selector: "field-card",
     standalone: true,
-    imports: [FormFieldComponent, ReactiveFormsModule],
+    imports: [FormFieldComponent, ReactiveFormsModule, DatePipe],
     templateUrl: "./field-card.component.html",
     styleUrl: "./field-card.component.scss",
 })

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from "@angular/core";
-import { NgTemplateOutlet } from "@angular/common";
+import { Component, inject, Input } from "@angular/core";
+import { DatePipe, NgTemplateOutlet } from "@angular/common";
 import { ExtractedField } from "src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component";
 import { FormFieldType, SelectDropdownOption } from "src/app/shared/components/forms/form-field/form-field.component";
 
@@ -37,18 +37,21 @@ export interface ReviewSummaryRow {
     selector: "review-summary",
     standalone: true,
     imports: [NgTemplateOutlet],
+    providers: [DatePipe],
     templateUrl: "./review-summary.component.html",
     styleUrl: "./review-summary.component.scss",
 })
 export class ReviewSummaryComponent {
+    private datePipe = inject(DatePipe);
+
     @Input() locationFields: ExtractedField[] = [];
     @Input() basicsFields: ExtractedField[] = [];
     @Input() parcelFields: ExtractedField[] = [];
     @Input() bmpGroups: { bmpIndex: number; displayName: string | null; fields: ExtractedField[]; isRejected: boolean }[] = [];
-    // NPT-1054: flat list of Source Control BMP rows with values (rows where IsPresent is
-    // null AND Note is empty are pre-filtered out by the parent). hasEvidence is true when
-    // any of the row's fields came from the AI extractor.
-    @Input() sourceControlRows: { categoryName: string; attributeName: string; isPresent: boolean | null; note: string; hasEvidence: boolean; wqmpRecordValue: string | null }[] = [];
+    // NPT-1054: flat list of Source Control BMP rows. origin mirrors Step 4's row classifier
+    // (getSourceControlRowOrigin) so the AI pill only shows when the displayed value actually
+    // came from the AI — not when the user accepted a value that was already on the record.
+    @Input() sourceControlRows: { categoryName: string; attributeName: string; isPresent: boolean | null; note: string; origin: "ai" | "record" | "edited" | "blank"; wqmpRecordValue: string | null }[] = [];
     @Input() lookupOptionsByKey: Record<string, SelectDropdownOption[]> = {};
     // NPT-1051: parent supplies a key→liveWqmpValue resolver so the summary can render the
     // third "WQMP Record" column without duplicating the key→DTO field mapping in the child.
@@ -85,12 +88,21 @@ export class ReviewSummaryComponent {
                 const display = isUnset
                     ? "(not set)"
                     : r.note ? `${presentDisplay} — ${r.note}` : presentDisplay;
+                // Map Step 4's four-state origin into the summary's three-state origin so the
+                // AI pill (which only fires on origin === "ai") matches Step 4's pill: "record"
+                // and "edited" both fall back to "user" (no AI pill); "ai" stays; "blank"
+                // collapses to "blank" only when the row is genuinely empty.
+                const summaryOrigin: ReviewSummaryRow["origin"] = isUnset
+                    ? "blank"
+                    : r.origin === "ai"
+                        ? "ai"
+                        : "user";
                 byCategory.get(r.categoryName)!.push({
                     label: r.attributeName,
                     displayValue: display,
                     wqmpRecordValue: r.wqmpRecordValue,
                     state: isUnset ? "pending" : "accepted",
-                    origin: isUnset ? "blank" : r.hasEvidence ? "ai" : "user",
+                    origin: summaryOrigin,
                 });
             }
             for (const [category, rows] of byCategory.entries()) {
@@ -140,6 +152,12 @@ export class ReviewSummaryComponent {
         if (f.state === "rejected") return "(rejected)";
         const raw = f.acceptedValue ?? f.value;
         if (raw == null || raw === "") return "(not set)";
+        // Date fields render in MM/dd/yyyy to match the WQMP Record column (which is formatted
+        // through the same pipe in getWqmpFieldValueForRow); without this the Workflow column
+        // showed raw ISO yyyy-mm-dd while the Record column showed MM/dd/yyyy on the same row.
+        if (f.fieldType === FormFieldType.Date) {
+            return this.datePipe.transform(raw, "MM/dd/yyyy", "+0000") ?? String(raw);
+        }
         // Lookup fields hold an ID — show the label for readability.
         if (f.fieldType === FormFieldType.Select) {
             const options = f.selectOptions ?? this.lookupOptionsByKey[f.key] ?? [];

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
@@ -158,6 +158,7 @@
                             [selectOptions]="field.selectOptions ?? []"
                             [mask]="field.mask ?? null"
                             [origin]="getFieldOrigin(field)"
+                            [readOnly]="field.readOnly ?? false"
                             [initialState]="field.state"
                             [initialValue]="field.acceptedValue ?? field.value"
                             [selected]="selectedFieldKey() === field.key"

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -33,7 +33,7 @@ import { WaterQualityManagementPlanDevelopmentTypesAsSelectDropdownOptions } fro
 import { WaterQualityManagementPlanLandUsesAsSelectDropdownOptions } from "src/app/shared/generated/enum/water-quality-management-plan-land-use-enum";
 import { WaterQualityManagementPlanPermitTermsAsSelectDropdownOptions } from "src/app/shared/generated/enum/water-quality-management-plan-permit-term-enum";
 import { HydromodificationAppliesTypesAsSelectDropdownOptions } from "src/app/shared/generated/enum/hydromodification-applies-type-enum";
-import { TrashCaptureStatusTypesAsSelectDropdownOptions } from "src/app/shared/generated/enum/trash-capture-status-type-enum";
+import { TrashCaptureStatusTypeEnum, TrashCaptureStatusTypesAsSelectDropdownOptions } from "src/app/shared/generated/enum/trash-capture-status-type-enum";
 import { US_STATES } from "src/app/shared/constants/us-states";
 import {
     PDF_EXTRACTION_FAILURE_HINT,
@@ -228,10 +228,10 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
         "MaintenanceContactAddress1", "MaintenanceContactAddress2", "MaintenanceContactCity", "MaintenanceContactState", "MaintenanceContactZip",
     ];
 
-    // NPT-1054: TrashCaptureStatusTypeID = 2 is "Partial (>5mm but less than full sizing)".
-    // TrashCaptureEffectiveness is only collected when the status is Partial; for any other
-    // status the field locks read-only and the saved value is forced to null.
-    private static readonly PARTIAL_TRASH_CAPTURE_STATUS_ID = 2;
+    // NPT-1054: TrashCaptureEffectiveness is only collected when status is Partial; for any
+    // other status the field locks read-only and the saved value is forced to null. Aliased
+    // to the generated enum so a future renumber of the lookup table doesn't drift this code.
+    private static readonly PARTIAL_TRASH_CAPTURE_STATUS_ID = TrashCaptureStatusTypeEnum.Partial;
 
     private fieldLabels: Record<string, string> = {
         WaterQualityManagementPlanName: "WQMP Name",
@@ -1408,6 +1408,25 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 : field.value;
             const v = this.normalizeOverlayValue(raw);
 
+            // Trash Capture Effectiveness must run BEFORE the null-skip below: when status
+            // flips away from Partial the field goes pending+null, which would otherwise
+            // hit `v == null && state !== "edited" → continue` and leave the seeded stale
+            // percentage on the dto. Handle the force-null case here and skip explicitly.
+            if (key === "TrashCaptureEffectiveness") {
+                const statusID = this.getCurrentTrashCaptureStatusID(this.fields())
+                    ?? dto.TrashCaptureStatusTypeID
+                    ?? null;
+                if (statusID !== WqmpReviewComponent.PARTIAL_TRASH_CAPTURE_STATUS_ID) {
+                    dto.TrashCaptureEffectiveness = null;
+                } else if (v == null) {
+                    dto.TrashCaptureEffectiveness = null;
+                } else {
+                    const n = parseInt(v, 10);
+                    if (!isNaN(n)) dto.TrashCaptureEffectiveness = n;
+                }
+                continue;
+            }
+
             // Tester feedback (Kathleen): don't overwrite user-entered data with nothing. If the
             // AI didn't extract a value and the reviewer hasn't typed one in (state=pending or
             // accepted with no value), leave the seeded live value alone. The reviewer can
@@ -1445,23 +1464,6 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
 
             if (key === "ApprovalDate" || key === "DateOfConstruction") {
                 dto[key] = v;
-                continue;
-            }
-
-            if (key === "TrashCaptureEffectiveness") {
-                // Force null when status isn't Partial so flipping the status away from
-                // Partial wipes a stale percentage rather than leaving the old number behind.
-                const statusID = this.getCurrentTrashCaptureStatusID(this.fields())
-                    ?? dto.TrashCaptureStatusTypeID
-                    ?? null;
-                if (statusID !== WqmpReviewComponent.PARTIAL_TRASH_CAPTURE_STATUS_ID) {
-                    dto.TrashCaptureEffectiveness = null;
-                } else if (v == null) {
-                    dto.TrashCaptureEffectiveness = null;
-                } else {
-                    const n = parseInt(v, 10);
-                    if (!isNaN(n)) dto.TrashCaptureEffectiveness = n;
-                }
                 continue;
             }
         }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -62,6 +62,9 @@ export interface ExtractedField {
     // True when the value came from the user (upload modal), not the AI. Drives the
     // "User-entered" origin pill and suppresses AI evidence styling.
     isUserEntered?: boolean;
+    // NPT-1054: read-only fields hide the Accept/Edit/Reject buttons in field-card.
+    // Currently used by TrashCaptureEffectiveness when TrashCaptureStatus !== Partial.
+    readOnly?: boolean;
 }
 
 @Component({
@@ -220,10 +223,15 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     private basicsFields = [
         "WaterQualityManagementPlanName", "WaterQualityManagementPlanPriority", "WaterQualityManagementPlanDevelopmentType",
         "WaterQualityManagementPlanLandUse", "WaterQualityManagementPlanPermitTerm", "ApprovalDate", "DateOfConstruction",
-        "HydromodificationAppliesType", "RecordNumber", "TrashCaptureStatusType",
+        "HydromodificationAppliesType", "RecordNumber", "TrashCaptureStatusType", "TrashCaptureEffectiveness",
         "MaintenanceContactName", "MaintenanceContactOrganization", "MaintenanceContactPhone",
         "MaintenanceContactAddress1", "MaintenanceContactAddress2", "MaintenanceContactCity", "MaintenanceContactState", "MaintenanceContactZip",
     ];
+
+    // NPT-1054: TrashCaptureStatusTypeID = 2 is "Partial (>5mm but less than full sizing)".
+    // TrashCaptureEffectiveness is only collected when the status is Partial; for any other
+    // status the field locks read-only and the saved value is forced to null.
+    private static readonly PARTIAL_TRASH_CAPTURE_STATUS_ID = 2;
 
     private fieldLabels: Record<string, string> = {
         WaterQualityManagementPlanName: "WQMP Name",
@@ -239,6 +247,7 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
         HydromodificationAppliesType: "Hydromodification Applies",
         RecordNumber: "Record Number",
         TrashCaptureStatusType: "Trash Capture Status",
+        TrashCaptureEffectiveness: "Trash Capture Effectiveness (%)",
         MaintenanceContactName: "Maintenance Contact Name",
         MaintenanceContactOrganization: "Maintenance Contact Organization",
         MaintenanceContactPhone: "Maintenance Contact Phone",
@@ -614,23 +623,26 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     }
 
     /** Used by ReviewSummary input — flatten the FormArray to read-only rows for the summary. */
-    get summarySourceControlRows(): { categoryName: string; attributeName: string; isPresent: boolean | null; note: string; hasEvidence: boolean; wqmpRecordValue: string | null }[] {
+    get summarySourceControlRows(): { categoryName: string; attributeName: string; isPresent: boolean | null; note: string; origin: "ai" | "record" | "edited" | "blank"; wqmpRecordValue: string | null }[] {
         // Emit every attribute row — the child summary renders unset rows as "(not set)" so
         // all three categories still appear (collapsed) even when AI extracted nothing and
         // the user hasn't touched Step 4. Keeps the Review structure stable.
-        const out: { categoryName: string; attributeName: string; isPresent: boolean | null; note: string; hasEvidence: boolean; wqmpRecordValue: string | null }[] = [];
+        const out: { categoryName: string; attributeName: string; isPresent: boolean | null; note: string; origin: "ai" | "record" | "edited" | "blank"; wqmpRecordValue: string | null }[] = [];
         for (const row of this.sourceControlRows.controls) {
             const isPresent = row.get("IsPresent")!.value as boolean | null;
             const note = ((row.get("SourceControlBMPNote")!.value as string) ?? "").trim();
             const attrID = row.get("SourceControlBMPAttributeID")!.value as number;
             const saved = this.existingSourceControlByAttributeID.get(attrID);
             const savedDisplay = this.formatSavedSourceControlValue(saved);
+            // Reuse Step 4's origin classifier so the Review's AI pill only fires when the
+            // displayed value actually came from the AI extraction — not when the user accepted
+            // a value that was already on the WQMP record. Mirrors getSourceControlRowOrigin().
             out.push({
                 categoryName: row.get("SourceControlBMPAttributeCategoryName")!.value as string,
                 attributeName: row.get("SourceControlBMPAttributeName")!.value as string,
                 isPresent,
                 note,
-                hasEvidence: this.sourceControlIsPresentEvidence.has(attrID) || this.sourceControlNoteEvidence.has(attrID),
+                origin: this.getSourceControlRowOrigin(row),
                 wqmpRecordValue: savedDisplay,
             });
         }
@@ -1088,19 +1100,40 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     onFieldAccepted(field: ExtractedField, value: string | null): void {
         field.state = "accepted";
         field.acceptedValue = value;
+        if (field.key === "TrashCaptureStatusType") this.syncTrashCaptureEffectivenessReadOnly();
         this.fields.update((f) => [...f]);
     }
 
     onFieldEdited(field: ExtractedField, value: string): void {
         field.state = "edited";
         field.acceptedValue = value;
+        if (field.key === "TrashCaptureStatusType") this.syncTrashCaptureEffectivenessReadOnly();
         this.fields.update((f) => [...f]);
     }
 
     onFieldRejected(field: ExtractedField): void {
         field.state = "rejected";
         field.acceptedValue = null;
+        if (field.key === "TrashCaptureStatusType") this.syncTrashCaptureEffectivenessReadOnly();
         this.fields.update((f) => [...f]);
+    }
+
+    /** NPT-1054: flip TrashCaptureEffectiveness between editable and read-only whenever the
+     *  Trash Capture Status changes. Clears the saved value when locking — matches legacy MVC,
+     *  where a non-Partial status nulls the percentage on save. */
+    private syncTrashCaptureEffectivenessReadOnly(): void {
+        const all = this.fields();
+        const tceField = all.find((f) => f.key === "TrashCaptureEffectiveness");
+        if (!tceField) return;
+        const partial = WqmpReviewComponent.PARTIAL_TRASH_CAPTURE_STATUS_ID;
+        const status = this.getCurrentTrashCaptureStatusID(all);
+        const isPartial = status === partial;
+        tceField.readOnly = !isPartial;
+        if (!isPartial) {
+            tceField.value = null;
+            tceField.acceptedValue = null;
+            tceField.state = "pending";
+        }
     }
 
     // NPT-1047: BmpReviewCard emits per-field events keyed by string. Bridge them into
@@ -1414,6 +1447,23 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 dto[key] = v;
                 continue;
             }
+
+            if (key === "TrashCaptureEffectiveness") {
+                // Force null when status isn't Partial so flipping the status away from
+                // Partial wipes a stale percentage rather than leaving the old number behind.
+                const statusID = this.getCurrentTrashCaptureStatusID(this.fields())
+                    ?? dto.TrashCaptureStatusTypeID
+                    ?? null;
+                if (statusID !== WqmpReviewComponent.PARTIAL_TRASH_CAPTURE_STATUS_ID) {
+                    dto.TrashCaptureEffectiveness = null;
+                } else if (v == null) {
+                    dto.TrashCaptureEffectiveness = null;
+                } else {
+                    const n = parseInt(v, 10);
+                    if (!isNaN(n)) dto.TrashCaptureEffectiveness = n;
+                }
+                continue;
+            }
         }
 
         return dto as WaterQualityManagementPlanUpsertDto;
@@ -1518,6 +1568,12 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
             const dd = String(d.getUTCDate()).padStart(2, "0");
             const yyyy = d.getUTCFullYear();
             return `${mm}/${dd}/${yyyy}`;
+        }
+        if (field.key === "TrashCaptureEffectiveness") {
+            // Suffix the saved percentage so the Step 5 row reads "75%" instead of bare "75".
+            // When the WQMP status isn't Partial the persisted value is null; getWqmpFieldValueForRow
+            // returns null for null/empty above, so no special handling is needed here.
+            return `${raw}%`;
         }
         return String(raw);
     }
@@ -1742,6 +1798,11 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 }
             }
 
+            // NPT-1054: TrashCaptureEffectiveness has no AI source — seed from the live WQMP
+            // and toggle readOnly based on the current TrashCaptureStatus. Mirrors the legacy
+            // MVC behavior: editable only when status = Partial; saved as null otherwise.
+            this.seedTrashCaptureEffectivenessField(allFields);
+
             this.fields.set(allFields);
         } catch {
             this.fields.set([]);
@@ -1791,6 +1852,12 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
             }
         } else if (key === "RecordedWQMPAreaInAcres") {
             fieldType = FormFieldType.Number;
+        } else if (key === "TrashCaptureEffectiveness") {
+            // AI extraction doesn't produce this; it's a manual percentage the user enters when
+            // TrashCaptureStatus = Partial. The post-build pass in parseExtractionResult marks
+            // the field as user-entered, seeds it from the live WQMP, and toggles readOnly
+            // based on the current TrashCaptureStatus.
+            fieldType = FormFieldType.Number;
         } else if (key === "MaintenanceContactPhone") {
             // Format any raw 10-digit AI capture as (NNN) NNN-NNNN for display; mask enforces
             // it on user edits too.
@@ -1839,5 +1906,39 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
         if (evidence && source) return "high";
         if (evidence || source) return "medium";
         return "low";
+    }
+
+    /** NPT-1054: hydrate the TrashCaptureEffectiveness field from the live WQMP and lock it
+     *  read-only when Trash Capture Status isn't Partial. Called in-place on the post-parse
+     *  field array so makeField stays generic. */
+    private seedTrashCaptureEffectivenessField(allFields: ExtractedField[]): void {
+        const tceField = allFields.find((f) => f.key === "TrashCaptureEffectiveness");
+        if (!tceField) return;
+        const wqmp = this.liveWqmp();
+        const partial = WqmpReviewComponent.PARTIAL_TRASH_CAPTURE_STATUS_ID;
+        const status = this.getCurrentTrashCaptureStatusID(allFields) ?? wqmp?.TrashCaptureStatusTypeID ?? null;
+        const isPartial = status === partial;
+        const existingValue = wqmp?.TrashCaptureEffectiveness != null ? String(wqmp.TrashCaptureEffectiveness) : null;
+        tceField.value = isPartial ? existingValue : null;
+        tceField.acceptedValue = isPartial ? existingValue : null;
+        tceField.state = "pending";
+        tceField.isUserEntered = true;
+        tceField.readOnly = !isPartial;
+        tceField.evidence = null;
+        tceField.source = null;
+        tceField.boundingBox = null;
+        tceField.confidence = "none";
+    }
+
+    /** Latest in-wizard TrashCaptureStatusTypeID — prefers the reviewer's pending edit over
+     *  the live WQMP value so the TCE field flips read-only mid-session when the status
+     *  changes. Returns null if the status field is missing or unset. */
+    private getCurrentTrashCaptureStatusID(allFields: ExtractedField[]): number | null {
+        const statusField = allFields.find((f) => f.key === "TrashCaptureStatusType");
+        if (!statusField) return null;
+        const raw = statusField.acceptedValue ?? statusField.value;
+        if (raw == null || raw === "") return null;
+        const n = Number(raw);
+        return Number.isFinite(n) ? n : null;
     }
 }


### PR DESCRIPTION
## Summary

Round 3 rework for NPT-1054 (AI Module: Source Control BMPs) + an opportunistic backend fix surfaced while verifying it.

### Frontend — wizard rework (PO Kathleen 5/18 + 5/19)
- **AI pill semantics on Step 5**: The Review's diff dashboard no longer marks rows with an AI pill when the displayed value actually came from the WQMP record. Re-uses Step 4's `getSourceControlRowOrigin` classifier so `"record"` and `"edited"` map to the regular "user" origin (no pill); only true AI-sourced values keep the pill.
- **Date format consistency**: All read-only date displays in the wizard now use Angular's `DatePipe` with `MM/dd/yyyy : "+0000"` — template pipe in the field-card, injected `DatePipe` in `review-summary`. Workflow Value and WQMP Record columns now render dates identically.
- **Trash Capture Effectiveness field**: Added to Step 2 (Basics) and surfaced on Step 5 (Review). Conditionally read-only when Trash Capture Status ≠ Partial; the save-side forces `TrashCaptureEffectiveness = null` when status isn't Partial so flipping the status away from Partial doesn't leave a stale percentage on the record. Mirrors the legacy MVC jQuery behavior.

### Backend — extraction hardening (opportunistic)
While verifying the front-end items I hit an extraction run that produced an empty Source Control array on WQMP 1143 (Chevron, the canonical reference) even though the same PDF returned 18–23 rows on adjacent runs. Tracing it: Claude occasionally double-encodes the `items` array AND the inner JSON has a corruption around character ~27k that the existing `,\s*([\]\}])` cleanup can't repair. PR #505 introduced the unwrap fallback; this round hardens it.
- `UnwrapItems` now returns `(Output, FailedFallback)` so callers can tell a legitimate empty array from a "fell back due to malformed inner JSON" empty array.
- **Auto-retry** the SourceControlBMPs category once when `UnwrapItems` falls back — recovers transparently from the flaky-model case the manual Re-run Extraction button used to require. Cost: one extra tool call only on failure.
- Diagnostics on the failure path: window-around-error log + full failing payload dumped to `/tmp/wqmp-sc-extraction-failure-*.json` inside the API container so the next failure can be repaired offline without re-running.

## Test plan

- [ ] Open the WQMP AI Review wizard for **WQMP 1143** with the current extraction (23 SC rows, 2 QuickBMPs). Advance to Step 5.
- [ ] **AI pill suppression**: SC rows whose Workflow Value column matches the WQMP Record column show **no** AI pill; rows where the AI provided a value not on the record still do.
- [ ] **Dates**: Approval Date / Date of Construction render `MM/dd/yyyy` in both Workflow Value and WQMP Record columns on Step 5; same format in the field-card read view on Steps 1/2.
- [ ] **Trash Capture Effectiveness**:
  - WQMP with status = **Partial** → TCE field on Step 2 is editable, accepts 1–99%, persists on save.
  - Flip status to **Full** in the same session → TCE card flips to read-only, value clears; save → DB column is `null`.
  - Step 5 shows TCE in the Basics group: `{n}%` when Partial, blank otherwise.
- [ ] **SC retry (negative path)**: Re-running extraction on a long PDF should still succeed on the primary call most of the time (retry stays dormant); if the API log shows `SourceControlBMPs unwrap failed — retrying extraction once before giving up.` followed by `SourceControlBMPs retry succeeded`, the safety net worked.
