### PR TITLE
NPT-1066: Land Use Block / Parcel toggle on Edit OVTA Area Location

### DIFF
--- a/Neptune.API/Controllers/OnlandVisualTrashAssessmentAreaController.cs
+++ b/Neptune.API/Controllers/OnlandVisualTrashAssessmentAreaController.cs
@@ -46,6 +46,10 @@ public class OnlandVisualTrashAssessmentAreaController(
     public ActionResult<OnlandVisualTrashAssessmentAreaDetailDto> Get([FromRoute] int onlandVisualTrashAssessmentAreaID)
     {
         var onlandVisualTrashAssessmentAreaDetailDto = OnlandVisualTrashAssessmentAreas.GetByID(DbContext, onlandVisualTrashAssessmentAreaID).AsDetailDto();
+        // NPT-1066: set here (not in AsDetailDto) so the extension stays dbContext-free; the edit
+        // page uses this to disable the Land Use Block toggle option when none exist.
+        onlandVisualTrashAssessmentAreaDetailDto.JurisdictionHasLandUseBlocks =
+            LandUseBlocks.JurisdictionHasLandUseBlocks(DbContext, onlandVisualTrashAssessmentAreaDetailDto.StormwaterJurisdictionID!.Value);
         return Ok(onlandVisualTrashAssessmentAreaDetailDto);
     }
 

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentAreas.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentAreas.cs
@@ -83,8 +83,14 @@ public static class OnlandVisualTrashAssessmentAreas
             var geometry = LandUseBlocks.UnionAggregateByLandUseBlockIDs(dbContext,
                 onlandVisualTrashAssessmentAreaGeometryDto.SelectedLandUseBlockIDs ?? new List<int>(),
                 onlandVisualTrashAssessmentArea.StormwaterJurisdictionID);
-            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = geometry;
-            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = geometry.ProjectTo4326();
+            // UnionAggregateByLandUseBlockIDs returns null for an empty / out-of-jurisdiction
+            // selection. Leave the existing geometry untouched rather than projecting null (NRE)
+            // or wiping the non-nullable area geometry — an empty save is a no-op.
+            if (geometry != null)
+            {
+                onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = geometry;
+                onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = geometry.ProjectTo4326();
+            }
         }
         else if (onlandVisualTrashAssessmentAreaGeometryDto.OvtaAreaSourceTypeID == (int)OvtaAreaSourceTypeEnum.Parcel)
         {

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentAreas.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentAreas.cs
@@ -73,18 +73,30 @@ public static class OnlandVisualTrashAssessmentAreas
     {
         var onlandVisualTrashAssessmentArea = dbContext.OnlandVisualTrashAssessmentAreas.Single(x =>
             x.OnlandVisualTrashAssessmentAreaID == onlandVisualTrashAssessmentAreaGeometryDto.OnlandVisualTrashAssessmentAreaID);
-        if (onlandVisualTrashAssessmentAreaGeometryDto.UsingParcels)
+
+        // NPT-1066: the edit page now offers Land Use Block / Parcel / Draw, mirroring the create
+        // workflow. Branch on the source type; Parcel + LandUseBlock geometries are already State
+        // Plane (2771) and only need projecting to 4326, while a manually-drawn shape comes from
+        // the browser in Web Mercator and projects the other way.
+        if (onlandVisualTrashAssessmentAreaGeometryDto.OvtaAreaSourceTypeID == (int)OvtaAreaSourceTypeEnum.LandUseBlock)
         {
-            // since this is parcel picks, we don't need to reproject; the parcels are already in the correct system (State Plane)
+            var geometry = LandUseBlocks.UnionAggregateByLandUseBlockIDs(dbContext,
+                onlandVisualTrashAssessmentAreaGeometryDto.SelectedLandUseBlockIDs ?? new List<int>(),
+                onlandVisualTrashAssessmentArea.StormwaterJurisdictionID);
+            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = geometry;
+            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = geometry.ProjectTo4326();
+        }
+        else if (onlandVisualTrashAssessmentAreaGeometryDto.OvtaAreaSourceTypeID == (int)OvtaAreaSourceTypeEnum.Parcel)
+        {
+            // parcels are already in the correct system (State Plane); no reprojection needed
             onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = ParcelGeometries.UnionAggregateByParcelIDs(dbContext, onlandVisualTrashAssessmentAreaGeometryDto.ParcelIDs);
             onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = ParcelGeometries.UnionAggregate4326ByParcelIDs(dbContext, onlandVisualTrashAssessmentAreaGeometryDto.ParcelIDs);
         }
         else
         {
+            // manually drawn (Geoman) — comes from the browser, so transform to State Plane
             var newGeometry4326 = GeoJsonSerializer.Deserialize<IFeature>(onlandVisualTrashAssessmentAreaGeometryDto.GeometryAsGeoJson);
             newGeometry4326.Geometry.SRID = Proj4NetHelper.WEB_MERCATOR;
-
-            // since this is coming from the browser, we have to transform to State Plane
             onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = newGeometry4326.Geometry;
             onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = newGeometry4326.Geometry.ProjectTo2771();
         }

--- a/Neptune.Models/DataTransferObjects/OnlandVisualTrashAssessment/OnlandVisualTrashAssessmentAreaDetailDto.cs
+++ b/Neptune.Models/DataTransferObjects/OnlandVisualTrashAssessment/OnlandVisualTrashAssessmentAreaDetailDto.cs
@@ -16,4 +16,7 @@ public class OnlandVisualTrashAssessmentAreaDetailDto
     public int CompletedProgressAssessmentCount { get; set; }
     public BoundingBoxDto BoundingBox { get; set; }
     public string Geometry { get; set; }
+    // NPT-1066: drives the edit page's Land Use Block toggle option — disabled + helper message
+    // when the jurisdiction has no land use blocks (mirrors the create workflow).
+    public bool JurisdictionHasLandUseBlocks { get; set; }
 }

--- a/Neptune.Models/DataTransferObjects/OnlandVisualTrashAssessment/OnlandVisualTrashAssessmentAreaGeometryDto.cs
+++ b/Neptune.Models/DataTransferObjects/OnlandVisualTrashAssessment/OnlandVisualTrashAssessmentAreaGeometryDto.cs
@@ -1,9 +1,12 @@
-﻿namespace Neptune.Models.DataTransferObjects;
+namespace Neptune.Models.DataTransferObjects;
 
 public class OnlandVisualTrashAssessmentAreaGeometryDto
 {
     public int OnlandVisualTrashAssessmentAreaID { get; set; }
-    public List<int> ParcelIDs { get; set; }
+    // NPT-1066: which source built the geometry. Null = manually drawn (Geoman) — use
+    // GeometryAsGeoJson. Parcel / LandUseBlock unions the corresponding selected IDs server-side.
+    public int? OvtaAreaSourceTypeID { get; set; }
+    public List<int> ParcelIDs { get; set; } = new();
+    public List<int> SelectedLandUseBlockIDs { get; set; } = new();
     public string GeometryAsGeoJson { get; set; }
-    public bool UsingParcels { get; set; }
 }

--- a/Neptune.Tests/OnlandVisualTrashAssessmentAreaUpdateGeometryTests.cs
+++ b/Neptune.Tests/OnlandVisualTrashAssessmentAreaUpdateGeometryTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.Common.GeoSpatial;
+using Neptune.EFModels.Entities;
+using Neptune.Models.DataTransferObjects;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1066: the Edit OVTA Area Location page gained a Land Use Block source option.
+    /// OnlandVisualTrashAssessmentAreas.UpdateGeometry now branches on OvtaAreaSourceTypeID, so
+    /// the LandUseBlock branch must union the selected blocks onto the area geometry (and project
+    /// the 4326 copy). Real-DB integration test inside a rolled-back transaction, mirroring
+    /// OnlandVisualTrashAssessmentAreaMoveAssessmentsTests.
+    /// </summary>
+    [TestClass]
+    public class OnlandVisualTrashAssessmentAreaUpdateGeometryTests
+    {
+        private NeptuneDbContext _dbContext = null!;
+        private IDbContextTransaction _transaction = null!;
+
+        private static NeptuneDbContext GetDbContext()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<NeptuneDbContext>();
+            optionsBuilder.UseSqlServer(
+                "Data Source=localhost;Initial Catalog=NeptuneDB;Persist Security Info=True;Integrated Security=true;Encrypt=False;",
+                x =>
+                {
+                    x.CommandTimeout((int)TimeSpan.FromMinutes(3).TotalSeconds);
+                    x.UseNetTopologySuite();
+                });
+            return new NeptuneDbContext(optionsBuilder.Options);
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _dbContext = GetDbContext();
+            _transaction = _dbContext.Database.BeginTransaction();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _transaction.Rollback();
+            _transaction.Dispose();
+            _dbContext.Dispose();
+        }
+
+        [TestMethod]
+        public void UpdateGeometry_LandUseBlockSource_UnionsSelectedBlocksOntoArea()
+        {
+            // Find a jurisdiction that already has at least two land use blocks with geometry.
+            var jurisdictionWithBlocks = _dbContext.LandUseBlocks.AsNoTracking()
+                .Where(x => x.LandUseBlockGeometry != null)
+                .GroupBy(x => x.StormwaterJurisdictionID)
+                .Where(g => g.Count() >= 2)
+                .Select(g => g.Key)
+                .FirstOrDefault();
+            if (jurisdictionWithBlocks == 0)
+            {
+                Assert.Inconclusive("Local NeptuneDB has no jurisdiction with >= 2 land use blocks to exercise the LUB union branch.");
+            }
+
+            var blockIDs = _dbContext.LandUseBlocks.AsNoTracking()
+                .Where(x => x.StormwaterJurisdictionID == jurisdictionWithBlocks && x.LandUseBlockGeometry != null)
+                .OrderBy(x => x.LandUseBlockID)
+                .Select(x => x.LandUseBlockID)
+                .Take(2)
+                .ToList();
+
+            // Seed an OVTA area in that jurisdiction with a throwaway starting geometry.
+            var expectedUnion = LandUseBlocks.UnionAggregateByLandUseBlockIDs(_dbContext, blockIDs, jurisdictionWithBlocks);
+            var startingGeometry = GeometryHelper.FromWKT(
+                "POLYGON((1840000 660000, 1840100 660000, 1840100 660100, 1840000 660100, 1840000 660000))",
+                Proj4NetHelper.NAD_83_HARN_CA_ZONE_VI_SRID);
+            var area = new OnlandVisualTrashAssessmentArea
+            {
+                OnlandVisualTrashAssessmentAreaName = $"NPT-1066 test {Guid.NewGuid()}",
+                StormwaterJurisdictionID = jurisdictionWithBlocks,
+                OnlandVisualTrashAssessmentAreaGeometry = startingGeometry,
+            };
+            _dbContext.OnlandVisualTrashAssessmentAreas.Add(area);
+            _dbContext.SaveChanges();
+
+            var dto = new OnlandVisualTrashAssessmentAreaGeometryDto
+            {
+                OnlandVisualTrashAssessmentAreaID = area.OnlandVisualTrashAssessmentAreaID,
+                OvtaAreaSourceTypeID = (int)OvtaAreaSourceTypeEnum.LandUseBlock,
+                SelectedLandUseBlockIDs = blockIDs,
+            };
+
+            OnlandVisualTrashAssessmentAreas.UpdateGeometry(_dbContext, dto);
+            _dbContext.SaveChanges();
+
+            var saved = _dbContext.OnlandVisualTrashAssessmentAreas.AsNoTracking()
+                .Single(x => x.OnlandVisualTrashAssessmentAreaID == area.OnlandVisualTrashAssessmentAreaID);
+
+            Assert.IsNotNull(saved.OnlandVisualTrashAssessmentAreaGeometry, "State Plane geometry should be set from the LUB union.");
+            Assert.IsNotNull(saved.OnlandVisualTrashAssessmentAreaGeometry4326, "4326 geometry should be projected from the union.");
+            Assert.AreEqual(expectedUnion!.Area, saved.OnlandVisualTrashAssessmentAreaGeometry.Area, 1.0,
+                "Saved area geometry should equal the union of the selected land use blocks.");
+        }
+    }
+}

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-add-remove-parcels/trash-ovta-add-remove-parcels.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-ovta-add-remove-parcels/trash-ovta-add-remove-parcels.component.html
@@ -39,6 +39,7 @@
           [sortOrder]="10"
           [stormwaterJurisdictionID]="selectAreaContext.StormwaterJurisdictionID"
           [selectedLandUseBlockIDs]="selectedLandUseBlockIDs"
