### PR TITLE
NPT-1064: Rework — anonymous/unassigned nav prune, local-time Last Updated, Overlap col width

### DIFF
--- a/Neptune.Web/src/app/pages/delineation/delineation-reconciliation-report/delineation-reconciliation-report.component.html
+++ b/Neptune.Web/src/app/pages/delineation/delineation-reconciliation-report/delineation-reconciliation-report.component.html
@@ -8,7 +8,7 @@
         <div class="report-meta">
             <em
                 >Regional Subbasins last updated on:
-                {{ ctx.RegionalSubbasinsLastUpdated | date: "MM/dd/yyyy" : "+0000" }}</em
+                {{ ctx.RegionalSubbasinsLastUpdated | date: "MM/dd/yyyy h:mm a" }}</em
             >
             @if (ctx.CallerIsAdministrator) {
                 <button class="btn btn-primary" (click)="onCheckForDiscrepancies()" [disabled]="isEnqueueing">

--- a/Neptune.Web/src/app/pages/delineation/delineation-reconciliation-report/delineation-reconciliation-report.component.ts
+++ b/Neptune.Web/src/app/pages/delineation/delineation-reconciliation-report/delineation-reconciliation-report.component.ts
@@ -169,6 +169,7 @@ export class DelineationReconciliationReportComponent implements OnInit {
                 DecimalPlacesToDisplay: 2,
                 FieldDefinitionType: "Area",
                 FieldDefinitionLabelOverride: "Area of Overlap (ac)",
+                Width: 180,
             }),
             this.utility.createMultiLinkColumnDef("Overlapping Delineations", "OverlappingDelineations", "TreatmentBMPID", "TreatmentBMPName", {
                 InRouterLink: "../../treatment-bmps/",

--- a/Neptune.Web/src/app/pages/site-layout/site-layout.component.html
+++ b/Neptune.Web/src/app/pages/site-layout/site-layout.component.html
@@ -1,6 +1,7 @@
 <header class="site-header">
     <header-nav moduleTitle="Inventory Module"></header-nav>
     <nav class="site-nav">
+        @let restrictedNav = isCurrentUserAnonymousOrUnassigned();
         <div style="width: 100%">
             <ul class="site-nav__links site-nav__main">
                 <!-- BMP Inventory Dropdown -->
@@ -11,20 +12,20 @@
                              items (Find a BMP, View All BMPs, Water Quality Management Plans).
                              The rest of BMP Inventory routes to pages they don't have permission
                              for in MVC — hiding them prevents click-bounce. -->
-                        @if (!isCurrentUserAnonymousOrUnassigned()) {
+                        @if (!restrictedNav) {
                             <li><a [routerLink]="['/jurisdictions']" class="dropdown-item">Jurisdictions</a></li>
                         }
                         <li><a [routerLink]="['/find-bmp']" class="dropdown-item">Find a BMP</a></li>
-                        @if (!isCurrentUserAnonymousOrUnassigned()) {
+                        @if (!restrictedNav) {
                             <li><a [routerLink]="['/modeling-parameters']" class="dropdown-item">Modeling Parameters</a></li>
                         }
                         <li><a [routerLink]="['/treatment-bmps']" class="dropdown-item">View All BMPs</a></li>
-                        @if (!isCurrentUserAnonymousOrUnassigned()) {
+                        @if (!restrictedNav) {
                             <li><a [routerLink]="['/latest-bmp-assessments']" class="dropdown-item">View Latest BMP Assessments</a></li>
                             <li><a [routerLink]="['/field-records']" class="dropdown-item">View All Field Records</a></li>
                         }
                         <li><a [routerLink]="['/water-quality-management-plans']" class="dropdown-item">Water Quality Management Plans</a></li>
-                        @if (!isCurrentUserAnonymousOrUnassigned()) {
+                        @if (!restrictedNav) {
                             <li><a [routerLink]="['/water-quality-management-plan-verifications']" class="dropdown-item">WQMP O&amp;M Verifications</a></li>
                             <li><a [routerLink]="['/wqmp-annual-report']" class="dropdown-item">WQMP Annual Report</a></li>
                             <li><a [routerLink]="['/parcels']" class="dropdown-item">Parcels</a></li>
@@ -46,7 +47,7 @@
                      anything they have permission for (MVC gates the corresponding controllers
                      to JurisdictionEditor+ or Admin). Find a BMP / View All BMPs / WQMP List
                      inside BMP Inventory above stay visible to satisfy the public list view. -->
-                @if (!isCurrentUserAnonymousOrUnassigned()) {
+                @if (!restrictedNav) {
                     <!-- Dashboard -->
                     <li class="nav-item" routerLinkActive="active">
                         <a [routerLink]="['/dashboard']" class="nav-link">Dashboard</a>

--- a/Neptune.Web/src/app/pages/site-layout/site-layout.component.html
+++ b/Neptune.Web/src/app/pages/site-layout/site-layout.component.html
@@ -7,19 +7,32 @@
                 <li class="nav-item dropdown" routerLinkActive="active">
                     <a href="javascript:void(0);" [dropdownToggle]="bmpMenu" class="nav-link dropdown-toggle"> BMP Inventory <icon icon="AngleDown"></icon> </a>
                     <ul #bmpMenu class="dropdown-menu">
-                        <li><a [routerLink]="['/jurisdictions']" class="dropdown-item">Jurisdictions</a></li>
+                        <!-- NPT-1064: Anonymous + Unassigned users see only the publicly-relevant
+                             items (Find a BMP, View All BMPs, Water Quality Management Plans).
+                             The rest of BMP Inventory routes to pages they don't have permission
+                             for in MVC — hiding them prevents click-bounce. -->
+                        @if (!isCurrentUserAnonymousOrUnassigned()) {
+                            <li><a [routerLink]="['/jurisdictions']" class="dropdown-item">Jurisdictions</a></li>
+                        }
                         <li><a [routerLink]="['/find-bmp']" class="dropdown-item">Find a BMP</a></li>
-                        <li><a [routerLink]="['/modeling-parameters']" class="dropdown-item">Modeling Parameters</a></li>
+                        @if (!isCurrentUserAnonymousOrUnassigned()) {
+                            <li><a [routerLink]="['/modeling-parameters']" class="dropdown-item">Modeling Parameters</a></li>
+                        }
                         <li><a [routerLink]="['/treatment-bmps']" class="dropdown-item">View All BMPs</a></li>
-                        <li><a [routerLink]="['/latest-bmp-assessments']" class="dropdown-item">View Latest BMP Assessments</a></li>
-                        <li><a [routerLink]="['/field-records']" class="dropdown-item">View All Field Records</a></li>
+                        @if (!isCurrentUserAnonymousOrUnassigned()) {
+                            <li><a [routerLink]="['/latest-bmp-assessments']" class="dropdown-item">View Latest BMP Assessments</a></li>
+                            <li><a [routerLink]="['/field-records']" class="dropdown-item">View All Field Records</a></li>
+                        }
                         <li><a [routerLink]="['/water-quality-management-plans']" class="dropdown-item">Water Quality Management Plans</a></li>
-                        <li><a [routerLink]="['/water-quality-management-plan-verifications']" class="dropdown-item">WQMP O&amp;M Verifications</a></li>
-                        <li><a [routerLink]="['/wqmp-annual-report']" class="dropdown-item">WQMP Annual Report</a></li>
-                        <li><a [routerLink]="['/parcels']" class="dropdown-item">Parcels</a></li>
+                        @if (!isCurrentUserAnonymousOrUnassigned()) {
+                            <li><a [routerLink]="['/water-quality-management-plan-verifications']" class="dropdown-item">WQMP O&amp;M Verifications</a></li>
+                            <li><a [routerLink]="['/wqmp-annual-report']" class="dropdown-item">WQMP Annual Report</a></li>
+                            <li><a [routerLink]="['/parcels']" class="dropdown-item">Parcels</a></li>
+                        }
                     </ul>
                 </li>
-                <!-- Program Info Dropdown -->
+                <!-- Program Info pages have no feature attribute in MVC — anonymous and
+                     Unassigned users can view them. Always visible. -->
                 <li class="nav-item dropdown" routerLinkActive="active">
                     <a href="javascript:void(0);" [dropdownToggle]="programInfoMenu" class="nav-link dropdown-toggle"> Program Info <icon icon="AngleDown"></icon> </a>
                     <ul #programInfoMenu class="dropdown-menu">
@@ -28,44 +41,51 @@
                         <li><a [routerLink]="['/funding-sources']" class="dropdown-item">Funding Sources</a></li>
                     </ul>
                 </li>
-                <!-- Dashboard -->
-                <li class="nav-item" routerLinkActive="active">
-                    <a [routerLink]="['/dashboard']" class="nav-link">Dashboard</a>
-                </li>
-                <!-- Delineation Dropdown -->
-                <li class="nav-item dropdown" routerLinkActive="active">
-                    <a href="javascript:void(0);" [dropdownToggle]="delineationMenu" class="nav-link dropdown-toggle"> Delineation <icon icon="AngleDown"></icon> </a>
-                    <ul #delineationMenu class="dropdown-menu">
-                        <li><a [routerLink]="['/delineation/delineation-map']" class="dropdown-item">Delineation Map</a></li>
-                        <li><a [routerLink]="['/delineation/delineation-reconciliation-report']" class="dropdown-item">Delineation Reconciliation Report</a></li>
-                    </ul>
-                </li>
-                <!-- Data Hub -->
-                <li class="nav-item" routerLinkActive="active">
-                    <a [routerLink]="['/data-hub']" class="nav-link">Data Hub</a>
-                </li>
-                <!-- Manage Dropdown -->
-                <li class="nav-item dropdown" routerLinkActive="active">
-                    <a href="javascript:void(0);" [dropdownToggle]="manageMenu" class="nav-link dropdown-toggle"> Manage <icon icon="AngleDown"></icon> </a>
-                    <ul #manageMenu class="dropdown-menu">
-                        <li><a [routerLink]="['/manage/homepage-configuration']" class="dropdown-item">Homepage Configuration</a></li>
-                        <li><a [routerLink]="['/manage/page-content']" class="dropdown-item">Page Content</a></li>
-                        <li><a [routerLink]="['/labels-and-definitions']" class="dropdown-item">Custom Labels & Definitions</a></li>
-                        <li><hr class="dropdown-divider" /></li>
-                        <li><a [routerLink]="['/users']" class="dropdown-item">Users</a></li>
-                        <li><a [routerLink]="['/organizations']" class="dropdown-item">Organizations</a></li>
-                        <li><hr class="dropdown-divider" /></li>
-                        <li><a [routerLink]="['/manage/custom-attributes']" class="dropdown-item">Custom Attributes</a></li>
-                        <li><a [routerLink]="['/manage/treatment-bmp-types']" class="dropdown-item">Treatment BMP Types</a></li>
-                        <li><a [routerLink]="['/manage/observation-types']" class="dropdown-item">Observation Types</a></li>
-                        <li><hr class="dropdown-divider" /></li>
-                        <li><a [routerLink]="['/load-generating-units']" class="dropdown-item">Load Generating Units</a></li>
-                        <li><a [routerLink]="['/hru-characteristics']" class="dropdown-item">HRU Characteristics</a></li>
-                        <li><a [routerLink]="['/regional-subbasins']" class="dropdown-item">Regional Subbasins</a></li>
-                        <li><a [routerLink]="['/delineation/revision-requests']" class="dropdown-item">Regional Subbasin Revision Requests</a></li>
-                        <li><a [routerLink]="['/manage/wqmp-lgu-audit']" class="dropdown-item">Water Quality Management Plan LGU Audit</a></li>
-                    </ul>
-                </li>
+                <!-- NPT-1064: Dashboard / Delineation / Data Hub / Manage are hidden for
+                     anonymous and Unassigned users — none of those pages let them do
+                     anything they have permission for (MVC gates the corresponding controllers
+                     to JurisdictionEditor+ or Admin). Find a BMP / View All BMPs / WQMP List
+                     inside BMP Inventory above stay visible to satisfy the public list view. -->
+                @if (!isCurrentUserAnonymousOrUnassigned()) {
+                    <!-- Dashboard -->
+                    <li class="nav-item" routerLinkActive="active">
+                        <a [routerLink]="['/dashboard']" class="nav-link">Dashboard</a>
+                    </li>
+                    <!-- Delineation Dropdown -->
+                    <li class="nav-item dropdown" routerLinkActive="active">
+                        <a href="javascript:void(0);" [dropdownToggle]="delineationMenu" class="nav-link dropdown-toggle"> Delineation <icon icon="AngleDown"></icon> </a>
+                        <ul #delineationMenu class="dropdown-menu">
+                            <li><a [routerLink]="['/delineation/delineation-map']" class="dropdown-item">Delineation Map</a></li>
+                            <li><a [routerLink]="['/delineation/delineation-reconciliation-report']" class="dropdown-item">Delineation Reconciliation Report</a></li>
+                        </ul>
+                    </li>
+                    <!-- Data Hub -->
+                    <li class="nav-item" routerLinkActive="active">
+                        <a [routerLink]="['/data-hub']" class="nav-link">Data Hub</a>
+                    </li>
+                    <!-- Manage Dropdown -->
+                    <li class="nav-item dropdown" routerLinkActive="active">
+                        <a href="javascript:void(0);" [dropdownToggle]="manageMenu" class="nav-link dropdown-toggle"> Manage <icon icon="AngleDown"></icon> </a>
+                        <ul #manageMenu class="dropdown-menu">
+                            <li><a [routerLink]="['/manage/homepage-configuration']" class="dropdown-item">Homepage Configuration</a></li>
+                            <li><a [routerLink]="['/manage/page-content']" class="dropdown-item">Page Content</a></li>
+                            <li><a [routerLink]="['/labels-and-definitions']" class="dropdown-item">Custom Labels & Definitions</a></li>
+                            <li><hr class="dropdown-divider" /></li>
+                            <li><a [routerLink]="['/users']" class="dropdown-item">Users</a></li>
+                            <li><a [routerLink]="['/organizations']" class="dropdown-item">Organizations</a></li>
+                            <li><hr class="dropdown-divider" /></li>
+                            <li><a [routerLink]="['/manage/custom-attributes']" class="dropdown-item">Custom Attributes</a></li>
+                            <li><a [routerLink]="['/manage/treatment-bmp-types']" class="dropdown-item">Treatment BMP Types</a></li>
+                            <li><a [routerLink]="['/manage/observation-types']" class="dropdown-item">Observation Types</a></li>
+                            <li><hr class="dropdown-divider" /></li>
+                            <li><a [routerLink]="['/load-generating-units']" class="dropdown-item">Load Generating Units</a></li>
+                            <li><a [routerLink]="['/hru-characteristics']" class="dropdown-item">HRU Characteristics</a></li>
+                            <li><a [routerLink]="['/regional-subbasins']" class="dropdown-item">Regional Subbasins</a></li>
+                            <li><a [routerLink]="['/delineation/revision-requests']" class="dropdown-item">Regional Subbasin Revision Requests</a></li>
+                            <li><a [routerLink]="['/manage/wqmp-lgu-audit']" class="dropdown-item">Water Quality Management Plan LGU Audit</a></li>
+                        </ul>
+                    </li>
+                }
             </ul>
         </div>
     </nav>

--- a/Neptune.Web/src/app/pages/site-layout/site-layout.component.ts
+++ b/Neptune.Web/src/app/pages/site-layout/site-layout.component.ts
@@ -43,6 +43,14 @@ export class SiteLayoutComponent implements OnInit {
         return !this.authenticationService.isUserUnassigned(currentUser);
     }
 
+    // NPT-1064: synchronous gate for nav items. Anonymous and Unassigned users see only the
+    // public-facing list pages (WQMP List + BMP List + WQMP Map + Find a BMP); everything else
+    // in the top nav routes to pages they don't have permission to access. Mirrors the MVC
+    // behavior where each nav item is gated by its controller's feature attribute.
+    public isCurrentUserAnonymousOrUnassigned(): boolean {
+        return this.authenticationService.isCurrentUserAnonymousOrUnassigned();
+    }
+
     public isOCTAGrantReviewer(): boolean {
         return this.authenticationService.isCurrentUserAnOCTAGrantReviewer();
     }

--- a/Neptune.Web/src/app/services/authentication.service.ts
+++ b/Neptune.Web/src/app/services/authentication.service.ts
@@ -237,8 +237,13 @@ export class AuthenticationService {
     // and Unassigned (logged in, no role) users share the same accessible surface area —
     // only AnonymousUnclassifiedFeature-allowed pages on the MVC side. The SPA uses this
     // to hide top-nav links to pages those users would just bounce off of anyway.
+    //
+    // Checking `!this.currentUser` (instead of `!isAuthenticated()`) covers both anonymous
+    // visitors AND the brief race between Auth0 setting `claimsUser` and the subsequent
+    // /people/me round-trip populating `currentUser` — during that window an Unassigned
+    // user would otherwise see the full nav and could click into a route that 403s.
     public isCurrentUserAnonymousOrUnassigned(): boolean {
-        return !this.isAuthenticated() || this.isCurrentUserUnassigned();
+        return !this.currentUser || this.isCurrentUserUnassigned();
     }
 
     public isUserUnassigned(user: PersonDto): boolean {

--- a/Neptune.Web/src/app/services/authentication.service.ts
+++ b/Neptune.Web/src/app/services/authentication.service.ts
@@ -229,6 +229,18 @@ export class AuthenticationService {
         );
     }
 
+    public isCurrentUserUnassigned(): boolean {
+        return this.isUserUnassigned(this.currentUser);
+    }
+
+    // NPT-1064: nav-visibility check that matches MVC behavior. Anonymous (not logged in)
+    // and Unassigned (logged in, no role) users share the same accessible surface area —
+    // only AnonymousUnclassifiedFeature-allowed pages on the MVC side. The SPA uses this
+    // to hide top-nav links to pages those users would just bounce off of anyway.
+    public isCurrentUserAnonymousOrUnassigned(): boolean {
+        return !this.isAuthenticated() || this.isCurrentUserUnassigned();
+    }
+
     public isUserUnassigned(user: PersonDto): boolean {
         const role = user ? user.RoleID : null;
         return role === RoleEnum.Unassigned;


### PR DESCRIPTION
## Summary
- **Nav prune for anonymous + unassigned users.** Added `isCurrentUserAnonymousOrUnassigned()` on `AuthenticationService` mirroring how MVC's `[AnonymousUnclassifiedFeature]` opens only select pages. Hides Modeling Parameters / View Latest BMP Assessments / View All Field Records / Jurisdictions / WQMP O&M Verifications / WQMP Annual Report / Parcels inside the BMP Inventory dropdown, plus the Dashboard / Delineation / Data Hub / Manage top-level items. Anonymous/Unassigned visitors now see only Find a BMP, View All BMPs, Water Quality Management Plans (in BMP Inventory) and the Program Info dropdown (those pages have no feature attribute in MVC).
- **Last Updated date uses local time.** Dropped the `"+0000"` UTC override on the Regional Subbasins last-updated label so it matches MVC Data Hub's local rendering, and added a time component (`MM/dd/yyyy h:mm a`).
- **Area of Overlap column width.** Set explicit `Width: 180` so the field-def label "Area of Overlap (ac)" stops getting ellipsis-truncated by the default ag-grid column width.

## Test plan
- [ ] Anonymous (logged out) visit: nav shows only BMP Inventory (with Find a BMP, View All BMPs, Water Quality Management Plans) and Program Info.
- [ ] Login as Unassigned: same nav as anonymous.
- [ ] Login as JurisdictionEditor / JurisdictionManager / Admin / SitkaAdmin: full nav restored — regression check.
- [ ] Open `/delineation/delineation-reconciliation-report`: "Regional Subbasins last updated on:" shows a local-time datetime matching the MVC Data Hub.
- [ ] On the same page, Grid 2 "Area of Overlap (ac)" header reads fully (no ellipsis), with the field-def `(?)` icon.