### PR TITLE
NPT-981: Round 2 — delineation click-to-select, provisional + parcels layers, Move BMP UX

### DIFF
--- a/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.html
+++ b/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.html
@@ -79,7 +79,7 @@
                                 @switch (mode) {
                                     @case ("editingDistributed") { Use the map tools to draw or edit the polygon, then save. }
                                     @case ("editingCentralized") { Loaded upstream catchment. Adjust vertices if needed, then save. }
-                                    @case ("editingLocation") { Click on the map to place the new BMP location, then save. }
+                                    @case ("editingLocation") { Drag the BMP marker or click anywhere on the map to relocate it, then Save. }
                                 }
                             </p>
                             <div class="inline-actions">
@@ -102,7 +102,13 @@
                         <stormwater-network-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="20"></stormwater-network-layer>
                         <jurisdictions-layer [mode]="OverlayMode.ReferenceOnly" [displayOnLoad]="true" [map]="map" [layerControl]="layerControl" [sortOrder]="30"></jurisdictions-layer>
                         <wqmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="40"></wqmps-layer>
-                        <delineations-layer [displayOnLoad]="true" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
+                        <!-- NPT-981 r2: two separate layers so the layer-control surfaces both as
+                             toggleable overlays and the WMS / WFS filter is correctly per-status.
+                             (selected) on each layer emits the clicked DelineationID; the parent
+                             matches it to the local BMP cache to populate the side panel. -->
+                        <delineations-layer [delineationStatus]="'Verified'" [displayOnLoad]="true" [map]="map" [layerControl]="layerControl" [sortOrder]="50" (selected)="onDelineationSelected($event)"></delineations-layer>
+                        <delineations-layer [delineationStatus]="'Provisional'" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="51" (selected)="onDelineationSelected($event)"></delineations-layer>
+                        <parcels-layer [mode]="OverlayMode.ReferenceOnly" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="60"></parcels-layer>
                     }
                 </neptune-map>
             }

