### PR TITLE
NPT-1063: Annual Report rework — Recorded Acres header, number filters, comments width

### DIFF
--- a/Neptune.Web/src/app/pages/wqmp-annual-report/wqmp-annual-report.component.ts
+++ b/Neptune.Web/src/app/pages/wqmp-annual-report/wqmp-annual-report.component.ts
@@ -132,7 +132,7 @@ export class WqmpAnnualReportComponent implements OnInit {
             this.utility.createBasicColumnDef("Priority", "Priority", { CustomDropdownFilterField: "Priority" }),
             this.utility.createBasicColumnDef("Land Use", "LandUse", { CustomDropdownFilterField: "LandUse" }),
             this.utility.createBasicColumnDef("Hydrologic Subarea", "HydrologicSubareaName", { CustomDropdownFilterField: "HydrologicSubareaName" }),
-            this.utility.createDecimalColumnDef("Acres (user-entered)", "RecordedWQMPAreaInAcres", { DecimalPlacesToDisplay: 2 }),
+            this.utility.createDecimalColumnDef("Recorded Acres", "RecordedWQMPAreaInAcres", { DecimalPlacesToDisplay: 2 }),
             this.utility.createDateColumnDef("Date Approved", "ApprovalDate", "shortDate"),
         ];
     }
@@ -145,10 +145,10 @@ export class WqmpAnnualReportComponent implements OnInit {
             this.utility.createBasicColumnDef("WQMP Status at End of Period", "WaterQualityManagementPlanVerifyStatusName", {
                 CustomDropdownFilterField: "WaterQualityManagementPlanVerifyStatusName",
             }),
-            this.utility.createBasicColumnDef("# of BMPs", "NumberOfBMPs"),
-            this.utility.createBasicColumnDef("BMPs Adequate", "NumberOfBMPsAdequate"),
-            this.utility.createBasicColumnDef("BMPs Deficient", "NumberOfBMPsDeficient"),
-            this.utility.createBasicColumnDef("WQMP O&M Verification Comments", "WQMPVerificationComments"),
+            this.utility.createDecimalColumnDef("# of BMPs", "NumberOfBMPs", { DecimalPlacesToDisplay: 0 }),
+            this.utility.createDecimalColumnDef("BMPs Adequate", "NumberOfBMPsAdequate", { DecimalPlacesToDisplay: 0 }),
+            this.utility.createDecimalColumnDef("BMPs Deficient", "NumberOfBMPsDeficient", { DecimalPlacesToDisplay: 0 }),
+            this.utility.createBasicColumnDef("WQMP O&M Verification Comments", "WQMPVerificationComments", { MaxWidth: 400 }),
         ];
     }
 }


### PR DESCRIPTION
## Summary
- Renamed Grid 1's Acres column header from "Acres (user-entered)" to "Recorded Acres" to match the AC.
- Switched Grid 2's three BMP-count columns (`# of BMPs`, `BMPs Adequate`, `BMPs Deficient`) to `createDecimalColumnDef` so they get `agNumberColumnFilter` instead of the default text filter.
- Constrained the O&M Verification Comments column to `MaxWidth: 400` so it stops dominating the grid.

## Test plan
- [ ] Open `/water-quality-management-plans/annual-report`; Grid 1's Recorded Acres column header reads "Recorded Acres".
- [ ] Each of Grid 2's three count column filter menus shows the number filter UI (`=`, `>`, `<`, etc.).
- [ ] Setting `> 9` on `# of BMPs` filters numerically (e.g., 10 passes, 2 does not).
- [ ] Grid 2 layout no longer blows out — comments column is constrained, long text truncates with hover tooltip.
- [ ] CSV download still exports full content (width is display-only).