### PR TITLE
NPT-999: Round 3 — Account link, admin jurisdiction stub, users-list lockdown, field-def CD fix

### DIFF
--- a/Neptune.Web/src/app/app.routes.ts
+++ b/Neptune.Web/src/app/app.routes.ts
@@ -362,7 +362,7 @@ export const routes: Routes = [
             {
                 // NPT-999 r3 (KE 5/20/26): the users list is Admin / SitkaAdmin only.
                 // Jurisdiction users have no business seeing the full user roster; they
-                // reach their own profile via the Welcome dropdown's "My Profile" link.
+                // reach their own profile via the Welcome dropdown's Account link.
                 path: "users",
                 title: "Users",
                 loadComponent: () => import("./pages/users/users.component").then((m) => m.UsersComponent),

--- a/Neptune.Web/src/app/app.routes.ts
+++ b/Neptune.Web/src/app/app.routes.ts
@@ -359,7 +359,15 @@ export const routes: Routes = [
                 redirectTo: `field-definitions/:${routeParams.definitionID}/edit`,
                 pathMatch: "full",
             },
-            { path: "users", title: "Users", loadComponent: () => import("./pages/users/users.component").then((m) => m.UsersComponent) },
+            {
+                // NPT-999 r3 (KE 5/20/26): the users list is Admin / SitkaAdmin only.
+                // Jurisdiction users have no business seeing the full user roster; they
+                // reach their own profile via the Welcome dropdown's "My Profile" link.
+                path: "users",
+                title: "Users",
+                loadComponent: () => import("./pages/users/users.component").then((m) => m.UsersComponent),
+                canActivate: [authGuardFn, ManagerOnlyGuard],
+            },
             {
                 path: `users/:${routeParams.personID}`,
                 title: "User Detail",

--- a/Neptune.Web/src/app/pages/field-definition-edit/field-definition-edit.component.ts
+++ b/Neptune.Web/src/app/pages/field-definition-edit/field-definition-edit.component.ts
@@ -66,13 +66,21 @@ export class FieldDefinitionEditComponent implements OnInit {
                         } else {
                             this.loadFailed = true;
                         }
+                        // NPT-999 r3 (KE 5/20/26): under zoneless change detection, mutating a
+                        // plain property inside a .subscribe() callback doesn't mark the view
+                        // dirty — the @if (fieldDefinition) branch only re-evaluates when the
+                        // next user-triggered tick fires (a click anywhere on the page). Force
+                        // a detectChanges so the editor renders as soon as the GET resolves.
+                        this.cdr.detectChanges();
                     },
                     error: () => {
                         this.loadFailed = true;
+                        this.cdr.detectChanges();
                     },
                 });
             } else {
                 this.loadFailed = true;
+                this.cdr.detectChanges();
             }
         });
     }

--- a/Neptune.Web/src/app/pages/field-definition-edit/field-definition-edit.component.ts
+++ b/Neptune.Web/src/app/pages/field-definition-edit/field-definition-edit.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, ChangeDetectorRef, ViewChild } from "@angular/core";
+import { Component, DestroyRef, OnInit, ChangeDetectorRef, ViewChild, inject } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { AuthenticationService } from "src/app/services/authentication.service";
 import { Router, ActivatedRoute, RouterLink } from "@angular/router";
 import { Alert } from "src/app/shared/models/alert";