--- a/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.ts
+++ b/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.ts
@@ -191,7 +191,12 @@ export class DelineationMapComponent implements OnInit {
             if (!bmp.Latitude || !bmp.Longitude) {
                 continue;
             }
-            const marker = L.marker([bmp.Latitude, bmp.Longitude], { icon: MarkerHelper.treatmentBMPMarker });
+            // NPT-981 r2: construct with draggable: true so Leaflet's _initInteraction
+            // builds the marker.dragging Handler when the cluster eventually exposes the
+            // marker on the map. Immediately disable on `add` so the marker is click-only
+            // outside edit mode; startEditLocation re-enables on demand.
+            const marker = L.marker([bmp.Latitude, bmp.Longitude], { icon: MarkerHelper.treatmentBMPMarker, draggable: true });
+            marker.on("add", () => marker.dragging?.disable());
             marker.on("click", () => {
                 if (this.editMode() !== "idle") {
                     return;
@@ -373,28 +378,48 @@ export class DelineationMapComponent implements OnInit {
         }
         this.cancelEdit();
         this.editMode.set("editingLocation");
-        this.pendingLocation = null;
 
         // NPT-981 r2: cursor goes on the map container (not the .leaflet-interactive SVG
         // overlay) so the crosshair is visible everywhere the user might click — matches
         // Jamie's OVTA assessment-point pattern.
         this.map.getContainer().style.cursor = "crosshair";
 
-        // NPT-981 r2: enable drag on the selected BMP marker so the user can drag it OR
-        // click somewhere new — either feeds the same handleLocationChange path.
+        // NPT-981 r2: drag the BMP's own cluster marker directly. The earlier preview-marker
+        // approach left an orphan marker on the map after save when reference tracking
+        // raced with cluster re-renders. Dragging the cluster marker keeps exactly one
+        // marker visible at all times; saveEdit's renderBMPMarkers rebuilds it cleanly.
         const marker = this.bmpMarkerByID.get(bmp.TreatmentBMPID);
         if (marker) {
             marker.dragging?.enable();
+            marker.on("drag", this.onMarkerDrag);
             marker.on("dragend", this.onMarkerDragEnd);
         }
+
+        // Seed pending location to the current position so Save without further interaction
+        // is a no-op rather than an error.
+        this.pendingLocation = { lat: bmp.Latitude, lng: bmp.Longitude };
     }
 
-    /** Bound reference so we can off() it cleanly on cancel — instance method would lose
-     *  this-binding when passed to off() unless we wrap it. Defined as a property to keep
-     *  the same Function identity across enable/disable cycles. */
+    /** Bound references so we can off() them cleanly on cancel — instance methods would lose
+     *  this-binding when passed to off() unless we wrap them. Property-assigned arrow
+     *  functions keep the same Function identity across enable/disable cycles. */
+
+    /** `drag` event carries the live latlng during the drag and fires on every mousemove.
+     *  Markercluster can return stale lat/lngs from getLatLng() on dragend (its internal
+     *  index doesn't update mid-drag), so we capture the position continuously here as the
+     *  authoritative source for pendingLocation. */
+    private onMarkerDrag = (event: any): void => {
+        this.handleLocationChange(event.latlng);
+    };
+
+    /** Belt-and-suspenders dragend handler — also refreshes the cluster's index so the
+     *  marker's new position propagates to the cluster's spatial query structures. */
     private onMarkerDragEnd = (event: any): void => {
         const latLng = event.target.getLatLng();
         this.handleLocationChange(latLng);
+        if (this.bmpsClusterLayer?.refreshClusters) {
+            this.bmpsClusterLayer.refreshClusters(event.target);
+        }
     };
 
     private attachMapClickForLocation(): void {
@@ -407,14 +432,17 @@ export class DelineationMapComponent implements OnInit {
     }
 
     /** NPT-981 r2: shared handler for both drag-end and map-click during Edit BMP Location.
-     *  Updates the pending location signal and moves a preview marker so the user can see
-     *  where the BMP would land before saving. */
+     *  Updates pending location and moves the BMP's cluster marker to the new spot so the
+     *  user sees the preview without a second marker on the map. */
     private handleLocationChange(latLng: L.LatLng): void {
         this.pendingLocation = { lat: latLng.lat, lng: latLng.lng };
-        if (this.locationPreviewMarker) {
-            this.locationPreviewMarker.setLatLng(latLng);
-        } else {
-            this.locationPreviewMarker = L.marker(latLng, { icon: MarkerHelper.selectedMarker, zIndexOffset: 11000 }).addTo(this.map);
+        const bmp = this.selectedBMP();
+        if (!bmp) {
+            return;
+        }
+        const marker = this.bmpMarkerByID.get(bmp.TreatmentBMPID);
+        if (marker) {
+            marker.setLatLng(latLng);
         }
     }
 
@@ -449,6 +477,16 @@ export class DelineationMapComponent implements OnInit {
                 next: () => {
                     this.savingSubject.next(false);
                     this.alertService.pushAlert(new Alert("Treatment BMP location updated.", AlertContext.Success, true));
+                    // The `bmp` local is a spread copy from the selectedBMP signal (set by
+                    // applyDelineationToSelectedBMP after select). Mutating it doesn't
+                    // propagate to this.bmps[]; we have to find and mutate the cached entry
+                    // so renderBMPMarkers below rebuilds at the new position. Without this,
+                    // the API persists the change but the SPA reverts on re-render.
+                    const cached = this.bmps.find((b) => b.TreatmentBMPID === bmp.TreatmentBMPID);
+                    if (cached) {
+                        cached.Latitude = newLat;
+                        cached.Longitude = newLng;
+                    }
                     bmp.Latitude = newLat;
                     bmp.Longitude = newLng;
                     this.selectedBMP.set({ ...bmp });
@@ -506,24 +544,25 @@ export class DelineationMapComponent implements OnInit {
     }
 
     private clearLocationPreview(): void {
-        if (this.locationPreviewMarker) {
-            this.map.removeLayer(this.locationPreviewMarker);
-            this.locationPreviewMarker = null;
-        }
+        // NPT-981 r2: we drag the cluster's own BMP marker now. Cleanup is just: disable
+        // dragging on it, unbind dragend, restore cursor, and revert the marker's visual
+        // position if the user cancelled (saveEdit's renderBMPMarkers rebuild handles the
+        // successful-save case). Reverting on cancel uses the BMP's authoritative lat/lng
+        // from the bmps array, which saveEdit has not yet mutated when cancelEdit is invoked.
         this.pendingLocation = null;
-
-        // NPT-981 r2: restore the map container's cursor and disable + unbind the marker's
-        // drag handler so the selected BMP marker doesn't stay draggable after Save/Cancel.
         if (this.map) {
             this.map.getContainer().style.cursor = "";
         }
         const bmp = this.selectedBMP();
-        if (bmp) {
-            const marker = this.bmpMarkerByID.get(bmp.TreatmentBMPID);
-            if (marker) {
-                marker.dragging?.disable();
-                marker.off("dragend", this.onMarkerDragEnd);
-            }
+        if (!bmp) return;
+        const marker = this.bmpMarkerByID.get(bmp.TreatmentBMPID);
+        if (marker) {
+            marker.dragging?.disable();
+            marker.off("drag", this.onMarkerDrag);
+            marker.off("dragend", this.onMarkerDragEnd);
+            // Revert any visual drag (no-op if user saved — by then the marker was
+            // rebuilt by renderBMPMarkers at the new position).
+            marker.setLatLng([bmp.Latitude, bmp.Longitude]);
         }
     }
 

--- a/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.ts
+++ b/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.ts
@@ -32,6 +32,7 @@ import { DelineationsLayerComponent } from "src/app/shared/components/leaflet/la
 import { JurisdictionsLayerComponent } from "src/app/shared/components/leaflet/layers/jurisdictions-layer/jurisdictions-layer.component";
 import { WqmpsLayerComponent } from "src/app/shared/components/leaflet/layers/wqmps-layer/wqmps-layer.component";
 import { StormwaterNetworkLayerComponent } from "src/app/shared/components/leaflet/layers/stormwater-network-layer/stormwater-network-layer.component";
+import { ParcelsLayerComponent } from "src/app/shared/components/leaflet/layers/parcels-layer/parcels-layer.component";
 import { OverlayMode } from "src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/overlay-mode.enum";
 
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
@@ -56,6 +57,7 @@ type EditMode = "idle" | "editingDistributed" | "editingCentralized" | "editingL
         JurisdictionsLayerComponent,
         WqmpsLayerComponent,
         StormwaterNetworkLayerComponent,
+        ParcelsLayerComponent,
         PageHeaderComponent,
         AlertDisplayComponent,
         IconComponent,
@@ -204,6 +206,23 @@ export class DelineationMapComponent implements OnInit {
         this.map.addLayer(this.bmpsClusterLayer);
     }
 
+    /**
+     * NPT-981 r2: handler for the delineations-layer (selected) event. The WMS GetFeatureInfo
+     * response from Geoserver returns features in draw order, so features[0] is the topmost —
+     * generic-wms-wfs-layer already emits that one ID. Match it against the local BMP cache
+     * (every TreatmentBMPDelineationMapDto carries its DelineationID); if the BMP is in the
+     * cache, select it via the existing selectBMP flow so the side panel populates. BMPs
+     * outside the user's jurisdiction won't be in the cache — clicking such a delineation is
+     * a no-op (the verified-delineation layer is visible to everyone but write actions are
+     * already permission-gated on the API).
+     */
+    public onDelineationSelected(delineationID: number): void {
+        const bmp = this.bmps.find((b) => b.DelineationID === delineationID);
+        if (bmp) {
+            this.selectBMP(bmp);
+        }
+    }
+
     public selectBMP(bmp: TreatmentBMPDelineationMapDto): void {
         this.cancelEdit();
         this.selectedBMP.set(bmp);
@@ -348,29 +367,55 @@ export class DelineationMapComponent implements OnInit {
     }
 
     public startEditLocation(): void {
-        if (!this.selectedBMP()) {
+        const bmp = this.selectedBMP();
+        if (!bmp) {
             return;
         }
         this.cancelEdit();
         this.editMode.set("editingLocation");
         this.pendingLocation = null;
-        const el = document.querySelector(".leaflet-interactive") as HTMLElement | null;
-        if (el) {
-            el.style.cursor = "crosshair";
+
+        // NPT-981 r2: cursor goes on the map container (not the .leaflet-interactive SVG
+        // overlay) so the crosshair is visible everywhere the user might click — matches
+        // Jamie's OVTA assessment-point pattern.
+        this.map.getContainer().style.cursor = "crosshair";
+
+        // NPT-981 r2: enable drag on the selected BMP marker so the user can drag it OR
+        // click somewhere new — either feeds the same handleLocationChange path.
+        const marker = this.bmpMarkerByID.get(bmp.TreatmentBMPID);
+        if (marker) {
+            marker.dragging?.enable();
+            marker.on("dragend", this.onMarkerDragEnd);
         }
     }
+
+    /** Bound reference so we can off() it cleanly on cancel — instance method would lose
+     *  this-binding when passed to off() unless we wrap it. Defined as a property to keep
+     *  the same Function identity across enable/disable cycles. */
+    private onMarkerDragEnd = (event: any): void => {
+        const latLng = event.target.getLatLng();
+        this.handleLocationChange(latLng);
+    };
 
     private attachMapClickForLocation(): void {
         this.map.on("click", (event: L.LeafletMouseEvent) => {
             if (this.editMode() !== "editingLocation") {
                 return;
             }
-            this.pendingLocation = { lat: event.latlng.lat, lng: event.latlng.lng };
-            if (this.locationPreviewMarker) {
-                this.map.removeLayer(this.locationPreviewMarker);
-            }
-            this.locationPreviewMarker = L.marker(event.latlng, { icon: MarkerHelper.selectedMarker, zIndexOffset: 11000 }).addTo(this.map);
+            this.handleLocationChange(event.latlng);
         });
+    }
+
+    /** NPT-981 r2: shared handler for both drag-end and map-click during Edit BMP Location.
+     *  Updates the pending location signal and moves a preview marker so the user can see
+     *  where the BMP would land before saving. */
+    private handleLocationChange(latLng: L.LatLng): void {
+        this.pendingLocation = { lat: latLng.lat, lng: latLng.lng };
+        if (this.locationPreviewMarker) {
+            this.locationPreviewMarker.setLatLng(latLng);
+        } else {
+            this.locationPreviewMarker = L.marker(latLng, { icon: MarkerHelper.selectedMarker, zIndexOffset: 11000 }).addTo(this.map);
+        }
     }
 
     private attachGeomanHandlers(): void {
@@ -466,9 +511,19 @@ export class DelineationMapComponent implements OnInit {
             this.locationPreviewMarker = null;
         }
         this.pendingLocation = null;
-        const el = document.querySelector(".leaflet-interactive") as HTMLElement | null;
-        if (el) {
-            el.style.cursor = "";
+
+        // NPT-981 r2: restore the map container's cursor and disable + unbind the marker's
+        // drag handler so the selected BMP marker doesn't stay draggable after Save/Cancel.
+        if (this.map) {
+            this.map.getContainer().style.cursor = "";
+        }
+        const bmp = this.selectedBMP();
+        if (bmp) {
+            const marker = this.bmpMarkerByID.get(bmp.TreatmentBMPID);
+            if (marker) {
+                marker.dragging?.disable();
+                marker.off("dragend", this.onMarkerDragEnd);
+            }
         }
     }
 

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.html
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.html
@@ -3,6 +3,7 @@
     [layerControl]="layerControl"
     [interactive]="true"
     [displayOnLoad]="displayOnLoad"
+    [sortOrder]="sortOrder"
     [cqlFilter]="cqlFilter"
     [wmsLayerName]="WMS_LAYER_NAME"
     [wmsStyle]="WMS_STYLE"

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.html
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.html
@@ -1,12 +1,14 @@
-<ng-template #layerName>
-    <span>Delineations ({{ delineationStatus }})</span>
-</ng-template>
-<ng-template #legend>
-    <p>
-        @if (delineationStatus === "Verified") {
-            <img src="./assets/main/map-legend-images/delineationVerified.png" style="margin-bottom: 3px" />
-        } @else {
-            <img src="./assets/main/map-legend-images/delineationProvisional.png" style="margin-bottom: 3px" />
-        }
-    </p>
-</ng-template>
+<generic-wms-wfs-layer
+    [map]="map"
+    [layerControl]="layerControl"
+    [interactive]="true"
+    [displayOnLoad]="displayOnLoad"
+    [cqlFilter]="cqlFilter"
+    [wmsLayerName]="WMS_LAYER_NAME"
+    [wmsStyle]="WMS_STYLE"
+    [wfsFeatureType]="WFS_FEATURE_TYPE"
+    [identifierProperty]="IDENTIFIER_PROPERTY"
+    [overlayLabel]="overlayLabel"
+    [legendHtml]="legendHtml"
+    (selected)="selected.emit($event)">
+</generic-wms-wfs-layer>

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.ts
@@ -1,39 +1,70 @@
-import { Component, Input, OnChanges } from "@angular/core";
-import { environment } from "src/environments/environment";
+import { Component, EventEmitter, Input, OnChanges, Output } from "@angular/core";
 import * as L from "leaflet";
-import { MapLayerBase } from "../map-layer-base.component";
+import { GenericWmsWfsLayerComponent } from "../generic-wms-wfs-layer/generic-wms-wfs-layer.component";
+
+/**
+ * NPT-981 Round 2: refactored to wrap GenericWmsWfsLayerComponent (parcels-layer pattern)
+ * so the delineations layer can emit a `selected` event when the user clicks a polygon.
+ * Round 1 only added a passive WMS tile with no click handler — KE flagged that delineations
+ * were visible but couldn't populate the side panel.
+ *
+ * Two layer-control entries get emitted via two parent instances:
+ *   <delineations-layer [delineationStatus]="'Verified'" ...></delineations-layer>
+ *   <delineations-layer [delineationStatus]="'Provisional'" ...></delineations-layer>
+ * Each has its own cql_filter and overlay label.
+ */
 @Component({
     selector: "delineations-layer",
-    imports: [],
+    imports: [GenericWmsWfsLayerComponent],
     templateUrl: "./delineations-layer.component.html",
     styleUrls: ["./delineations-layer.component.scss"],
 })
-export class DelineationsLayerComponent extends MapLayerBase implements OnChanges {
-    constructor() {
-        super();
-    }
-    @Input() isAnalyzedInModelingModule: boolean = true;
-    @Input() delineationStatus: "Verified" | "Provisional" = "Verified";
-    public wmsOptions: L.WMSOptions;
-    public layer;
+export class DelineationsLayerComponent implements OnChanges {
+    readonly WFS_FEATURE_TYPE = "OCStormwater:Delineations";
+    readonly WMS_LAYER_NAME = "OCStormwater:Delineations";
+    readonly IDENTIFIER_PROPERTY = "DelineationID";
+    readonly WMS_STYLE = "delineation";
 
-    ngAfterViewInit(): void {
+    @Input() delineationStatus: "Verified" | "Provisional" = "Verified";
+    @Input() isAnalyzedInModelingModule: boolean = true;
+    @Input() map: L.Map;
+    @Input() layerControl: any;
+    @Input() sortOrder: number = 1;
+    @Input() displayOnLoad: boolean = true;
+    /** Emits the clicked DelineationID. Selection of the topmost feature is handled by the
+     *  WMS GetFeatureInfo response in GenericWmsWfsLayerComponent — the API returns features
+     *  in draw order, so `features[0]` is the topmost. */
+    @Output() selected = new EventEmitter<number>();
+
+    public cqlFilter: string = "1=1";
+    public overlayLabel: string = "Delineations";
+    public legendHtml: string = "";
+
+    ngOnChanges(): void {
         let cqlFilter = `DelineationStatus = '${this.delineationStatus}'`;
         if (this.delineationStatus === "Verified" && this.isAnalyzedInModelingModule) {
             cqlFilter += " AND IsAnalyzedInModelingModule = 1";
         }
+        this.cqlFilter = cqlFilter;
+        this.overlayLabel = `${this.delineationStatus} Delineations`;
+        // NPT-981 r2 KE feedback: build inline HTML swatches rather than serving Geoserver's
+        // GetLegendGraphic (which emits 6 SLD rules including WQMP Boundary + status-suffixed
+        // labels) and rather than the bundled static PNGs (which bake the "(Verified)" /
+        // "(Provisional)" suffix into the image). The group header above ("Verified Delineations"
+        // / "Provisional Delineations") already conveys status, so the swatches just need
+        // Centralized + Distributed labels. Colors approximate the legacy MVC delineation map
+        // palette: verified gets the saturated purple / blue pair; provisional uses the
+        // lighter magenta / light-blue pair so the two statuses are visually distinct.
+        this.legendHtml = this.delineationStatus === "Verified"
+            ? this.buildSwatchHtml("#d4b8e4", "#7e4d8a", "#b8c5e0", "#3a55a0")
+            : this.buildSwatchHtml("#e6bdd4", "#b04880", "#c5d4ea", "#6378b8");
+    }
 
-        this.wmsOptions = {
-            layers: "OCStormwater:Delineations",
-            transparent: true,
-            format: "image/png",
-            tiled: true,
-            styles: "delineation",
-            cql_filter: cqlFilter,
-            maxZoom: 22,
-        } as any;
-
-        this.layer = L.tileLayer.wms(environment.geoserverMapServiceUrl + "/wms?", this.wmsOptions);
-        this.initLayer();
+    private buildSwatchHtml(centralizedFill: string, centralizedStroke: string, distributedFill: string, distributedStroke: string): string {
+        const swatch = (fill: string, stroke: string, label: string) =>
+            `<div style="display:flex;align-items:center;margin-bottom:3px;font-size:12px;line-height:1;">` +
+            `<span style="display:inline-block;width:14px;height:14px;background:${fill};border:2px solid ${stroke};vertical-align:middle;margin-right:6px;"></span>` +
+            `${label}</div>`;
+        return swatch(centralizedFill, centralizedStroke, "Centralized") + swatch(distributedFill, distributedStroke, "Distributed");
     }
 }

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/generic-wms-wfs-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/generic-wms-wfs-layer.component.ts
@@ -74,6 +74,11 @@ export class GenericWmsWfsLayerComponent extends MapLayerBase implements OnChang
             if (this.legendHtml) {
                 (this.layer as any).legendHtml = this.legendHtml;
             }
+            // leaflet.groupedlayercontrol sorts overlays by layer.sortOrder. Without this,
+            // GenericWmsWfsLayer overlays land in unstable order; Copilot PR #518 flagged it.
+            if (this.sortOrder != null) {
+                (this.layer as any).sortOrder = this.sortOrder;
+            }
         }
         // Add to layerControl only once, after both layer and layerControl are available
         if (this.layer && this.layerControl && !this.overlayAddedToControl && this.addToLayerControl) {

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/generic-wms-wfs-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/generic-wms-wfs-layer.component.ts
@@ -31,6 +31,13 @@ export class GenericWmsWfsLayerComponent extends MapLayerBase implements OnChang
         fillOpacity: 0.1,
     };
     @Input() cqlFilter: string = "1=1";
+    /** Optional pre-rendered legend HTML (e.g. a static `<img>` swatch from
+     *  `/assets/main/map-legend-images/`). When provided, applied to the WMS layer as
+     *  `layer.legendHtml` so `neptune-map.createLegendItems` uses this HTML instead of
+     *  Geoserver's auto-generated `GetLegendGraphic`. Lets wrappers like delineations-layer
+     *  hand-craft legend swatches and bypass Geoserver SLD rules that include unwanted
+     *  variants (e.g. WQMP Boundary) or status-suffixed labels. */
+    @Input() legendHtml?: string;
     @Input() addToLayerControl: boolean = true;
     @Input() fitBoundsOnSelect: boolean = true;
     @Output() selected = new EventEmitter<number>();
@@ -61,6 +68,12 @@ export class GenericWmsWfsLayerComponent extends MapLayerBase implements OnChang
                 maxZoom: 22,
             } as any;
             this.layer = L.tileLayer.wms(environment.geoserverMapServiceUrl + "/wms?", wmsOptions);
+            // neptune-map.createLegendItems reads layer.legendHtml first and falls back to
+            // Geoserver GetLegendGraphic; setting it here lets wrappers ship a pre-rendered
+            // legend swatch (see DelineationsLayerComponent).
+            if (this.legendHtml) {
+                (this.layer as any).legendHtml = this.legendHtml;
+            }
         }
         // Add to layerControl only once, after both layer and layerControl are available
         if (this.layer && this.layerControl && !this.overlayAddedToControl && this.addToLayerControl) {


### PR DESCRIPTION
## Summary

Round 2 rework for NPT-981 (Migrate Delineation Map to SPA). Addresses KE's 5/19/26 rework items.

### Delineation click-to-select (Items 2 + 4)
Refactored `delineations-layer` to wrap `GenericWmsWfsLayerComponent` (parcels-layer pattern) with `interactive=true`. The generic component's WMS `GetFeatureInfo` click handler emits the topmost feature's ID (features are returned in WMS draw order). Parent `delineation-map` subscribes via `onDelineationSelected(delineationID)`, matches against the local BMP cache, and routes through the existing `selectBMP` flow so the side panel populates with name / type / delineation details / actions.

### Provisional Delineations layer (Item 3)
Added a second `<delineations-layer [delineationStatus]="'Provisional'">` instance, default-off in the layer-control overlay list. Same click-to-select wiring as Verified.

### Parcels reference layer (Item 5)
One-line addition using the existing `<parcels-layer>` in `ReferenceOnly` mode, default-off. Matches the planning-map's pattern.

### Legend swatches (KE follow-up)
- `GenericWmsWfsLayerComponent` gains a `legendHtml` input. `neptune-map.createLegendItems` already prefers `layer.legendHtml` over Geoserver's `GetLegendGraphic`, so this short-circuits the 6-rule SLD legend output (which included unwanted "WQMP Boundary" entries and labels suffixed with the status name).
- `delineations-layer` builds the legend HTML inline per status — just *Centralized* and *Distributed* swatches with no suffix (the layer-group header conveys status). Verified uses saturated purple / blue; Provisional uses lighter magenta / light-blue so the two statuses are visually distinct.

### Move BMP UX (Item 6, OVTA parity)
- `startEditLocation` now sets `map.getContainer().style.cursor = "crosshair"` (the prior selector on `.leaflet-interactive` only covered the SVG overlay).
- Enables Leaflet marker dragging on the selected BMP's marker and binds `dragend` to a shared `handleLocationChange(latLng)` — the existing map-click handler also feeds the same method, so drag and click both update the pending location + move the preview marker.
- `clearLocationPreview` restores the cursor and disables/unbinds the marker drag on Save or Cancel.
- Instruction text updated: *"Drag the BMP marker or click anywhere on the map to relocate it, then Save."*

### Item 1 (BMP pins missing) — QA-environment-only
Local works correctly; the fetch + cluster + click handler in `delineation-map.component.ts:152–205` are intact. Most likely an environment delta on the QA pod (older API build, stale DB, or KE's QA user role/jurisdictions). The next QA deploy should resolve. If it persists, will re-diagnose with QA logs + role/jurisdiction inspection.

## Test plan

- [ ] Open Delineation Map. Layer-control overlay list now shows: Treatment BMPs, Verified Delineations, Provisional Delineations, Parcels (plus existing reference layers).
- [ ] Toggle Provisional Delineations on → polygons appear in the lighter magenta / light-blue color palette.
- [ ] Click any verified delineation polygon → side panel populates with BMP name + type + delineation type/area/status. Where polygons overlap, the topmost one is selected.
- [ ] Click any provisional delineation → side panel populates similarly.
- [ ] Toggle Parcels on → parcels reference layer shows.
- [ ] Legend (bottom-left toggle): each delineation group shows just *Centralized* + *Distributed* swatches in the right colors per status; no "(Verified)" / "(Provisional)" suffix; no WQMP Boundary row.
- [ ] Select a BMP → Edit BMP Location → cursor goes crosshair; instruction reads drag-or-click; drag the marker → it moves; click elsewhere → marker jumps; Save → location persists.
- [ ] No regression on already-green reference layers (WQMPs / RSBs / Stormwater Network / Jurisdictions).
- [ ] **QA**: confirm BMP pins render after deploy. If not, capture network response from `/treatment-bmps/for-delineation-map` and check KE's QA role + jurisdiction assignments.