+          [restrictToViewport]="true"
           (landUseBlockClicked)="onLandUseBlockClicked($event)"></selected-land-use-block-layer>
       }
       @if (mapIsReady && sourceTypeID === OvtaAreaSourceTypeEnum.Parcel) {

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.html
@@ -8,13 +8,29 @@
 
 @if (onlandVisualTrashAssessmentArea$ | async; as onlandVisualTrashAssessmentArea) {
 <div class="page-body">
+    <div class="source-type-toggle">
+        <btn-group-radio-input [options]="sourceTypeOptions" [(ngModel)]="mode" (ngModelChange)="onModeChange($event)"></btn-group-radio-input>
+        @if (!jurisdictionHasLandUseBlocks) {
+            <p class="copy copy-3 helper-text">No land use blocks uploaded for this jurisdiction.</p>
+        }
+    </div>
     <neptune-map
         (onMapLoad)="handleMapReady($event, onlandVisualTrashAssessmentArea.Geometry)"
         (onLegendControlReady)="handleLegendControlReady($event)"
         [mapHeight]="mapHeight"
         [showLegend]="true"
         [boundingBox]="onlandVisualTrashAssessmentArea.BoundingBox">
-        @if (mapIsReady) {
+        @if (mapIsReady && mode === OvtaAreaSourceTypeEnum.LandUseBlock) {
+        <selected-land-use-block-layer
+            [displayOnLoad]="true"
+            [map]="map"
+            [layerControl]="layerControl"
+            [sortOrder]="20"
+            [stormwaterJurisdictionID]="stormwaterJurisdictionID"
+            [selectedLandUseBlockIDs]="selectedLandUseBlockIDs"
+            [restrictToViewport]="true"
+            (landUseBlockClicked)="onLandUseBlockClicked($event)"></selected-land-use-block-layer>
+        } @else if (mapIsReady) {
         <land-use-block-layer [displayOnLoad]="true" [map]="map" [layerControl]="layerControl" [sortOrder]="20"></land-use-block-layer>
         } @if (mapIsReady) {
         <transect-line-layer
@@ -27,17 +43,6 @@
     </neptune-map>
     <div class="flex-between">
         <button class="btn btn-primary" (click)="resetZoom()">Reset Map Zoom</button>
-        <button
-            class="btn btn-primary"
-            (click)="
-                setCanPickParcels(
-                    onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaID,
-                    onlandVisualTrashAssessmentArea.BoundingBox,
-                    onlandVisualTrashAssessmentArea.Geometry
-                )
-            ">
-            {{ buttonText }}
-        </button>
     </div>
     <hr />
     <div class="flex-end">

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.scss
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.scss
@@ -1,0 +1,44 @@
+@use "/src/scss/abstracts" as *;
+
+// NPT-1066: match the Select Assessment Area page's source-type toggle — a centered,
+// light-gray-bordered pill where the active option is filled primary and inactive options
+// reveal the same fill on hover. Mirrors trash-ovta-add-remove-parcels.component.scss.
+.source-type-toggle {
+    text-align: center;
+    margin-bottom: $spacing-200;
+
+    ::ng-deep .button-group {
+        display: inline-flex;
+        border: 1px solid $gray-200;
+        border-radius: 0.25rem;
+        padding: 4px;
+        margin-bottom: 0;
+        gap: 4px;
+    }
+
+    ::ng-deep .button-group__item {
+        background-color: transparent;
+        color: $primary;
+        border: none;
+        border-radius: 0.25rem;
+        font-weight: 600;
+        padding: 0.5rem 1.25rem;
+        transition: background-color 200ms ease, color 200ms ease;
+
+        &:hover:not(:disabled),
+        &.active {
+            background-color: $primary;
+            color: $white;
+        }
+
+        &:disabled {
+            opacity: 0.5;
+            pointer-events: none;
+        }
+    }
+
+    .helper-text {
+        color: $gray-600;
+        margin: $spacing-100 0 0;
+    }
+}

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.ts
@@ -5,7 +5,9 @@ import { NeptuneMapComponent, NeptuneMapInitEvent } from "../../../../shared/com
 import * as L from "leaflet";
 import "@geoman-io/leaflet-geoman-free";
 import { LandUseBlockLayerComponent } from "../../../../shared/components/leaflet/layers/land-use-block-layer/land-use-block-layer.component";
+import { SelectedLandUseBlockLayerComponent } from "../../../../shared/components/leaflet/layers/selected-land-use-block-layer/selected-land-use-block-layer.component";
 import { AsyncPipe } from "@angular/common";
+import { FormsModule } from "@angular/forms";
 import { Router, RouterLink } from "@angular/router";
 import { Input } from "@angular/core";
 import { Observable, forkJoin } from "rxjs";
@@ -14,18 +16,36 @@ import { OnlandVisualTrashAssessmentAreaService } from "src/app/shared/generated
 import { OnlandVisualTrashAssessmentAreaDetailDto } from "src/app/shared/generated/model/onland-visual-trash-assessment-area-detail-dto";
 import { TransectLineLayerComponent } from "../../../../shared/components/leaflet/layers/transect-line-layer/transect-line-layer.component";
 import { OnlandVisualTrashAssessmentAreaGeometryDto } from "src/app/shared/generated/model/onland-visual-trash-assessment-area-geometry-dto";
+import { OvtaAreaSourceTypeEnum } from "src/app/shared/generated/enum/ovta-area-source-type-enum";
+import { BtnGroupRadioInputComponent, IBtnGroupRadioInputOption } from "src/app/shared/components/inputs/btn-group-radio-input/btn-group-radio-input.component";
 import { GroupByPipe } from "src/app/shared/pipes/group-by.pipe";
 import { WfsService } from "src/app/shared/services/wfs.service";
 import { LeafletHelperService } from "src/app/shared/services/leaflet-helper.service";
 
+// NPT-1066: the edit page offers the create workflow's Land Use Block / Parcel source types
+// plus the existing Geoman freehand draw. OvtaAreaSourceTypeEnum only covers LUB/Parcel, so
+// "Draw" is a local sentinel for the manual-geometry mode.
+type EditMode = OvtaAreaSourceTypeEnum | "Draw";
+
 @Component({
     selector: "trash-ovta-area-edit-location",
-    imports: [PageHeaderComponent, NeptuneMapComponent, LandUseBlockLayerComponent, AsyncPipe, TransectLineLayerComponent, RouterLink],
+    imports: [
+        PageHeaderComponent,
+        NeptuneMapComponent,
+        LandUseBlockLayerComponent,
+        SelectedLandUseBlockLayerComponent,
+        AsyncPipe,
+        FormsModule,
+        TransectLineLayerComponent,
+        RouterLink,
+        BtnGroupRadioInputComponent,
+    ],
     templateUrl: "./trash-ovta-area-edit-location.component.html",
     styleUrl: "./trash-ovta-area-edit-location.component.scss",
 })
 export class TrashOvtaAreaEditLocationComponent {
     public customRichTextTypeID = NeptunePageTypeEnum.EditOVTAArea;
+    public OvtaAreaSourceTypeEnum = OvtaAreaSourceTypeEnum;
 
     public onlandVisualTrashAssessmentArea$: Observable<OnlandVisualTrashAssessmentAreaDetailDto>;
     public mapHeight = window.innerHeight - window.innerHeight * 0.4 + "px";
@@ -36,9 +56,19 @@ export class TrashOvtaAreaEditLocationComponent {
     public bounds: any;
 
     public selectedParcelIDs: number[] = [];
+    public selectedLandUseBlockIDs: number[] = [];
 
-    public canPickParcels: boolean = false;
-    public buttonText = "Pick Parcels";
+    // NPT-1066: default to Draw so opening the page shows the existing geometry, editable —
+    // preserving the prior behavior. The user opts into LUB/Parcel to rebuild from a selection.
+    public mode: EditMode = "Draw";
+    public sourceTypeOptions: IBtnGroupRadioInputOption[] = [];
+    public jurisdictionHasLandUseBlocks = false;
+    public stormwaterJurisdictionID?: number;
+
+    // Captured from the loaded detail DTO so mode-switching can rebuild layers without re-fetching.
+    private ovtaAreaID!: number;
+    private boundingBox: any;
+    private geometryJson: string;
 
     public layer: L.FeatureGroup = new L.FeatureGroup();
 
@@ -88,7 +118,22 @@ export class TrashOvtaAreaEditLocationComponent {
     }
 
     ngOnInit(): void {
-        this.onlandVisualTrashAssessmentArea$ = this.onlandVisualTrashAssessmentAreaService.getOnlandVisualTrashAssessmentArea(this.onlandVisualTrashAssessmentAreaID);
+        this.onlandVisualTrashAssessmentArea$ = this.onlandVisualTrashAssessmentAreaService.getOnlandVisualTrashAssessmentArea(this.onlandVisualTrashAssessmentAreaID).pipe(
+            tap((dto) => {
+                this.ovtaAreaID = dto.OnlandVisualTrashAssessmentAreaID;
+                this.boundingBox = dto.BoundingBox;
+                this.geometryJson = dto.Geometry;
+                this.stormwaterJurisdictionID = dto.StormwaterJurisdictionID;
+                this.jurisdictionHasLandUseBlocks = dto.JurisdictionHasLandUseBlocks;
+                // Mirrors the create workflow's toggle; the Land Use Blocks option is disabled
+                // when the jurisdiction has none. "Draw" keeps the existing Geoman freehand option.
+                this.sourceTypeOptions = [
+                    { label: "Land Use Blocks", value: OvtaAreaSourceTypeEnum.LandUseBlock, disabled: !dto.JurisdictionHasLandUseBlocks },
+                    { label: "Parcels", value: OvtaAreaSourceTypeEnum.Parcel },
+                    { label: "Draw", value: "Draw" },
+                ];
+            })
+        );
     }
 
     public handleLayerBoundsCalculated(bounds: any) {
@@ -100,15 +145,23 @@ export class TrashOvtaAreaEditLocationComponent {
     }
 
     public save(ovtaAreaID) {
-        var ovtaGeometryDto = new OnlandVisualTrashAssessmentAreaGeometryDto();
-        ovtaGeometryDto.UsingParcels = this.canPickParcels;
-        let geoJson = null;
-        this.layer.eachLayer((layer: L.Path & { toGeoJSON: () => GeoJSON.Feature }) => {
-            geoJson = layer.toGeoJSON();
-        });
-        ovtaGeometryDto.GeometryAsGeoJson = geoJson ? JSON.stringify(geoJson) : null;
-        ovtaGeometryDto.ParcelIDs = this.selectedParcelIDs;
+        const ovtaGeometryDto = new OnlandVisualTrashAssessmentAreaGeometryDto();
         ovtaGeometryDto.OnlandVisualTrashAssessmentAreaID = ovtaAreaID;
+        if (this.mode === OvtaAreaSourceTypeEnum.LandUseBlock) {
+            ovtaGeometryDto.OvtaAreaSourceTypeID = OvtaAreaSourceTypeEnum.LandUseBlock;
+            ovtaGeometryDto.SelectedLandUseBlockIDs = this.selectedLandUseBlockIDs;
+        } else if (this.mode === OvtaAreaSourceTypeEnum.Parcel) {
+            ovtaGeometryDto.OvtaAreaSourceTypeID = OvtaAreaSourceTypeEnum.Parcel;
+            ovtaGeometryDto.ParcelIDs = this.selectedParcelIDs;
+        } else {
+            // Draw: send the manually drawn geometry; null source type tells the API to use it.
+            ovtaGeometryDto.OvtaAreaSourceTypeID = null;
+            let geoJson = null;
+            this.layer.eachLayer((layer: L.Path & { toGeoJSON: () => GeoJSON.Feature }) => {
+                geoJson = layer.toGeoJSON();
+            });
+            ovtaGeometryDto.GeometryAsGeoJson = geoJson ? JSON.stringify(geoJson) : null;
+        }
         this.onlandVisualTrashAssessmentAreaService.updateOnlandVisualTrashAssessmentWithParcelsOnlandVisualTrashAssessmentArea(ovtaAreaID, ovtaGeometryDto).subscribe((x) => {
             this.router.navigate(`trash/onland-visual-trash-assessment-areas/${ovtaAreaID}`.split("/"));
         });
@@ -193,24 +246,54 @@ export class TrashOvtaAreaEditLocationComponent {
         this.map.pm.removeControls();
     }
 
-    public setCanPickParcels(ovtaAreaID, boundingBox, geometry) {
-        this.canPickParcels = !this.canPickParcels;
-        this.layer.clearLayers();
-        if (this.canPickParcels) {
-            if (this.map.pm.globalEditModeEnabled()) {
-                this.map.pm.disableGlobalEditMode();
-            }
-            this.map.pm.removeControls();
-            this.addOVTAAreaToLayer(ovtaAreaID);
-            this.addParcelsToLayer(boundingBox);
-            this.buttonText = "Draw OVTA Areas";
-        } else {
-            this.addFeatureCollectionToFeatureGroup(JSON.parse(geometry), this.layer);
-            this.addOrRemoveGeomanControl(true);
-            this.buttonText = "Pick Parcels";
+    /** NPT-1066: swap between Land Use Block / Parcel / Draw. Tears down the prior mode's
+     *  layers + Geoman controls, then sets up the new mode. LUB mode is rendered by the template's
+     *  <selected-land-use-block-layer>; Parcel + Draw populate this.layer as before. */
+    public onModeChange(newMode: EditMode) {
+        // NB: [(ngModel)] has already written this.mode = newMode by the time ngModelChange fires,
+        // so we can't guard on (this.mode === newMode) — that would always early-return and skip
+        // the layer setup below. Branch on the newMode argument instead.
+        // Clear the inactive selections so we never save a stale mix of sources.
+        if (newMode !== OvtaAreaSourceTypeEnum.Parcel) {
+            this.selectedParcelIDs = [];
         }
-        const bounds = this.layer.getBounds();
-        this.map.fitBounds(bounds);
+        if (newMode !== OvtaAreaSourceTypeEnum.LandUseBlock) {
+            this.selectedLandUseBlockIDs = [];
+        }
+        this.mode = newMode;
+
+        this.layer.clearLayers();
+        if (this.map.pm.globalEditModeEnabled()) {
+            this.map.pm.disableGlobalEditMode();
+        }
+        this.map.pm.removeControls();
+
+        if (newMode === "Draw") {
+            this.addFeatureCollectionToFeatureGroup(JSON.parse(this.geometryJson), this.layer);
+            this.addOrRemoveGeomanControl(true);
+            if (this.layer.getLayers().length > 0 && !this.map.pm.globalEditModeEnabled()) {
+                this.map.pm.toggleGlobalEditMode();
+            }
+        } else if (newMode === OvtaAreaSourceTypeEnum.Parcel) {
+            this.addOVTAAreaToLayer(this.ovtaAreaID);
+            this.addParcelsToLayer(this.boundingBox);
+        }
+        // LandUseBlock: the interactive selected-land-use-block-layer handles its own rendering
+        // + click selection via onLandUseBlockClicked.
+
+        if (this.layer.getLayers().length > 0) {
+            this.map.fitBounds(this.layer.getBounds());
+        }
+    }
+
+    /** Toggle membership in the selected LUB list; replace the array (not mutate) so the layer's
+     *  ngOnChanges fires and it re-styles. Mirrors the create workflow. */
+    public onLandUseBlockClicked(landUseBlockID: number) {
+        if (this.selectedLandUseBlockIDs.includes(landUseBlockID)) {
+            this.selectedLandUseBlockIDs = this.selectedLandUseBlockIDs.filter((id) => id !== landUseBlockID);
+        } else {
+            this.selectedLandUseBlockIDs = [...this.selectedLandUseBlockIDs, landUseBlockID];
+        }
     }
 
     public resetZoom() {
@@ -238,6 +321,11 @@ export class TrashOvtaAreaEditLocationComponent {
     private addParcelsToLayer(boundingBox) {
         const bbox = boundingBox != null ? `${boundingBox.Bottom},${boundingBox.Right},${boundingBox.Top},${boundingBox.Left}` : null;
         this.wfsService.getGeoserverWFSLayer("OCStormwater:Parcels", "ParcelID", bbox).subscribe((response) => {
+            // NPT-1066: the parcel WFS (whole-area bbox) can be slow; if the user switched away
+            // from Parcel mode before it returned, don't re-add parcels onto a now-cleared layer.
+            if (this.mode !== OvtaAreaSourceTypeEnum.Parcel) {
+                return;
+            }
             if (response.length == 0) return;
             const featuresGroupedByParcelID = this.groupByPipe.transform(response, "properties.ParcelID");
             Object.keys(featuresGroupedByParcelID).forEach((parcelID) => {
@@ -281,7 +369,8 @@ export class TrashOvtaAreaEditLocationComponent {
                     } else {
                         layer.setStyle(this.highlightStyle);
                     }
-                    this.map.fitBounds(layer.getBounds());
+                    // NPT-1066 (KE): don't fly the map on each parcel toggle — the user is picking
+                    // and the zoom is disorienting.
                 }
             }
         });

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.ts
@@ -262,6 +262,13 @@ export class TrashOvtaAreaEditLocationComponent {
         }
         this.mode = newMode;
 
+        // The toggle renders as soon as the area loads, which can be before the map fires
+        // onMapLoad. ngModel has set this.mode; bail before touching Geoman/map APIs if the map
+        // isn't ready yet (handleMapReady sets up the default Draw mode once it is).
+        if (!this.map) {
+            return;
+        }
+
         this.layer.clearLayers();
         if (this.map.pm.globalEditModeEnabled()) {
             this.map.pm.disableGlobalEditMode();

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/selected-land-use-block-layer/selected-land-use-block-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/selected-land-use-block-layer/selected-land-use-block-layer.component.ts
@@ -21,6 +21,11 @@ export class SelectedLandUseBlockLayerComponent extends MapLayerBase implements 
     /** Single-select callers (e.g. the LUB index page) want the map to fit-bounds on each
      * external selection change. Multi-select callers (Select Assessment Area) opt out. */
     @Input() zoomToSelectionOnChange: boolean = false;
+    /** NPT-1066: only fetch + render blocks within the current map view, re-fetching on pan/zoom.
+     * Without this, picking jurisdictions with thousands of blocks (e.g. Tustin ~3k, Irvine ~61k)
+     * renders every block as an interactive vector and locks up the browser. Opt-in so the LUB
+     * index page (browse-all, single-select) keeps loading the full set. */
+    @Input() restrictToViewport: boolean = false;
 
     @Output() layerBoundsCalculated = new EventEmitter();
     @Output() landUseBlockClicked = new EventEmitter<number>();
@@ -31,6 +36,12 @@ export class SelectedLandUseBlockLayerComponent extends MapLayerBase implements 
     /** Set true between an in-layer click and the parent's input write-back, so the
      * write-back's ngOnChanges doesn't trigger a re-zoom or re-style of work we already did. */
     private clickedWithinLayer: boolean = false;
+
+    /** NPT-1066: cache of the jurisdiction's blocks (grouped by LandUseBlockID) + each group's
+     * bounds, so restrictToViewport callers can re-render the visible subset on pan/zoom without
+     * re-fetching. */
+    private featureGroups: { [landUseBlockID: string]: any[] } | null = null;
+    private featureGroupBounds: { [landUseBlockID: string]: L.LatLngBounds | null } = {};
 
     private styleDictionary = {
         [PriorityLandUseTypeEnum.Commercial]: {
@@ -119,7 +130,25 @@ export class SelectedLandUseBlockLayerComponent extends MapLayerBase implements 
     ngAfterViewInit(): void {
         this.setupLayer();
         this.updateLayer();
+        if (this.restrictToViewport) {
+            this.map.on("moveend", this.onMapMoveEnd);
+        }
     }
+
+    override ngOnDestroy(): void {
+        if (this.restrictToViewport && this.map) {
+            this.map.off("moveend", this.onMapMoveEnd);
+        }
+        super.ngOnDestroy();
+    }
+
+    /** NPT-1066: re-render (not re-fetch) the visible blocks after the user pans/zooms. The whole
+     * jurisdiction's features are cached from the single fetch; we just re-filter to the viewport. */
+    private onMapMoveEnd = () => {
+        if (this.featureGroups) {
+            this.renderFeatures();
+        }
+    };
 
     private updateLayer() {
         this.layer.clearLayers();
@@ -128,43 +157,92 @@ export class SelectedLandUseBlockLayerComponent extends MapLayerBase implements 
     }
 
     private addLandUseBlocksToLayer() {
-        const cql_filter = this.stormwaterJurisdictionID
-            ? `StormwaterJurisdictionID = ${this.stormwaterJurisdictionID}`
-            : ``;
+        // Fetch the jurisdiction's blocks once (no spatial filter — the GeoServer BBOX CQL path
+        // returned nothing here, and rendering, not fetching, was the bottleneck). When
+        // restrictToViewport is set we cache everything and only render what's in view, so dense
+        // jurisdictions (Tustin ~3k, Irvine ~61k) don't lock up the browser drawing every polygon.
+        const cql_filter = this.stormwaterJurisdictionID ? `StormwaterJurisdictionID = ${this.stormwaterJurisdictionID}` : ``;
 
         const request$ = this.wfsService.getGeoserverWFSLayerWithCQLFilter("OCStormwater:LandUseBlocks", cql_filter, "LandUseBlockID");
         const tracked$ = this.trackLayerRequest$(request$);
 
         this.isLoading = true;
         tracked$.pipe(finalize(() => (this.isLoading = false))).subscribe((response) => {
-            if (response.length == 0) return;
+            if (response.length == 0) {
+                this.featureGroups = {};
+                this.featureGroupBounds = {};
+                return;
+            }
 
-            const featuresGroupedByLandUseBlockID = this.groupByPipe.transform(response, "properties.LandUseBlockID");
-
-            Object.keys(featuresGroupedByLandUseBlockID).forEach((landUseBlockID) => {
-                const idAsNumber = Number(landUseBlockID);
-                const features = featuresGroupedByLandUseBlockID[landUseBlockID];
-                const isSelected = this.selectedLandUseBlockIDs.includes(idAsNumber);
-                const baseStyle = isSelected ? this.highlightStyle : this.styleDictionary[features[0].properties.PriorityLandUseTypeID];
-                const geoJson = L.geoJSON(features, { style: baseStyle });
-                geoJson.on("mouseover", () => {
-                    geoJson.setStyle({ fillOpacity: 0.75 });
-                });
-                geoJson.on("mouseout", () => {
-                    geoJson.setStyle({ fillOpacity: 0.5 });
-                });
-
-                geoJson.on("click", () => {
-                    this.onLandUseBlockClicked(idAsNumber);
-                });
-
-                geoJson.addTo(this.layer);
+            // GroupByPipe.transform's declared ReadonlyMap return type is inaccurate — it returns a
+            // plain keyed object at runtime (hence the Object.keys / index access used here).
+            this.featureGroups = this.groupByPipe.transform(response, "properties.LandUseBlockID") as unknown as { [landUseBlockID: string]: any[] };
+            // Pre-compute each block's bounds once so the per-pan viewport filter is a cheap
+            // intersects() check rather than re-deriving geometry bounds on every moveend.
+            this.featureGroupBounds = {};
+            Object.keys(this.featureGroups).forEach((id) => {
+                this.featureGroupBounds[id] = this.computeGroupBounds(this.featureGroups[id]);
             });
+
+            this.renderFeatures();
 
             if (this.zoomToSelectionOnChange) {
                 this.zoomToSelection();
             }
         });
+    }
+
+    /** Draw the cached blocks, restricted to the current viewport when restrictToViewport is set. */
+    private renderFeatures() {
+        if (!this.featureGroups) return;
+        this.layer.clearLayers();
+        const viewportBounds = this.restrictToViewport && this.map ? this.map.getBounds() : null;
+
+        Object.keys(this.featureGroups).forEach((landUseBlockID) => {
+            if (viewportBounds) {
+                const groupBounds = this.featureGroupBounds[landUseBlockID];
+                if (!groupBounds || !viewportBounds.intersects(groupBounds)) {
+                    return;
+                }
+            }
+            const idAsNumber = Number(landUseBlockID);
+            const features = this.featureGroups[landUseBlockID];
+            const isSelected = this.selectedLandUseBlockIDs.includes(idAsNumber);
+            const baseStyle = isSelected ? this.highlightStyle : this.styleDictionary[features[0].properties.PriorityLandUseTypeID];
+            const geoJson = L.geoJSON(features, { style: baseStyle });
+            geoJson.on("mouseover", () => {
+                geoJson.setStyle({ fillOpacity: 0.75 });
+            });
+            geoJson.on("mouseout", () => {
+                geoJson.setStyle({ fillOpacity: 0.5 });
+            });
+            geoJson.on("click", () => {
+                this.onLandUseBlockClicked(idAsNumber);
+            });
+            geoJson.addTo(this.layer);
+        });
+    }
+
+    /** Bounding box of a block's GeoJSON features (lng/lat coords), used for the viewport filter. */
+    private computeGroupBounds(features: any[]): L.LatLngBounds | null {
+        let minLat = Infinity, minLng = Infinity, maxLat = -Infinity, maxLng = -Infinity;
+        const visit = (node: any) => {
+            if (typeof node[0] === "number") {
+                const [lng, lat] = node;
+                if (lat < minLat) minLat = lat;
+                if (lat > maxLat) maxLat = lat;
+                if (lng < minLng) minLng = lng;
+                if (lng > maxLng) maxLng = lng;
+                return;
+            }
+            node.forEach(visit);
+        };
+        for (const feature of features) {
+            if (feature?.geometry?.coordinates) {
+                visit(feature.geometry.coordinates);
+            }
+        }
+        return minLat === Infinity ? null : L.latLngBounds([minLat, minLng], [maxLat, maxLng]);
     }
 
     private onLandUseBlockClicked(landUseBlockID: number) {

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/selected-land-use-block-layer/selected-land-use-block-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/selected-land-use-block-layer/selected-land-use-block-layer.component.ts
@@ -152,6 +152,10 @@ export class SelectedLandUseBlockLayerComponent extends MapLayerBase implements 
 
     private updateLayer() {
         this.layer.clearLayers();
+        // Drop the cached features up front so a moveend during the in-flight refetch (e.g. after a
+        // jurisdiction change) can't re-render the previous jurisdiction's blocks.
+        this.featureGroups = null;
+        this.featureGroupBounds = {};
         this.addLandUseBlocksToLayer();
         this.layer.addTo(this.map);
     }

--- a/Neptune.Web/src/app/shared/generated/model/onland-visual-trash-assessment-area-detail-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/onland-visual-trash-assessment-area-detail-dto.ts
@@ -26,6 +26,7 @@ export class OnlandVisualTrashAssessmentAreaDetailDto {
     CompletedProgressAssessmentCount?: number;
     BoundingBox?: BoundingBoxDto;
     Geometry?: string | null;
+    JurisdictionHasLandUseBlocks?: boolean;
     constructor(obj?: any) {
         Object.assign(this, obj);
     }
@@ -46,6 +47,7 @@ export interface OnlandVisualTrashAssessmentAreaDetailDtoForm {
     CompletedProgressAssessmentCount?: FormControl<number>;
     BoundingBox?: FormControl<BoundingBoxDto>;
     Geometry?: FormControl<string>;
+    JurisdictionHasLandUseBlocks?: FormControl<boolean>;
 }
 
 export class OnlandVisualTrashAssessmentAreaDetailDtoFormControls { 
@@ -180,6 +182,16 @@ export class OnlandVisualTrashAssessmentAreaDetailDtoFormControls {
         }
     );
     public static Geometry = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static JurisdictionHasLandUseBlocks = (value: FormControlState<boolean> | boolean = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<boolean>(
         value,
         formControlOptions ?? 
         {

--- a/Neptune.Web/src/app/shared/generated/model/onland-visual-trash-assessment-area-geometry-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/onland-visual-trash-assessment-area-geometry-dto.ts
@@ -12,9 +12,10 @@
 import { FormControl, FormControlOptions, FormControlState, Validators } from "@angular/forms";
 export class OnlandVisualTrashAssessmentAreaGeometryDto { 
     OnlandVisualTrashAssessmentAreaID?: number;
+    OvtaAreaSourceTypeID?: number | null;
     ParcelIDs?: Array<number> | null;
+    SelectedLandUseBlockIDs?: Array<number> | null;
     GeometryAsGeoJson?: string | null;
-    UsingParcels?: boolean;
     constructor(obj?: any) {
         Object.assign(this, obj);
     }
@@ -22,13 +23,24 @@ export class OnlandVisualTrashAssessmentAreaGeometryDto {
 
 export interface OnlandVisualTrashAssessmentAreaGeometryDtoForm { 
     OnlandVisualTrashAssessmentAreaID?: FormControl<number>;
+    OvtaAreaSourceTypeID?: FormControl<number>;
     ParcelIDs?: FormControl<Array<number>>;
+    SelectedLandUseBlockIDs?: FormControl<Array<number>>;
     GeometryAsGeoJson?: FormControl<string>;
-    UsingParcels?: FormControl<boolean>;
 }
 
 export class OnlandVisualTrashAssessmentAreaGeometryDtoFormControls { 
     public static OnlandVisualTrashAssessmentAreaID = (value: FormControlState<number> | number = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<number>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static OvtaAreaSourceTypeID = (value: FormControlState<number> | number = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<number>(
         value,
         formControlOptions ?? 
         {
@@ -48,7 +60,7 @@ export class OnlandVisualTrashAssessmentAreaGeometryDtoFormControls {
             ],
         }
     );
-    public static GeometryAsGeoJson = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
+    public static SelectedLandUseBlockIDs = (value: FormControlState<Array<number>> | Array<number> = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<Array<number>>(
         value,
         formControlOptions ?? 
         {
@@ -58,7 +70,7 @@ export class OnlandVisualTrashAssessmentAreaGeometryDtoFormControls {
             ],
         }
     );
-    public static UsingParcels = (value: FormControlState<boolean> | boolean = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<boolean>(
+    public static GeometryAsGeoJson = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
         value,
         formControlOptions ?? 
         {


### PR DESCRIPTION
## Summary
Brings the **Edit OVTA Area Location** page to parity with the OVTA create workflow's source-type picker. The edit page previously had only a "Pick Parcels" / "Draw OVTA Areas" button and a non-interactive land-use-block reference layer.

**Frontend — `trash-ovta-area-edit-location`**
- Replaces the button with the create workflow's `btn-group-radio-input`, extended to three options: **Land Use Blocks / Parcels / Draw**. Defaults to Draw, so the page opens showing the existing geometry editable.
- **Land Use Block** mode renders the interactive `selected-land-use-block-layer` (click to select/deselect); **Parcel** mode keeps the existing WFS parcel pick; **Draw** keeps Geoman freehand editing.
- Land Use Blocks option is disabled with the "No land use blocks uploaded for this jurisdiction" helper when the jurisdiction has none (matches create / the Jira spec).
- No auto-zoom when toggling parcels; a late parcel WFS response no longer re-adds parcels after switching modes.

**Shared `selected-land-use-block-layer`**
- Opt-in `restrictToViewport`: fetches the jurisdiction's blocks once, caches them, and renders only those in the current viewport (re-rendering from cache on pan/zoom). Prevents dense jurisdictions (Tustin ~3k, Irvine ~61k) from locking up the browser. Enabled on the edit page + create workflow; the LUB index page keeps its browse-all behavior.

**Backend**
- `OnlandVisualTrashAssessmentAreaGeometryDto` gains `OvtaAreaSourceTypeID` + `SelectedLandUseBlockIDs`; `OnlandVisualTrashAssessmentAreas.UpdateGeometry` branches on source type, unioning the selected land use blocks (State Plane + 4326) alongside the existing parcel and manual-geometry paths.
- Area detail DTO exposes `JurisdictionHasLandUseBlocks` (set in the GET action) to drive the disabled toggle option.
- Test covering the `UpdateGeometry` land-use-block branch.

> ⚠️ Backend (DTO/service/controller) changed — the **API container must be rebuilt** for the new save behavior + flag to take effect.

## Test plan
- [ ] Edit an OVTA area in a jurisdiction **with** land use blocks (e.g. City of Tustin). Toggle shows **Land Use Blocks / Parcels / Draw**, opens in Draw with the existing geometry editable.
- [ ] **Land Use Blocks**: blocks load (viewport-limited, responsive), click selects/deselects, pan loads more; Save persists the unioned geometry (reopen confirms the new shape).
- [ ] **Parcels**: parcel picking works; toggling doesn't fly the map; Save persists.
- [ ] **Draw**: Geoman freehand edit still saves.
- [ ] Switching Parcels → Land Use Blocks clears the parcels (only LUBs remain interactive).
- [ ] Jurisdiction with **no** land use blocks: Land Use Blocks option disabled + helper message; Parcels/Draw work.
- [ ] Regression: create workflow (Select Assessment Area) still works and is now viewport-limited for LUBs; the Land Use Block index page still loads all blocks.