@@ -40,6 +41,11 @@ export class FieldDefinitionEditComponent implements OnInit {
 
     public isLoadingSubmit: boolean;
 
+    // NPT-999 r3 (Copilot PR #519): cancels the in-flight subscribes when the component is
+    // destroyed so the subscribe callbacks (which call cdr.detectChanges) don't run on a
+    // torn-down view if the user navigates away mid-request.
+    private destroyRef = inject(DestroyRef);
+
     constructor(
         private route: ActivatedRoute,
         private router: Router,
@@ -50,7 +56,7 @@ export class FieldDefinitionEditComponent implements OnInit {
     ) {}
 
     ngOnInit() {
-        this.authenticationService.getCurrentUser().subscribe((currentUser) => {
+        this.authenticationService.getCurrentUser().pipe(takeUntilDestroyed(this.destroyRef)).subscribe((currentUser) => {
             this.currentUser = currentUser;
             // NPT-999: read `fieldDefinitionTypeID` (canonical AC param). Legacy `definitionID`
             // route still resolves via a redirect in app.routes.ts that preserves the value, so
@@ -59,7 +65,7 @@ export class FieldDefinitionEditComponent implements OnInit {
                 ?? this.route.snapshot.paramMap.get("definitionID");
             const id = raw ? parseInt(raw, 10) : NaN;
             if (Number.isFinite(id)) {
-                this.fieldDefinitionService.getFieldDefinition(id).subscribe({
+                this.fieldDefinitionService.getFieldDefinition(id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
                     next: (fieldDefinition) => {
                         if (fieldDefinition) {
                             this.fieldDefinition = fieldDefinition;

--- a/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.html
+++ b/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.html
@@ -3,7 +3,7 @@
         <ng-template #templateAbove>
             <!-- NPT-999 r3 (KE 5/20/26): the back-link only renders for Admin / SitkaAdmin
                  viewers since the /users list itself is now guarded to those roles. Jurisdiction
-                 users land on this page through "My Profile" in the Welcome dropdown and have
+                 users land on this page through the Welcome dropdown's Account link and have
                  no business browsing the full user roster. -->
             @if (isAdmin()) {
                 <div class="back">

--- a/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.html
+++ b/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.html
@@ -1,9 +1,15 @@
 @if (detail$ | async; as detail) {
     <page-header [pageTitle]="detail.FirstName + ' ' + detail.LastName" [templateAbove]="templateAbove" [templateRight]="headerActions">
         <ng-template #templateAbove>
-            <div class="back">
-                <a [routerLink]="['/users']" class="back__link"><i class="fa fa-arrow-left"></i> Back to Users List</a>
-            </div>
+            <!-- NPT-999 r3 (KE 5/20/26): the back-link only renders for Admin / SitkaAdmin
+                 viewers since the /users list itself is now guarded to those roles. Jurisdiction
+                 users land on this page through "My Profile" in the Welcome dropdown and have
+                 no business browsing the full user roster. -->
+            @if (isAdmin()) {
+                <div class="back">
+                    <a [routerLink]="['/users']" class="back__link"><i class="fa fa-arrow-left"></i> Back to Users List</a>
+                </div>
+            }
         </ng-template>
         <ng-template #headerActions>
             @if (isAdmin()) {
@@ -102,12 +108,17 @@
             <div class="card mt-3">
                 <div class="card-header">
                     <span class="card-title">Assigned Jurisdictions</span>
-                    @if (isAdmin()) {
+                    @if (isAdmin() && !isDetailUserAdmin(detail)) {
                         <a (click)="openEditJurisdictionsModal(detail)" style="cursor: pointer" title="Edit Jurisdictions"><icon class="icon-button" icon="CirclePencil"></icon></a>
                     }
                 </div>
                 <div class="card-body">
-                    @if (detail.AssignedStormwaterJurisdictions && detail.AssignedStormwaterJurisdictions.length > 0) {
+                    @if (isDetailUserAdmin(detail)) {
+                        <!-- KE 5/20/26: Admin / SitkaAdmin users implicitly manage every jurisdiction;
+                             show the stub message in place of the assigned list and suppress the Edit
+                             pencil above so it can't be clicked to add a redundant assignment. -->
+                        <p class="system-text">Administrators are by definition assigned to manage all Jurisdictions.</p>
+                    } @else if (detail.AssignedStormwaterJurisdictions && detail.AssignedStormwaterJurisdictions.length > 0) {
                         <ul class="plain-list">
                             @for (jurisdiction of detail.AssignedStormwaterJurisdictions; track jurisdiction.StormwaterJurisdictionID) {
                                 <li>

--- a/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.ts
+++ b/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.ts
@@ -80,7 +80,10 @@ export class UserDetailComponent implements OnInit {
             catchError((err) => {
                 if (err?.status === 403) {
                     this.alertService.pushAlert(new Alert("You don't have permission to view that user's profile.", AlertContext.Danger, true));
-                    this.router.navigate(["/users"]);
+                    // NPT-999 r3 (Copilot PR #519): /users is now ManagerOnlyGuard-protected.
+                    // Non-admin viewers redirected there would bounce to / via the guard, firing
+                    // a second unauthorized alert. Send admins to the list and everyone else home.
+                    this.router.navigate([this.isAdmin() ? "/users" : "/"]);
                 }
                 return of(null as unknown as PersonDetailDto);
             }),

--- a/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.ts
+++ b/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.ts
@@ -52,6 +52,13 @@ export class UserDetailComponent implements OnInit {
         return !!u && (u.RoleID === RoleEnum.Admin || u.RoleID === RoleEnum.SitkaAdmin);
     });
 
+    /** KE 5/20/26: the viewed user (not the viewer) — Admin / SitkaAdmin users implicitly
+     *  manage every jurisdiction, so the Assigned Jurisdictions panel renders a stub
+     *  message and suppresses the Edit pencil for those role IDs. */
+    public isDetailUserAdmin(detail: PersonDetailDto): boolean {
+        return detail.RoleID === RoleEnum.Admin || detail.RoleID === RoleEnum.SitkaAdmin;
+    }
+
     public isWorking = signal(false);
 
     ngOnInit(): void {

--- a/Neptune.Web/src/app/shared/components/header-nav/header-nav.component.html
+++ b/Neptune.Web/src/app/shared/components/header-nav/header-nav.component.html
@@ -82,7 +82,7 @@
                     </span>
                 </a>
                 <div #userToggle class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-                    <a [routerLink]="['/users', currentUser.PersonID]" class="dropdown-item">My Profile</a>
+                    <a [routerLink]="['/users', currentUser.PersonID]" class="dropdown-item">Account</a>
                     <a href="javascript:void(0);" (click)="logout()" class="dropdown-item"> Sign Out </a>
                 </div>
             </li>


### PR DESCRIPTION
## Summary

Round 3 rework for NPT-999 (Migrate Users Mgmt + Request Support). KE 5/20/26 follow-ups on top of round 2:

### Assigned Jurisdictions panel — admin viewed user
When the user being viewed has `RoleID = Admin` or `SitkaAdmin`, the panel renders *"Administrators are by definition assigned to manage all Jurisdictions."* in place of the assignment list, and the card-header Edit pencil is suppressed. Admins implicitly manage every jurisdiction so the explicit assignment list is meaningless. New `isDetailUserAdmin(detail)` helper checks the role of the viewed user, distinct from `isAdmin()` which checks the viewer.

### Users list lockdown — Jurisdiction users
- `/users` list route now has `canActivate: [authGuardFn, ManagerOnlyGuard]`. Non-admin users redirect to `/` with an unauthorized alert. They reach their own profile via the Welcome dropdown's Account link (renamed below).
- The "Back to Users List" breadcrumb on `/users/:personID` is wrapped in `@if (isAdmin())` so jurisdiction users on their own profile don't see a link they couldn't use.

### Welcome dropdown copy
"My Profile" link renamed to **Account** per KE's terminology preference.

### Field Definition Edit page — zoneless CD fix
The edit page required a stray click before the form rendered. Under zoneless change detection, mutating `this.fieldDefinition = …` inside the `.subscribe()` callback doesn't mark the view dirty — the `@if (fieldDefinition)` branch only re-evaluated on the next user-triggered tick. Calling `this.cdr.detectChanges()` right after each assignment (next, error, and the NaN-id fallback) forces the editor to render as soon as the GET resolves.

## Test plan

- [ ] As a SitkaAdmin, view another SitkaAdmin's profile → Assigned Jurisdictions panel reads "Administrators are by definition assigned to manage all Jurisdictions." and the Edit pencil is hidden.
- [ ] As a SitkaAdmin, view a JurisdictionEditor's profile → panel still shows the assignment list + Edit pencil.
- [ ] As a JurisdictionEditor, navigate directly to `/users` → redirected to `/` with an unauthorized alert.
- [ ] As a JurisdictionEditor, click the Welcome dropdown → **Account** → lands on `/users/{ownPersonID}` and the "Back to Users List" link is not shown.
- [ ] As an admin, click any field-definition label in `/labels-and-definitions` → edit page loads **immediately**, no click required.
