### PR TITLE
NPT-981: Delineation Map rework (KE 5/26/26 QA pass)

### DIFF
--- a/Neptune.QGISAPI/Controllers/QgisRunnerController.cs
+++ b/Neptune.QGISAPI/Controllers/QgisRunnerController.cs
@@ -141,6 +141,28 @@ public class QgisRunnerController : ControllerBase
             }
         }
 
+        // NPT-981: the delineation input set is snapshotted at the top of this action, but the QGIS
+        // overlay above runs long enough that a user can delete a delineation on the Delineation Map
+        // before we reach this insert. That would leave an LGU pointing at a now-deleted DelineationID
+        // and trip FK_LoadGeneratingUnit_Delineation_DelineationID. Drop any orphaned rows just before
+        // the insert (a null DelineationID is valid — those are regional-subbasin-only LGUs).
+        var referencedDelineationIDs = loadGeneratingUnits
+            .Where(x => x.DelineationID.HasValue)
+            .Select(x => x.DelineationID!.Value)
+            .Distinct()
+            .ToList();
+        if (referencedDelineationIDs.Any())
+        {
+            var existingDelineationIDs = (await _dbContext.Delineations.AsNoTracking()
+                    .Where(x => referencedDelineationIDs.Contains(x.DelineationID))
+                    .Select(x => x.DelineationID)
+                    .ToListAsync())
+                .ToHashSet();
+            loadGeneratingUnits = loadGeneratingUnits
+                .Where(x => !x.DelineationID.HasValue || existingDelineationIDs.Contains(x.DelineationID.Value))
+                .ToList();
+        }
+
         if (loadGeneratingUnits.Any())
         {
             await _dbContext.LoadGeneratingUnits.AddRangeAsync(loadGeneratingUnits);

--- a/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.html
+++ b/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.html
@@ -31,8 +31,11 @@
                             <dt>Type</dt>
                             <dd>{{ bmp.TreatmentBMPTypeName }}</dd>
                         </dl>
+                        @if (mode === "idle" && !choosingFlowType()) {
+                            <button type="button" class="btn btn-sm btn-primary" (click)="startEditLocation()">Edit Location</button>
+                        }
 
-                        <h4 class="panel-section-header">Selected Delineation</h4>
+                        <h4 class="panel-section-header panel-section-header--divided">Selected Delineation</h4>
                         <dl class="kv">
                             <dt>Type</dt>
                             <dd>{{ delineationTypeName() }}</dd>
@@ -51,16 +54,14 @@
                         @if (mode === "idle") {
                             @if (delineation && !choosingFlowType()) {
                                 <div class="inline-actions">
-                                    <button type="button" class="btn btn-sm btn-primary" (click)="openFlowTypeChooser()">Edit Delineation</button>
+                                    <button type="button" class="btn btn-sm btn-primary" (click)="openFlowTypeChooser()">Edit</button>
                                     <button type="button" class="btn btn-sm btn-danger icon-btn" [disabled]="saving$ | async" (click)="deleteDelineation()" title="Delete Delineation">
                                         <i class="fa fa-trash"></i>
                                     </button>
+                                    @if (delineation.DelineationTypeID === DelineationTypeEnum.Centralized) {
+                                        <a class="btn btn-sm btn-primary" [routerLink]="requestRevisionUrl()">Request Revision</a>
+                                    }
                                 </div>
-                                @if (delineation.DelineationTypeID === DelineationTypeEnum.Centralized) {
-                                    <a class="btn btn-sm btn-primary action-btn request-revision-btn" [routerLink]="requestRevisionUrl()">Request Revision</a>
-                                }
-                                <hr />
-                                <button type="button" class="btn btn-sm btn-primary action-btn" (click)="startEditLocation()">Edit BMP Location</button>
                             } @else {
                                 <!-- NPT-981 r3 (KE): flow-type chooser mirrors the legacy "Delineate Drainage
                                      Area" control — radio select + a single Delineate button. Shown directly
@@ -87,10 +88,6 @@
                                         <button type="button" class="btn btn-sm btn-secondary" (click)="closeFlowTypeChooser()">Cancel</button>
                                     }
                                 </div>
-                                @if (!choosingFlowType()) {
-                                    <hr />
-                                    <button type="button" class="btn btn-sm btn-primary action-btn" (click)="startEditLocation()">Edit BMP Location</button>
-                                }
                             }
                         } @else {
                             <hr />

--- a/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.html
+++ b/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.html
@@ -49,9 +49,9 @@
                         </dl>
 
                         @if (mode === "idle") {
-                            @if (delineation) {
+                            @if (delineation && !choosingFlowType()) {
                                 <div class="inline-actions">
-                                    <button type="button" class="btn btn-sm btn-primary" (click)="editExistingDelineation()">Edit</button>
+                                    <button type="button" class="btn btn-sm btn-primary" (click)="openFlowTypeChooser()">Edit Delineation</button>
                                     <button type="button" class="btn btn-sm btn-danger icon-btn" [disabled]="saving$ | async" (click)="deleteDelineation()" title="Delete Delineation">
                                         <i class="fa fa-trash"></i>
                                     </button>
@@ -59,26 +59,45 @@
                                 @if (delineation.DelineationTypeID === DelineationTypeEnum.Centralized) {
                                     <a class="btn btn-sm btn-primary action-btn request-revision-btn" [routerLink]="requestRevisionUrl()">Request Revision</a>
                                 }
+                                <hr />
+                                <button type="button" class="btn btn-sm btn-primary action-btn" (click)="startEditLocation()">Edit BMP Location</button>
                             } @else {
-                                <p class="explanatory">
-                                    <strong>Distributed</strong> BMPs receive only local surface flow — draw the drainage area on the map.<br />
-                                    <strong>Centralized</strong> BMPs also receive piped flow — we'll trace the regional subbasin network for you.
-                                </p>
-                                <div class="stacked-actions">
-                                    <button type="button" class="btn btn-sm btn-primary" (click)="startEditDistributed()">Add Distributed Delineation</button>
-                                    <button type="button" class="btn btn-sm btn-primary" (click)="startEditCentralized()">Add Centralized Delineation</button>
+                                <!-- NPT-981 r3 (KE): flow-type chooser mirrors the legacy "Delineate Drainage
+                                     Area" control — radio select + a single Delineate button. Shown directly
+                                     when no delineation exists, or via "Edit Delineation" for an existing one
+                                     (where picking the other type switches it). Distributed → draw/edit
+                                     vertices; Centralized → trace the RSB network. -->
+                                <p class="chooser-step">Select the type of flow this BMP receives:</p>
+                                <div class="flow-options">
+                                    <label class="flow-option">
+                                        <input type="radio" name="flowType" [value]="DelineationTypeEnum.Distributed" [(ngModel)]="selectedFlowType" />
+                                        Receives Local Surface Flow Only (Distributed)
+                                    </label>
+                                    <label class="flow-option">
+                                        <input type="radio" name="flowType" [value]="DelineationTypeEnum.Centralized" [(ngModel)]="selectedFlowType" />
+                                        Receives Both Piped Flow and Local Surface Flow (Centralized)
+                                    </label>
                                 </div>
+                                @if (flowTypeHint()) {
+                                    <p class="chooser-hint">{{ flowTypeHint() }}</p>
+                                }
+                                <div class="inline-actions">
+                                    <button type="button" class="btn btn-sm btn-primary" [disabled]="!selectedFlowType" (click)="beginDelineate()">Delineate</button>
+                                    @if (choosingFlowType()) {
+                                        <button type="button" class="btn btn-sm btn-secondary" (click)="closeFlowTypeChooser()">Cancel</button>
+                                    }
+                                </div>
+                                @if (!choosingFlowType()) {
+                                    <hr />
+                                    <button type="button" class="btn btn-sm btn-primary action-btn" (click)="startEditLocation()">Edit BMP Location</button>
+                                }
                             }
-
-                            <hr />
-
-                            <button type="button" class="btn btn-sm btn-primary action-btn" (click)="startEditLocation()">Edit BMP Location</button>
                         } @else {
                             <hr />
                             <p class="edit-hint">
                                 @switch (mode) {
                                     @case ("editingDistributed") { Use the map tools to draw or edit the polygon, then save. }
-                                    @case ("editingCentralized") { Loaded upstream catchment. Adjust vertices if needed, then save. }
+                                    @case ("editingCentralized") { Traced the upstream catchment. Save to accept it, or Request Revision if the regional subbasin network needs a change. }
                                     @case ("editingLocation") { Drag the BMP marker or click anywhere on the map to relocate it, then Save. }
                                 }
                             </p>
@@ -86,6 +105,11 @@
                                 <button type="button" class="btn btn-sm btn-primary" [disabled]="saving$ | async" (click)="saveEdit()">Save</button>
                                 <button type="button" class="btn btn-sm btn-secondary" (click)="cancelEdit()">Cancel</button>
                             </div>
+                            @if (mode === "editingCentralized") {
+                                <!-- NPT-981 r3 (KE id-22): offer Request Revision during the trace, not only
+                                     after a centralized delineation already exists. -->
+                                <a class="btn btn-sm btn-primary action-btn request-revision-btn" [routerLink]="requestRevisionUrl()">Request Revision</a>
+                            }
                         }
                     } @else {
                         <p class="empty-hint">Click a Treatment BMP marker on the map to view details and actions.</p>

--- a/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.scss
+++ b/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.scss
@@ -69,13 +69,6 @@
     margin-top: $spacing-200;
 }
 
-.stacked-actions {
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-200;
-    margin-top: $spacing-200;
-}
-
 .action-btn {
     display: block;
     width: 100%;
@@ -84,12 +77,6 @@
 .icon-btn {
     padding-left: $spacing-200;
     padding-right: $spacing-200;
-}
-
-.explanatory {
-    font-size: $type-size-200;
-    color: $gray-700;
-    margin: 0 0 $spacing-200;
 }
 
 .request-revision-btn {
@@ -109,12 +96,55 @@
     margin: 0;
 }
 
+// NPT-981 r3: flow-type chooser (radio + Delineate), mirroring the legacy "Delineate Drainage
+// Area" control. Long option labels wrap cleanly in the narrow side panel.
+.chooser-step {
+    font-size: $type-size-200;
+    font-weight: 600;
+    margin: $spacing-200 0 $spacing-100;
+}
+
+.flow-options {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-100;
+}
+
+.flow-option {
+    display: flex;
+    align-items: flex-start;
+    gap: $spacing-100;
+    font-size: $type-size-200;
+    font-weight: 400;
+    margin: 0;
+    cursor: pointer;
+
+    input {
+        margin-top: 0.2rem;
+        flex-shrink: 0;
+    }
+}
+
+.chooser-hint {
+    font-size: $type-size-200;
+    color: $gray-700;
+    margin: $spacing-200 0 0;
+}
+
 hr {
     margin: $spacing-300 0;
 }
 
 .header-action {
     margin-left: $spacing-200;
+}
+
+// NPT-981 r3 (KE id-27): force the crosshair everywhere during Edit BMP Location, including on
+// top of the selected delineation's interactive SVG overlay (which otherwise imposes its own
+// cursor). Toggled via .location-edit-cursor on the leaflet container in startEditLocation.
+::ng-deep .leaflet-container.location-edit-cursor,
+::ng-deep .leaflet-container.location-edit-cursor .leaflet-interactive {
+    cursor: crosshair !important;
 }
 
 ::ng-deep .treatment-bmp-cluster {

--- a/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.scss
+++ b/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.scss
@@ -13,6 +13,12 @@
     &:first-child {
         margin-top: 0;
     }
+
+    // NPT-981 r3 (KE): visual divider between the Selected BMP and Selected Delineation sections.
+    &--divided {
+        border-top: 1px solid $gray-300;
+        padding-top: $spacing-300;
+    }
 }
 
 .kv {
@@ -65,6 +71,8 @@
 
 .inline-actions {
     display: flex;
+    flex-wrap: wrap;
+    align-items: center;
     gap: $spacing-200;
     margin-top: $spacing-200;
 }

--- a/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.ts
+++ b/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, signal } from "@angular/core";
+import { Component, OnInit, QueryList, signal, ViewChildren } from "@angular/core";
 import { ActivatedRoute, RouterLink } from "@angular/router";
 import { AsyncPipe } from "@angular/common";
 import { FormControl, FormsModule, ReactiveFormsModule } from "@angular/forms";
@@ -78,10 +78,19 @@ export class DelineationMapComponent implements OnInit {
     public layerControl: L.Control.Layers;
     public mapIsReady = false;
 
+    @ViewChildren(DelineationsLayerComponent) private delineationLayers!: QueryList<DelineationsLayerComponent>;
+
     public bmps: TreatmentBMPDelineationMapDto[] = [];
     public selectedBMP = signal<TreatmentBMPDelineationMapDto | null>(null);
     public selectedDelineation = signal<DelineationDto | null>(null);
     public editMode = signal<EditMode>("idle");
+    // NPT-981 r3 (KE): "Edit Delineation" on an existing delineation reopens the flow-type
+    // chooser (Distributed / Centralized) so the user can re-delineate OR switch the type —
+    // mirroring the legacy "Delineate Drainage Area" control (radio select + Delineate button).
+    public choosingFlowType = signal<boolean>(false);
+    // Bound to the chooser radios via ngModel. Null until the user picks, which keeps the
+    // Delineate button disabled (matches the legacy disabled-until-selected behavior).
+    public selectedFlowType: DelineationTypeEnum | null = null;
 
     private bmpsClusterLayer: any = null;
     private bmpMarkerByID: Map<number, L.Marker> = new Map();
@@ -134,6 +143,9 @@ export class DelineationMapComponent implements OnInit {
                 this.savingSubject.next(false);
                 this.alertService.pushAlert(new Alert(`Delineation marked ${isVerified ? "Verified" : "Provisional"}.`, AlertContext.Success, true));
                 this.reloadSelectedDelineation();
+                // Verified/Provisional are two separate WMS layers with status-based cql_filters;
+                // the row moves between them, so refresh both.
+                this.refreshDelineationLayers();
             },
             error: () => {
                 this.savingSubject.next(false);
@@ -180,6 +192,9 @@ export class DelineationMapComponent implements OnInit {
         }
         this.bmpMarkerByID.clear();
         this.bmpsClusterLayer = L.markerClusterGroup({
+            // NPT-981 r3 (KE id-7): suppress the blue convex-hull coverage polygon that markercluster
+            // draws on hover/click — KE found it confusing when clicking a clustered pin.
+            showCoverageOnHover: false,
             iconCreateFunction: (cluster: any) =>
                 L.divIcon({
                     html: `<div><span>${cluster.getChildCount()}</span></div>`,
@@ -191,12 +206,10 @@ export class DelineationMapComponent implements OnInit {
             if (!bmp.Latitude || !bmp.Longitude) {
                 continue;
             }
-            // NPT-981 r2: construct with draggable: true so Leaflet's _initInteraction
-            // builds the marker.dragging Handler when the cluster eventually exposes the
-            // marker on the map. Immediately disable on `add` so the marker is click-only
-            // outside edit mode; startEditLocation re-enables on demand.
-            const marker = L.marker([bmp.Latitude, bmp.Longitude], { icon: MarkerHelper.treatmentBMPMarker, draggable: true });
-            marker.on("add", () => marker.dragging?.disable());
+            // NPT-981 r3: BMP pins are click-to-select only. Relocating a BMP is done via a
+            // separate preview marker in startEditLocation (KE id-26), so the cluster marker
+            // itself is never dragged.
+            const marker = L.marker([bmp.Latitude, bmp.Longitude], { icon: MarkerHelper.inventoriedTreatmentBMPMarker });
             marker.on("click", () => {
                 if (this.editMode() !== "idle") {
                     return;
@@ -206,7 +219,7 @@ export class DelineationMapComponent implements OnInit {
             this.bmpMarkerByID.set(bmp.TreatmentBMPID, marker);
             this.bmpsClusterLayer.addLayer(marker);
         }
-        this.bmpsClusterLayer["legendHtml"] = "<img src='./assets/main/map-icons/marker-icon-violet.png' style='height:17px'>";
+        this.bmpsClusterLayer["legendHtml"] = "<img src='./assets/main/map-icons/marker-icon-orange.png' style='height:17px'>";
         this.layerControl.addOverlay(this.bmpsClusterLayer, "Treatment BMPs");
         this.map.addLayer(this.bmpsClusterLayer);
     }
@@ -222,18 +235,30 @@ export class DelineationMapComponent implements OnInit {
      * already permission-gated on the API).
      */
     public onDelineationSelected(delineationID: number): void {
+        // NPT-981 r3 (KE id-19): ignore delineation-polygon clicks unless we're idle. While
+        // drawing/editing/tracing/moving, a stray polygon click must not hijack the selection
+        // (KE got yanked into a centralized delineation mid-draw and stuck in a broken state).
+        if (this.editMode() !== "idle") {
+            return;
+        }
         const bmp = this.bmps.find((b) => b.DelineationID === delineationID);
         if (bmp) {
-            this.selectBMP(bmp);
+            // Polygon click → populate the panel but do NOT auto-zoom (KE id-19b / id-23: the
+            // map flew away erratically). Only pin clicks zoom.
+            this.selectBMP(bmp, false);
         }
     }
 
-    public selectBMP(bmp: TreatmentBMPDelineationMapDto): void {
+    /** @param zoomToSelection fly the map to the selection. True for pin clicks + deep-link;
+     *  false for delineation-polygon clicks (KE id-19b). */
+    public selectBMP(bmp: TreatmentBMPDelineationMapDto, zoomToSelection: boolean = true): void {
         this.cancelEdit();
+        this.choosingFlowType.set(false);
+        this.selectedFlowType = null;
         this.selectedBMP.set(bmp);
         this.selectedDelineation.set(null);
         this.clearSelectedDelineationLayer();
-        this.refreshMarkerHighlight();
+        this.refreshMarkerHighlight(zoomToSelection);
 
         const requestedID = bmp.TreatmentBMPID;
         this.delineationService.getForTreatmentBMPDelineation(requestedID).subscribe((dto) => {
@@ -242,18 +267,18 @@ export class DelineationMapComponent implements OnInit {
             }
             this.selectedDelineation.set(dto);
             this.applyDelineationToSelectedBMP(dto);
-            this.renderSelectedDelineation();
+            this.renderSelectedDelineation(zoomToSelection);
         });
     }
 
-    private refreshMarkerHighlight(): void {
+    private refreshMarkerHighlight(zoomToSelection: boolean = true): void {
         const selected = this.selectedBMP();
         for (const [id, marker] of this.bmpMarkerByID) {
             const isSelected = id === selected?.TreatmentBMPID;
-            marker.setIcon(isSelected ? MarkerHelper.selectedMarker : MarkerHelper.treatmentBMPMarker);
+            marker.setIcon(isSelected ? MarkerHelper.selectedMarker : MarkerHelper.inventoriedTreatmentBMPMarker);
             marker.setZIndexOffset(isSelected ? 10000 : 1000);
         }
-        if (!selected) {
+        if (!selected || !zoomToSelection) {
             return;
         }
         const selectedMarker = this.bmpMarkerByID.get(selected.TreatmentBMPID);
@@ -266,14 +291,22 @@ export class DelineationMapComponent implements OnInit {
         }
     }
 
-    private renderSelectedDelineation(): void {
+    private renderSelectedDelineation(zoomToSelection: boolean = true): void {
         this.clearSelectedDelineationLayer();
         const delineation = this.selectedDelineation();
         if (!delineation?.Geometry) {
             return;
         }
         const geom = JSON.parse(delineation.Geometry);
-        this.selectedDelineationLayer = L.geoJSON(geom, { style: this.delineationSelectedStyle }).addTo(this.map);
+        // NPT-981 r3 (KE): non-interactive so it doesn't swallow map clicks. This highlight
+        // overlay is purely decorative (re-selection happens via the WMS GetFeatureInfo handler),
+        // and an interactive vector layer consumes the click so the map `click` event never fires
+        // — which broke click-to-place during Edit BMP Location whenever the BMP sat inside its
+        // own delineation polygon.
+        this.selectedDelineationLayer = L.geoJSON(geom, { style: this.delineationSelectedStyle, interactive: false }).addTo(this.map);
+        if (!zoomToSelection) {
+            return;
+        }
         try {
             this.map.flyToBounds(this.selectedDelineationLayer.getBounds(), { padding: [50, 50], duration: 0.6 });
         } catch {
@@ -285,6 +318,48 @@ export class DelineationMapComponent implements OnInit {
         if (this.selectedDelineationLayer) {
             this.map.removeLayer(this.selectedDelineationLayer);
             this.selectedDelineationLayer = null;
+        }
+    }
+
+    /** NPT-981 r3: force the Verified + Provisional WMS layers to re-fetch their tiles after a
+     *  delineation mutation. The selected-delineation highlight overlay is just decoration on top
+     *  of the GeoServer tiles; without busting those tiles the saved/edited/deleted geometry keeps
+     *  showing its pre-mutation shape (KE id-21 ghost-after-edit, id-23 deleted-polygon-lingers). */
+    private refreshDelineationLayers(): void {
+        this.delineationLayers?.forEach((layer) => layer.redraw());
+    }
+
+    /** Open the flow-type chooser for an existing delineation (the "Edit Delineation" action),
+     *  pre-selecting the delineation's current type so re-delineating the same type is one click
+     *  and switching is just picking the other radio. */
+    public openFlowTypeChooser(): void {
+        this.selectedFlowType = this.selectedDelineation()?.DelineationTypeID ?? null;
+        this.choosingFlowType.set(true);
+    }
+
+    public closeFlowTypeChooser(): void {
+        this.choosingFlowType.set(false);
+    }
+
+    /** Hint text under the radios, mirroring the legacy "Choose a delineation option" copy. */
+    public flowTypeHint(): string {
+        if (this.selectedFlowType === DelineationTypeEnum.Distributed) {
+            return "Draw the drainage area on the map.";
+        }
+        if (this.selectedFlowType === DelineationTypeEnum.Centralized) {
+            return "The delineation will be computed by tracing Regional Subbasins upstream.";
+        }
+        return "";
+    }
+
+    /** The legacy "Delineate" button: enter draw (Distributed) or trace (Centralized) mode for
+     *  the selected flow type. The selected type becomes the saved DelineationTypeID, so picking
+     *  the opposite radio switches the delineation's type on save. */
+    public beginDelineate(): void {
+        if (this.selectedFlowType === DelineationTypeEnum.Distributed) {
+            this.startEditDistributed();
+        } else if (this.selectedFlowType === DelineationTypeEnum.Centralized) {
+            this.startEditCentralized();
         }
     }
 
@@ -314,6 +389,7 @@ export class DelineationMapComponent implements OnInit {
                         this.selectedDelineation.set(null);
                         this.clearSelectedDelineationLayer();
                         this.applyDelineationToSelectedBMP(null);
+                        this.refreshDelineationLayers();
                     },
                     error: () => this.savingSubject.next(false),
                 });
@@ -336,6 +412,11 @@ export class DelineationMapComponent implements OnInit {
             const geom = JSON.parse(delineation!.Geometry);
             this.selectedDelineationLayer = L.geoJSON(geom, { style: this.delineationDraftStyle }).addTo(this.map);
             this.selectedDelineationLayer.eachLayer((l) => (l as any).pm?.enable());
+        } else {
+            // NPT-981 r3 (KE id-18): drop straight into draw mode instead of making the user
+            // hunt for the Geoman "Add Delineation" toolbar button. setupGeomanControls only
+            // *adds* the control; enableDraw actually arms the cursor.
+            this.map.pm.enableDraw("Polygon", { snappable: true, snapDistance: 20 });
         }
     }
 
@@ -356,8 +437,10 @@ export class DelineationMapComponent implements OnInit {
                     return;
                 }
                 this.selectedDelineationLayer = L.geoJSON(feature.geometry, { style: this.delineationDraftStyle }).addTo(this.map);
-                this.leafletHelperService.setupGeomanControls(this.map, false, true, false, "Delineation");
-                this.selectedDelineationLayer.eachLayer((l) => (l as any).pm?.enable());
+                // NPT-981 r3 (KE id-22): centralized delineations are traced from the RSB network,
+                // not hand-edited. Don't add Geoman controls or enable vertex editing — the traced
+                // geometry is display-only. The user accepts it with Save or asks for changes via
+                // Request Revision (both rendered in the panel during trace mode).
                 try {
                     this.map.flyToBounds(this.selectedDelineationLayer.getBounds(), { padding: [50, 50] });
                 } catch {
@@ -379,47 +462,32 @@ export class DelineationMapComponent implements OnInit {
         this.cancelEdit();
         this.editMode.set("editingLocation");
 
-        // NPT-981 r2: cursor goes on the map container (not the .leaflet-interactive SVG
-        // overlay) so the crosshair is visible everywhere the user might click — matches
-        // Jamie's OVTA assessment-point pattern.
-        this.map.getContainer().style.cursor = "crosshair";
+        // NPT-981 r3 (KE id-27): crosshair via a container class (not inline style) so the rule
+        // can also cover the .leaflet-interactive SVG overlay — otherwise the cursor reverts to
+        // default when hovering on top of the selected delineation polygon.
+        this.setLocationEditCursor(true);
 
-        // NPT-981 r2: drag the BMP's own cluster marker directly. The earlier preview-marker
-        // approach left an orphan marker on the map after save when reference tracking
-        // raced with cluster re-renders. Dragging the cluster marker keeps exactly one
-        // marker visible at all times; saveEdit's renderBMPMarkers rebuilds it cleanly.
-        const marker = this.bmpMarkerByID.get(bmp.TreatmentBMPID);
-        if (marker) {
-            marker.dragging?.enable();
-            marker.on("drag", this.onMarkerDrag);
-            marker.on("dragend", this.onMarkerDragEnd);
-        }
+        // NPT-981 r3 (KE id-26): drop a distinct, draggable PREVIEW marker at the current
+        // location and leave the real BMP pin in place until Save. Moving the real pin on every
+        // map click read as an autosave. The preview lives directly on the map (not the cluster)
+        // so cluster re-renders can't orphan it; clearLocationPreview removes it on save + cancel.
+        this.locationPreviewMarker = L.marker([bmp.Latitude, bmp.Longitude], {
+            icon: MarkerHelper.selectedMarker,
+            draggable: true,
+            zIndexOffset: 20000,
+        }).addTo(this.map);
+        this.locationPreviewMarker.on("drag", this.onPreviewMarkerMove);
+        this.locationPreviewMarker.on("dragend", this.onPreviewMarkerMove);
 
         // Seed pending location to the current position so Save without further interaction
         // is a no-op rather than an error.
         this.pendingLocation = { lat: bmp.Latitude, lng: bmp.Longitude };
     }
 
-    /** Bound references so we can off() them cleanly on cancel — instance methods would lose
-     *  this-binding when passed to off() unless we wrap them. Property-assigned arrow
-     *  functions keep the same Function identity across enable/disable cycles. */
-
-    /** `drag` event carries the live latlng during the drag and fires on every mousemove.
-     *  Markercluster can return stale lat/lngs from getLatLng() on dragend (its internal
-     *  index doesn't update mid-drag), so we capture the position continuously here as the
-     *  authoritative source for pendingLocation. */
-    private onMarkerDrag = (event: any): void => {
-        this.handleLocationChange(event.latlng);
-    };
-
-    /** Belt-and-suspenders dragend handler — also refreshes the cluster's index so the
-     *  marker's new position propagates to the cluster's spatial query structures. */
-    private onMarkerDragEnd = (event: any): void => {
-        const latLng = event.target.getLatLng();
-        this.handleLocationChange(latLng);
-        if (this.bmpsClusterLayer?.refreshClusters) {
-            this.bmpsClusterLayer.refreshClusters(event.target);
-        }
+    /** Property-assigned arrow keeps a stable Function identity so off() unbinds cleanly.
+     *  Handles both `drag` (live latlng) and `dragend` (target.getLatLng()). */
+    private onPreviewMarkerMove = (event: any): void => {
+        this.handleLocationChange(event.latlng ?? event.target.getLatLng());
     };
 
     private attachMapClickForLocation(): void {
@@ -431,19 +499,15 @@ export class DelineationMapComponent implements OnInit {
         });
     }
 
-    /** NPT-981 r2: shared handler for both drag-end and map-click during Edit BMP Location.
-     *  Updates pending location and moves the BMP's cluster marker to the new spot so the
-     *  user sees the preview without a second marker on the map. */
+    /** NPT-981 r3: stage the candidate location and move only the PREVIEW marker. The real BMP
+     *  pin stays put until the user clicks Save (saveEdit persists `pendingLocation`). */
     private handleLocationChange(latLng: L.LatLng): void {
         this.pendingLocation = { lat: latLng.lat, lng: latLng.lng };
-        const bmp = this.selectedBMP();
-        if (!bmp) {
-            return;
-        }
-        const marker = this.bmpMarkerByID.get(bmp.TreatmentBMPID);
-        if (marker) {
-            marker.setLatLng(latLng);
-        }
+        this.locationPreviewMarker?.setLatLng(latLng);
+    }
+
+    private setLocationEditCursor(on: boolean): void {
+        this.map?.getContainer().classList.toggle("location-edit-cursor", on);
     }
 
     private attachGeomanHandlers(): void {
@@ -493,7 +557,9 @@ export class DelineationMapComponent implements OnInit {
                     this.clearLocationPreview();
                     this.editMode.set("idle");
                     this.renderBMPMarkers();
-                    this.refreshMarkerHighlight();
+                    // NPT-981 r3 (KE): don't fly the map after a save — the user is already looking
+                    // at the spot they just edited. Refresh highlight + delineation without zooming.
+                    this.refreshMarkerHighlight(false);
                     this.reloadSelectedDelineation();
                 },
                 error: () => this.savingSubject.next(false),
@@ -521,7 +587,8 @@ export class DelineationMapComponent implements OnInit {
                         this.map.pm.removeControls();
                         this.selectedDelineation.set(dto);
                         this.applyDelineationToSelectedBMP(dto);
-                        this.renderSelectedDelineation();
+                        this.renderSelectedDelineation(false);
+                        this.refreshDelineationLayers();
                     },
                     error: () => this.savingSubject.next(false),
                 });
@@ -540,29 +607,22 @@ export class DelineationMapComponent implements OnInit {
         }
         this.clearLocationPreview();
         this.editMode.set("idle");
+        // Return to the default action view rather than dropping back into the flow-type chooser.
+        this.choosingFlowType.set(false);
         this.renderSelectedDelineation();
     }
 
     private clearLocationPreview(): void {
-        // NPT-981 r2: we drag the cluster's own BMP marker now. Cleanup is just: disable
-        // dragging on it, unbind dragend, restore cursor, and revert the marker's visual
-        // position if the user cancelled (saveEdit's renderBMPMarkers rebuild handles the
-        // successful-save case). Reverting on cancel uses the BMP's authoritative lat/lng
-        // from the bmps array, which saveEdit has not yet mutated when cancelEdit is invoked.
+        // NPT-981 r3: tear down the preview marker + cursor. The real BMP pin was never moved
+        // (it's a separate preview marker now), so there's nothing to revert on cancel; on save,
+        // renderBMPMarkers rebuilds the real pin at its new position.
         this.pendingLocation = null;
-        if (this.map) {
-            this.map.getContainer().style.cursor = "";
-        }
-        const bmp = this.selectedBMP();
-        if (!bmp) return;
-        const marker = this.bmpMarkerByID.get(bmp.TreatmentBMPID);
-        if (marker) {
-            marker.dragging?.disable();
-            marker.off("drag", this.onMarkerDrag);
-            marker.off("dragend", this.onMarkerDragEnd);
-            // Revert any visual drag (no-op if user saved — by then the marker was
-            // rebuilt by renderBMPMarkers at the new position).
-            marker.setLatLng([bmp.Latitude, bmp.Longitude]);
+        this.setLocationEditCursor(false);
+        if (this.locationPreviewMarker) {
+            this.locationPreviewMarker.off("drag", this.onPreviewMarkerMove);
+            this.locationPreviewMarker.off("dragend", this.onPreviewMarkerMove);
+            this.map.removeLayer(this.locationPreviewMarker);
+            this.locationPreviewMarker = null;
         }
     }
 
@@ -590,7 +650,9 @@ export class DelineationMapComponent implements OnInit {
         this.delineationService.getForTreatmentBMPDelineation(bmp.TreatmentBMPID).subscribe((dto) => {
             this.selectedDelineation.set(dto);
             this.applyDelineationToSelectedBMP(dto);
-            this.renderSelectedDelineation();
+            // reloadSelectedDelineation only runs after a save/verify-toggle — never zoom (the
+            // user is already on the area they edited).
+            this.renderSelectedDelineation(false);
         });
     }
 
@@ -647,15 +709,4 @@ export class DelineationMapComponent implements OnInit {
         return `${delineation.DelineationArea} ac`;
     }
 
-    public editExistingDelineation(): void {
-        const delineation = this.selectedDelineation();
-        if (!delineation) {
-            return;
-        }
-        if (delineation.DelineationTypeID === DelineationTypeEnum.Distributed) {
-            this.startEditDistributed();
-        } else {
-            this.startEditCentralized();
-        }
-    }
 }

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.html
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.html
@@ -1,4 +1,5 @@
 <generic-wms-wfs-layer
+    #wmsLayer
     [map]="map"
     [layerControl]="layerControl"
     [interactive]="true"

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, Output } from "@angular/core";
+import { Component, EventEmitter, Input, OnChanges, Output, ViewChild } from "@angular/core";
 import * as L from "leaflet";
 import { GenericWmsWfsLayerComponent } from "../generic-wms-wfs-layer/generic-wms-wfs-layer.component";
 
@@ -36,9 +36,18 @@ export class DelineationsLayerComponent implements OnChanges {
      *  in draw order, so `features[0]` is the topmost. */
     @Output() selected = new EventEmitter<number>();
 
+    @ViewChild("wmsLayer") private wmsLayer?: GenericWmsWfsLayerComponent;
+
     public cqlFilter: string = "1=1";
     public overlayLabel: string = "Delineations";
     public legendHtml: string = "";
+
+    /** NPT-981 r3: pass-through so the Delineation Map can force a tile refresh after a
+     *  delineation mutation (save / delete / verify-toggle). Without it the GeoServer WMS tiles
+     *  keep showing the pre-mutation geometry (ghost polygon after edit; deleted polygon lingers). */
+    public redraw(): void {
+        this.wmsLayer?.redraw();
+    }
 
     ngOnChanges(): void {
         let cqlFilter = `DelineationStatus = '${this.delineationStatus}'`;
@@ -55,9 +64,13 @@ export class DelineationsLayerComponent implements OnChanges {
         // Centralized + Distributed labels. Colors approximate the legacy MVC delineation map
         // palette: verified gets the saturated purple / blue pair; provisional uses the
         // lighter magenta / light-blue pair so the two statuses are visually distinct.
+        // NPT-981 r3 (KE id-6): the provisional swatch outlines were noticeably darker than the
+        // lighter outline GeoServer renders for provisional delineations on the map. Lighten the
+        // provisional strokes (verified keeps its saturated pair so the two statuses stay
+        // distinguishable in the legend).
         this.legendHtml = this.delineationStatus === "Verified"
             ? this.buildSwatchHtml("#d4b8e4", "#7e4d8a", "#b8c5e0", "#3a55a0")
-            : this.buildSwatchHtml("#e6bdd4", "#b04880", "#c5d4ea", "#6378b8");
+            : this.buildSwatchHtml("#e6bdd4", "#cf7faa", "#c5d4ea", "#9aa9d6");
     }
 
     private buildSwatchHtml(centralizedFill: string, centralizedStroke: string, distributedFill: string, distributedStroke: string): string {

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/generic-wms-wfs-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/generic-wms-wfs-layer.component.ts
@@ -129,6 +129,17 @@ export class GenericWmsWfsLayerComponent extends MapLayerBase implements OnChang
         }
     }
 
+    /** NPT-981 r3: force the WMS tiles to re-fetch. Bumps a dummy `_dc` param via setParams so
+     *  the tile URLs change and GeoWebCache can't serve stale tiles — a plain redraw() re-requests
+     *  identical URLs and may return cached geometry. Callers use this after a mutation (delineation
+     *  save/delete/verify) so the layer reflects the new server state. No-op if the WMS layer isn't
+     *  built yet (e.g. a WFS-only usage). */
+    public redraw(): void {
+        if (this.layer) {
+            (this.layer as L.TileLayer.WMS).setParams({ _dc: Date.now() } as any);
+        }
+    }
+
     private wireMapClickHandler() {
         if (this.interactive && this.map && !this.mapClickHandlerWired) {
             this.map.on("click", this.onMapClick.bind(this));


### PR DESCRIPTION
## Summary
Addresses the 10 rework items from KE's 5/26/26 QA pass on the migrated Delineation Map, plus two follow-ups raised during review (centralized type-switch, post-save auto-zoom) and a backend hardening fix for an FK race surfaced while testing.

**Frontend — `delineation-map` + shared layers**
- **Lingering polygons (id-21 edit ghost, id-23 deleted-but-visible):** refresh the Verified/Provisional GeoServer WMS layers after save/delete/verify via a new cache-busted `redraw()` on `generic-wms-wfs-layer` + a pass-through on `delineations-layer`. The selected highlight is only an overlay; the stale tiles were the actual ghost.
- **Selection/zoom (id-19, id-23):** delineation-polygon clicks are ignored unless idle (no more getting yanked into a centralized polygon mid-draw); only BMP-pin clicks fly the map — polygon clicks and **all save/verify actions** no longer auto-zoom.
- **Distributed draw (id-18):** drops straight into draw mode (`map.pm.enableDraw`) — no extra toolbar click.
- **Centralized (id-22):** trace-only, no Geoman vertex editing; Request Revision shows during the trace with Save/Cancel.
- **Edit BMP Location (id-26, id-27):** dedicated draggable preview marker so the real pin stays put until Save (no autosave feel); crosshair cursor now shows over the selected delineation too. Click-to-place works over a delineation (highlight overlay made non-interactive).
- **Edit Delineation / type switch:** reopens a legacy-style flow-type chooser (radio + Delineate) so the user can re-delineate or switch Distributed/Centralized; centralized hides the Edit-vertices path.
- **Styling (id-7, id-8, id-6):** markercluster coverage polygon off; inventoried BMP pins orange (planning-module parity); lighter provisional legend swatch outline.

**Backend — QGISAPI**
- `GenerateLoadGeneratingUnits` now drops any LGU whose `DelineationID` was deleted between the input snapshot and the insert, so a concurrent delineation delete during a network solve can't trip `FK_LoadGeneratingUnit_Delineation_DelineationID`. Pre-existing race (legacy MVC had the same exposure); the SPA delete/upsert wiring itself matches legacy exactly.

> ⚠️ The QGISAPI change requires a **container rebuild** to take effect (frontend dev server won't pick it up).

## Test plan
- [ ] **Edit ghost / delete (id-21/id-23):** edit a delineation's vertices + Save → only the new shape shows. Delete a delineation → it disappears immediately; clicking the map afterward doesn't fling the view.
- [ ] **Draw (id-18):** Add Distributed → cursor is immediately drawing, no toolbar click.
- [ ] **Selection lockout (id-19):** while drawing, clicking another delineation/vertex does nothing and doesn't zoom; pin clicks still zoom.
- [ ] **Centralized (id-22):** vertices not editable; Request Revision shows during trace alongside Save/Cancel.
- [ ] **Type switch:** select a centralized delineation → Edit Delineation → pick Distributed → draw → Save → it becomes distributed (and vice versa). Layout is the radio + Delineate chooser.
- [ ] **Move BMP (id-26/id-27):** clicking/dragging moves a preview marker, real pin stays until Save; clicking the map over the delineation still moves the preview; crosshair shows over the delineation. Save doesn't fly the map.
- [ ] **Save/verify zoom:** no save or verify-toggle auto-zooms; map stays put.
- [ ] **Styling:** no blue cluster coverage polygon; BMP pins orange; provisional legend outline matches the map.
- [ ] **FK guard (needs QGISAPI rebuild):** with a network solve / LGU refresh running, delete a delineation on the map — the refresh completes without the FK_LoadGeneratingUnit_Delineation_DelineationID 500.
- [ ] Regression: reference layers (WQMP/RSB/Parcel/Stormwater/Jurisdiction) and the verified/provisional toggle still work.