### PR TITLE
NPT-1061: Treatment BMP grid polish (Yes/No, picklist filters, Notes width)

### DIFF
--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
@@ -92,28 +92,39 @@ export class TreatmentBmpsComponent {
             this.utilityFunctionsService.createLinkColumnDef("Jurisdiction", "StormwaterJurisdictionName", "StormwaterJurisdictionID", {
                 InRouterLink: "/jurisdictions/",
                 FieldDefinitionType: "Jurisdiction",
+                UseCustomDropdownFilter: true,
             }),
-            this.utilityFunctionsService.createBasicColumnDef("Owner Organization", "OwnerOrganizationName"),
+            this.utilityFunctionsService.createBasicColumnDef("Owner Organization", "OwnerOrganizationName", { UseCustomDropdownFilter: true }),
             this.utilityFunctionsService.createBasicColumnDef("Type", "TreatmentBMPTypeName", {
                 FieldDefinitionType: "TreatmentBMPType",
                 FieldDefinitionLabelOverride: "Type",
+                UseCustomDropdownFilter: true,
             }),
             this.utilityFunctionsService.createBasicColumnDef("Year Built", "YearBuilt"),
-            this.utilityFunctionsService.createBasicColumnDef("Notes", "Notes"),
             this.utilityFunctionsService.createDateColumnDef("Last Assessment Date", "LatestAssessmentDate", "MM/dd/yyyy"),
             this.utilityFunctionsService.createBasicColumnDef("Last Assessed Score", "LatestAssessmentScore"),
             this.utilityFunctionsService.createBasicColumnDef("# of Assessments", "NumberOfAssessments"),
             this.utilityFunctionsService.createDateColumnDef("Last Maintenance Date", "LatestMaintenanceDate", "MM/dd/yyyy"),
             this.utilityFunctionsService.createBasicColumnDef("# of Maintenance Events", "NumberOfMaintenanceRecords"),
-            this.utilityFunctionsService.createBasicColumnDef("Benchmark and Threshold Set?", "BenchmarkAndThresholdSet"),
-            this.utilityFunctionsService.createBasicColumnDef("Required Lifespan of Installation", "TreatmentBMPLifespanTypeDisplayName"),
+            this.utilityFunctionsService.createBooleanColumnDef("Benchmark and Threshold Set?", "BenchmarkAndThresholdSet"),
+            this.utilityFunctionsService.createBasicColumnDef("Required Lifespan of Installation", "TreatmentBMPLifespanTypeDisplayName", { UseCustomDropdownFilter: true }),
             this.utilityFunctionsService.createBasicColumnDef("Lifespan End Date (if Fixed End Date)", "TreatmentBMPLifespanEndDate"),
             this.utilityFunctionsService.createBasicColumnDef("Required Field Visits/Year", "RequiredFieldVisitsPerYear"),
             this.utilityFunctionsService.createBasicColumnDef("Required Post-Storm Field Visits/Year", "RequiredPostStormFieldVisitsPerYear"),
-            this.utilityFunctionsService.createBasicColumnDef("Sizing Basis", "SizingBasisTypeDisplayName"),
-            this.utilityFunctionsService.createBasicColumnDef("Trash Capture Status", "TrashCaptureStatusTypeDisplayName"),
+            this.utilityFunctionsService.createBasicColumnDef("Sizing Basis", "SizingBasisTypeDisplayName", { UseCustomDropdownFilter: true }),
+            this.utilityFunctionsService.createBasicColumnDef("Trash Capture Status", "TrashCaptureStatusTypeDisplayName", { UseCustomDropdownFilter: true }),
             this.utilityFunctionsService.createBasicColumnDef("Trash Capture Effectiveness (%)", "TrashCaptureEffectiveness"),
-            this.utilityFunctionsService.createBasicColumnDef("Delineation Type", "DelineationTypeDisplayName"),
+            this.utilityFunctionsService.createBasicColumnDef("Delineation Type", "DelineationTypeDisplayName", { UseCustomDropdownFilter: true }),
+            // NPT-1061: Notes was previously mid-grid and dominated visible width on rows with
+            // long entries. Moved to the far right + capped at 300px with wrap so long notes flow
+            // vertically instead of pushing every other column off-screen.
+            {
+                ...this.utilityFunctionsService.createBasicColumnDef("Notes", "Notes"),
+                maxWidth: 300,
+                wrapText: true,
+                autoHeight: true,
+                cellStyle: { whiteSpace: "normal", lineHeight: "1.3" },
+            },
         ];
         this.treatmentBmps$ = this.treatmentBMPService
             .listTreatmentBMP()


### PR DESCRIPTION
## Summary
- **Benchmark and Threshold Set?** column now uses `createBooleanColumnDef`. The cell renders **Yes / No**, the column filter dropdown lists Yes/No options, and the CSV download carries Yes/No values — all driven by the existing `booleanValueGetter` helper that the export path already honors.
- Picklist (CustomDropdownFilter) filters added to seven categorical columns: Jurisdiction, Owner Organization, Type, Required Lifespan of Installation, Sizing Basis, Trash Capture Status, Delineation Type.
- **Notes** column moved from mid-grid to the far right and capped at 300px (`wrapText: true, autoHeight: true`) so long notes flow vertically instead of pushing every other column off-screen.

Jira item 1 (Funding Source detail page) was already complete from NPT-999 r2 — no work needed there.

## Test plan
- [ ] At `/treatment-bmps`, confirm the "Benchmark and Threshold Set?" cells render **Yes** / **No** (not `true`/`false`).
- [ ] Open that column's filter — the value list shows **Yes** / **No** options (not true/false). Selecting either narrows the rows correctly.
- [ ] Export CSV — open the file; the Benchmark column shows Yes/No values.
- [ ] Click each of the seven picklist columns' header filters — confirm the UI is a dropdown of distinct values (with multi-select checkboxes), not a free-text search.
- [ ] Confirm the Notes column is now the rightmost; rows with long notes wrap to multiple lines; the column doesn't dominate horizontal space.
- [ ] (Sanity) `/funding-sources/<id>` still loads correctly.