### PR TITLE
NPT-1040: Treatment BMP Type editor fixes + assessment score hardening

### DIFF
--- a/Neptune.EFModels/Entities/ObservationTypeCollectionMethod.cs
+++ b/Neptune.EFModels/Entities/ObservationTypeCollectionMethod.cs
@@ -166,7 +166,17 @@ namespace Neptune.EFModels.Entities
         public override double? GetObservationValueFromObservationData(string observationData)
         {
             var observation = GeoJsonSerializer.Deserialize<PassFailObservationSchema>(observationData);
-            var conveyanceFails = observation.SingleValueObservations.Any(x => bool.TryParse(x.ObservationValue?.ToString(), out var passed) && !passed);
+            // Distinguish "no valid value" (return null) from "all values passed": skip blank/unparseable
+            // values, and if none remain don't report a passing score that would mask incomplete data.
+            var passFailValues = observation.SingleValueObservations
+                .Where(x => bool.TryParse(x.ObservationValue?.ToString(), out _))
+                .Select(x => bool.Parse(x.ObservationValue.ToString()))
+                .ToList();
+            if (passFailValues.Count == 0)
+            {
+                return null;
+            }
+            var conveyanceFails = passFailValues.Any(passed => !passed);
             return conveyanceFails ? 0 : 5;
         }
 
@@ -181,8 +191,17 @@ namespace Neptune.EFModels.Entities
             bool overrideAssessmentScoreIfFailing)
         {
             var observation = GeoJsonSerializer.Deserialize<PassFailObservationSchema>(observationData);
-            var conveyanceFails = observation.SingleValueObservations.Any(x => bool.TryParse(x.ObservationValue?.ToString(), out var passed) && !passed);
+            var passFailValues = observation.SingleValueObservations
+                .Where(x => bool.TryParse(x.ObservationValue?.ToString(), out _))
+                .Select(x => bool.Parse(x.ObservationValue.ToString()))
+                .ToList();
+            if (passFailValues.Count == 0)
+            {
+                // No valid value yet — don't label a blank observation as passing.
+                return string.Empty;
+            }
             var schema = GeoJsonSerializer.Deserialize<PassFailObservationTypeSchema>(observationTypeSchema);
+            var conveyanceFails = passFailValues.Any(passed => !passed);
             return conveyanceFails ? schema.FailingScoreLabel : schema.PassingScoreLabel;
         }
     }

--- a/Neptune.EFModels/Entities/ObservationTypeCollectionMethod.cs
+++ b/Neptune.EFModels/Entities/ObservationTypeCollectionMethod.cs
@@ -83,7 +83,13 @@ namespace Neptune.EFModels.Entities
         public override double? GetObservationValueFromObservationData(string observationData)
         {
             var observation = GeoJsonSerializer.Deserialize<DiscreteObservationSchema>(observationData);
-            return observation.SingleValueObservations.Average(x => double.Parse(x.ObservationValue.ToString()));
+            // A blank ObservationValue is a valid persisted state (validation flags it but doesn't block
+            // save), so skip null/unparseable values rather than NRE on .ToString().
+            var values = observation.SingleValueObservations
+                .Where(x => double.TryParse(x.ObservationValue?.ToString(), out _))
+                .Select(x => double.Parse(x.ObservationValue.ToString()))
+                .ToList();
+            return values.Count > 0 ? values.Average() : null;
         }
 
         public override double? CalculateScore(TreatmentBMPObservation treatmentBMPObservation, TreatmentBMP treatmentBMP)
@@ -160,7 +166,7 @@ namespace Neptune.EFModels.Entities
         public override double? GetObservationValueFromObservationData(string observationData)
         {
             var observation = GeoJsonSerializer.Deserialize<PassFailObservationSchema>(observationData);
-            var conveyanceFails = observation.SingleValueObservations.Any(x => bool.Parse(x.ObservationValue.ToString()) == false);
+            var conveyanceFails = observation.SingleValueObservations.Any(x => bool.TryParse(x.ObservationValue?.ToString(), out var passed) && !passed);
             return conveyanceFails ? 0 : 5;
         }
 
@@ -175,7 +181,7 @@ namespace Neptune.EFModels.Entities
             bool overrideAssessmentScoreIfFailing)
         {
             var observation = GeoJsonSerializer.Deserialize<PassFailObservationSchema>(observationData);
-            var conveyanceFails = observation.SingleValueObservations.Any(x => bool.Parse(x.ObservationValue.ToString()) == false);
+            var conveyanceFails = observation.SingleValueObservations.Any(x => bool.TryParse(x.ObservationValue?.ToString(), out var passed) && !passed);
             var schema = GeoJsonSerializer.Deserialize<PassFailObservationTypeSchema>(observationTypeSchema);
             return conveyanceFails ? schema.FailingScoreLabel : schema.PassingScoreLabel;
         }
@@ -239,7 +245,13 @@ namespace Neptune.EFModels.Entities
         public override double? GetObservationValueFromObservationData(string observationData)
         {
             var observation = GeoJsonSerializer.Deserialize<PercentageObservationSchema>(observationData);
-            return observation.SingleValueObservations.Sum(x => double.Parse(x.ObservationValue.ToString()));
+            // A blank ObservationValue is a valid persisted state (validation flags it but doesn't block
+            // save), so skip null/unparseable values rather than NRE on .ToString().
+            var values = observation.SingleValueObservations
+                .Where(x => double.TryParse(x.ObservationValue?.ToString(), out _))
+                .Select(x => double.Parse(x.ObservationValue.ToString()))
+                .ToList();
+            return values.Count > 0 ? values.Sum() : null;
         }
 
         public override double? CalculateScore(TreatmentBMPObservation treatmentBMPObservation, TreatmentBMP treatmentBMP)

--- a/Neptune.EFModels/Entities/TreatmentBMPTypes.StaticHelpers.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPTypes.StaticHelpers.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Neptune.Common;
 using Neptune.Models.DataTransferObjects;
 
 namespace Neptune.EFModels.Entities;
@@ -67,16 +68,54 @@ public static class TreatmentBMPTypesAdmin
 
         entity.TreatmentBMPTypeName = dto.TreatmentBMPTypeName;
         entity.TreatmentBMPTypeDescription = dto.TreatmentBMPTypeDescription;
-        await dbContext.SaveChangesAsync();
 
-        // Delete-and-recreate child relationship records
-        dbContext.TreatmentBMPTypeAssessmentObservationTypes.RemoveRange(
-            dbContext.TreatmentBMPTypeAssessmentObservationTypes.Where(x => x.TreatmentBMPTypeID == treatmentBMPTypeID));
-        dbContext.TreatmentBMPTypeCustomAttributeTypes.RemoveRange(
-            dbContext.TreatmentBMPTypeCustomAttributeTypes.Where(x => x.TreatmentBMPTypeID == treatmentBMPTypeID));
-        await dbContext.SaveChangesAsync();
+        // Merge (upsert) rather than delete-and-recreate the child relationship rows. A
+        // TreatmentBMPTypeAssessmentObservationType is referenced by real TreatmentBMPObservation
+        // field data, so blanket-deleting the rows trips that FK on any type that already has
+        // assessments. Merge updates existing rows in place (preserving their PK), adds genuinely
+        // new ones, and deletes only rows the user actually removed — matching the legacy MVC editor.
+        var existingObservationTypes = await dbContext.TreatmentBMPTypeAssessmentObservationTypes
+            .Where(x => x.TreatmentBMPTypeID == treatmentBMPTypeID)
+            .ToListAsync();
+        var updatedObservationTypes = (dto.ObservationTypes ?? new List<TreatmentBMPTypeObservationTypeUpsertDto>())
+            .Select(x => new TreatmentBMPTypeAssessmentObservationType
+            {
+                TreatmentBMPTypeID = treatmentBMPTypeID,
+                TreatmentBMPAssessmentObservationTypeID = x.TreatmentBMPAssessmentObservationTypeID,
+                AssessmentScoreWeight = x.AssessmentScoreWeight,
+                DefaultThresholdValue = x.DefaultThresholdValue,
+                DefaultBenchmarkValue = x.DefaultBenchmarkValue,
+                OverrideAssessmentScoreIfFailing = x.OverrideAssessmentScoreIfFailing,
+                SortOrder = x.SortOrder,
+            }).ToList();
+        existingObservationTypes.Merge(updatedObservationTypes,
+            dbContext.TreatmentBMPTypeAssessmentObservationTypes,
+            (x, y) => x.TreatmentBMPTypeID == y.TreatmentBMPTypeID && x.TreatmentBMPAssessmentObservationTypeID == y.TreatmentBMPAssessmentObservationTypeID,
+            (x, y) =>
+            {
+                x.AssessmentScoreWeight = y.AssessmentScoreWeight;
+                x.DefaultThresholdValue = y.DefaultThresholdValue;
+                x.DefaultBenchmarkValue = y.DefaultBenchmarkValue;
+                x.OverrideAssessmentScoreIfFailing = y.OverrideAssessmentScoreIfFailing;
+                x.SortOrder = y.SortOrder;
+            });
 
-        await SaveChildRecordsAsync(dbContext, treatmentBMPTypeID, dto);
+        var existingCustomAttributeTypes = await dbContext.TreatmentBMPTypeCustomAttributeTypes
+            .Where(x => x.TreatmentBMPTypeID == treatmentBMPTypeID)
+            .ToListAsync();
+        var updatedCustomAttributeTypes = (dto.CustomAttributeTypes ?? new List<TreatmentBMPTypeCustomAttributeTypeUpsertDto>())
+            .Select(x => new TreatmentBMPTypeCustomAttributeType
+            {
+                TreatmentBMPTypeID = treatmentBMPTypeID,
+                CustomAttributeTypeID = x.CustomAttributeTypeID,
+                SortOrder = x.SortOrder,
+            }).ToList();
+        existingCustomAttributeTypes.Merge(updatedCustomAttributeTypes,
+            dbContext.TreatmentBMPTypeCustomAttributeTypes,
+            (x, y) => x.TreatmentBMPTypeID == y.TreatmentBMPTypeID && x.CustomAttributeTypeID == y.CustomAttributeTypeID,
+            (x, y) => x.SortOrder = y.SortOrder);
+
+        await dbContext.SaveChangesAsync();
         return await GetByIDAsDtoAsync(dbContext, treatmentBMPTypeID);
     }
 

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/visit-summary-step/visit-summary-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/visit-summary-step/visit-summary-step.component.html
@@ -36,7 +36,7 @@
             @if (workflow.InitialAssessmentID) {
                 {{ workflow.InitialAssessmentComplete ? "Complete" : "In Progress" }}
                 @if (workflow.InitialAssessmentScore != null) {
-                    &mdash; Score {{ workflow.InitialAssessmentScore | number: "1.1-1" }}
+                    &mdash; Score {{ workflow.InitialAssessmentScore | number: "1.2-2" }}
                 }
             } @else {
                 Not Performed
@@ -71,7 +71,7 @@
             @if (workflow.PostMaintenanceAssessmentID) {
                 {{ workflow.PostMaintenanceAssessmentComplete ? "Complete" : "In Progress" }}
                 @if (workflow.PostMaintenanceAssessmentScore != null) {
-                    &mdash; Score {{ workflow.PostMaintenanceAssessmentScore | number: "1.1-1" }}
+                    &mdash; Score {{ workflow.PostMaintenanceAssessmentScore | number: "1.2-2" }}
                 }
             } @else {
                 Not Performed

--- a/Neptune.Web/src/app/pages/manage/treatment-bmp-type-edit/treatment-bmp-type-edit.component.html
+++ b/Neptune.Web/src/app/pages/manage/treatment-bmp-type-edit/treatment-bmp-type-edit.component.html
@@ -112,6 +112,7 @@
                                     <td>
                                         <input type="number" class="form-control form-control-sm"
                                             [(ngModel)]="row.AssessmentScoreWeight"
+                                            (ngModelChange)="onObservationRowChanged()"
                                             [disabled]="isPassFail(row) && row.OverrideAssessmentScoreIfFailing"
                                             min="0" max="100" step="1">
                                     </td>
@@ -119,7 +120,7 @@
                                     <!-- Assessment Fails if Observation Fails: only meaningful for Pass/Fail rows. -->
                                     <td class="cell-center">
                                         @if (isPassFail(row)) {
-                                            <input type="checkbox" [(ngModel)]="row.OverrideAssessmentScoreIfFailing">
+                                            <input type="checkbox" [(ngModel)]="row.OverrideAssessmentScoreIfFailing" (ngModelChange)="onObservationRowChanged()">
                                         } @else {
                                             <span class="muted">—</span>
                                         }
@@ -214,7 +215,7 @@
 
         <!-- Actions -->
         <div class="page-footer">
-            <button class="btn btn-primary" (click)="save()" [disabled]="isSaving || nameControl.invalid || descriptionControl.invalid || hasWeightError()">Save</button>
+            <button class="btn btn-primary" (click)="save()" [disabled]="isSaving">Save</button>
             <button class="btn btn-secondary-outline" (click)="cancel()">Cancel</button>
             @if (!isCreate) {
                 <button class="btn btn-danger-outline" (click)="deleteBMPType()" style="margin-left: auto">

--- a/Neptune.Web/src/app/pages/manage/treatment-bmp-type-edit/treatment-bmp-type-edit.component.ts
+++ b/Neptune.Web/src/app/pages/manage/treatment-bmp-type-edit/treatment-bmp-type-edit.component.ts
@@ -144,7 +144,10 @@ export class TreatmentBmpTypeEditComponent implements OnInit {
                         HasBenchmarkAndThreshold: o.HasBenchmarkAndThreshold,
                         BenchmarkUnitDisplayName: o.BenchmarkUnitDisplayName,
                         ThresholdUnitDisplayName: o.ThresholdUnitDisplayName,
-                        AssessmentScoreWeight: o.AssessmentScoreWeight ?? null,
+                        // NPT-1040: the API stores AssessmentScoreWeight as a decimal 0–1; the UI
+                        // shows + sums whole percents (matching MVC). Convert to percent on load
+                        // (toFixed(4) trims float noise like 0.07*100=7.0000001) and back on save.
+                        AssessmentScoreWeight: o.AssessmentScoreWeight != null ? Number((o.AssessmentScoreWeight * 100).toFixed(4)) : null,
                         DefaultThresholdValue: o.DefaultThresholdValue,
                         DefaultBenchmarkValue: o.DefaultBenchmarkValue,
                         OverrideAssessmentScoreIfFailing: o.OverrideAssessmentScoreIfFailing,
@@ -181,6 +184,16 @@ export class TreatmentBmpTypeEditComponent implements OnInit {
 
     public isPassFail(row: ObservationTypeRow): boolean {
         return row.CollectionMethodID === ObservationTypeCollectionMethodEnum.PassFail;
+    }
+
+    /**
+     * The weight + "fails-if-fails" inputs use [(ngModel)], which mutates the row object in place
+     * without changing the observationTypeRows signal reference — so the weightTotal / hasWeightError
+     * computeds never recompute and the total goes stale. Re-set the signal with a fresh array (same
+     * row objects) on each edit so those computeds re-run and the live total stays correct.
+     */
+    public onObservationRowChanged(): void {
+        this.observationTypeRows.set([...this.observationTypeRows()]);
     }
 
     addObservationType(): void {
@@ -264,11 +277,28 @@ export class TreatmentBmpTypeEditComponent implements OnInit {
     }
 
     save(): void {
-        if (this.nameControl.invalid || this.descriptionControl.invalid) return;
+        // NPT-1040: the Save button stays enabled even when the form is invalid — this form is
+        // complex enough that a silently-disabled button is confusing. Validate on click and
+        // surface a clear alert per failure instead.
+        this.nameControl.markAsTouched();
+        this.descriptionControl.markAsTouched();
+
+        const validationErrors: string[] = [];
+        if (this.nameControl.invalid) {
+            validationErrors.push("Name is required.");
+        }
+        if (this.descriptionControl.invalid) {
+            validationErrors.push("Description is required.");
+        }
         if (this.hasWeightError()) {
-            this.alertService.pushAlert(new Alert(`Observation type weights must sum to 100%. Currently: ${this.weightTotal()}%.`, AlertContext.Danger));
+            validationErrors.push(`Observation type weights must sum to 100%. Currently: ${this.weightTotal()}%.`);
+        }
+        if (validationErrors.length > 0) {
+            this.alertService.clearAlerts();
+            validationErrors.forEach((message) => this.alertService.pushAlert(new Alert(message, AlertContext.Danger)));
             return;
         }
+
         this.isSaving = true;
         this.alertService.clearAlerts();
 
@@ -278,7 +308,8 @@ export class TreatmentBmpTypeEditComponent implements OnInit {
             ObservationTypes: this.observationTypeRows().map((r) => ({
                 TreatmentBMPAssessmentObservationTypeID: r.TreatmentBMPAssessmentObservationTypeID,
                 // Pass/Fail-with-override rows have null weight (the row's failure short-circuits scoring).
-                AssessmentScoreWeight: this.rowCountsTowardWeight(r) ? r.AssessmentScoreWeight : null,
+                // Convert the whole-percent UI value back to the decimal 0–1 the API stores.
+                AssessmentScoreWeight: this.rowCountsTowardWeight(r) && r.AssessmentScoreWeight != null ? Number(r.AssessmentScoreWeight) / 100 : null,
                 DefaultThresholdValue: r.HasBenchmarkAndThreshold ? r.DefaultThresholdValue : null,
                 DefaultBenchmarkValue: r.HasBenchmarkAndThreshold ? r.DefaultBenchmarkValue : null,
                 OverrideAssessmentScoreIfFailing: r.OverrideAssessmentScoreIfFailing,
@@ -297,10 +328,13 @@ export class TreatmentBmpTypeEditComponent implements OnInit {
         save$.subscribe({
             next: (saved) => {
                 this.isSaving = false;
-                this.alertService.pushAlert(new Alert(`Treatment BMP Type ${this.isCreate ? "created" : "updated"}.`, AlertContext.Success));
                 // Match MVC behavior: redirect to the detail page after save (works for both
-                // create and update — the response carries the persisted ID).
-                this.router.navigate(["/program-info/treatment-bmp-types", saved.TreatmentBMPTypeID]);
+                // create and update — the response carries the persisted ID). Push the success
+                // alert *after* navigation resolves: this page's own <app-alert-display> clears
+                // alerts on destroy, so an alert pushed before navigating gets wiped en route.
+                this.router.navigate(["/program-info/treatment-bmp-types", saved.TreatmentBMPTypeID]).then(() => {
+                    this.alertService.pushAlert(new Alert(`Treatment BMP Type ${this.isCreate ? "created" : "updated"}.`, AlertContext.Success));
+                });
             },
             error: () => {
                 this.isSaving = false;

--- a/Neptune.Web/src/app/pages/manage/treatment-bmp-type-edit/treatment-bmp-type-edit.component.ts
+++ b/Neptune.Web/src/app/pages/manage/treatment-bmp-type-edit/treatment-bmp-type-edit.component.ts
@@ -290,7 +290,13 @@ export class TreatmentBmpTypeEditComponent implements OnInit {
         if (this.descriptionControl.invalid) {
             validationErrors.push("Description is required.");
         }
-        if (this.hasWeightError()) {
+        // Every row that counts toward the weight total (non-override) must have a weight: a blank
+        // one is excluded from the sum, so it can slip past the "= 100%" check yet save as a null
+        // weight that CalculateAssessmentScore later dereferences. Matches the legacy MVC validator.
+        const countingRowsMissingWeight = this.observationTypeRows().filter((r) => this.rowCountsTowardWeight(r) && r.AssessmentScoreWeight == null);
+        if (countingRowsMissingWeight.length > 0) {
+            validationErrors.push("Each observation type that does not override the assessment score when failing must have an assessment score weight.");
+        } else if (this.hasWeightError()) {
             validationErrors.push(`Observation type weights must sum to 100%. Currently: ${this.weightTotal()}%.`);
         }
         if (validationErrors.length > 0) {

--- a/Neptune.Web/src/app/pages/program-info/treatment-bmp-type-detail/treatment-bmp-type-detail.component.html
+++ b/Neptune.Web/src/app/pages/program-info/treatment-bmp-type-detail/treatment-bmp-type-detail.component.html
@@ -16,6 +16,8 @@
         </ng-template>
     </page-header>
 
+    <app-alert-display></app-alert-display>
+
     <div class="grid-12">
         <!-- Basics -->
         <div class="card g-col-12">

--- a/Neptune.Web/src/app/pages/program-info/treatment-bmp-type-detail/treatment-bmp-type-detail.component.ts
+++ b/Neptune.Web/src/app/pages/program-info/treatment-bmp-type-detail/treatment-bmp-type-detail.component.ts
@@ -7,6 +7,7 @@ import { escapeHtml } from "src/app/shared/helpers/html-escape";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
 import { NeptuneGridComponent } from "src/app/shared/components/neptune-grid/neptune-grid.component";
+import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
 import { ConfirmService } from "src/app/shared/services/confirm/confirm.service";
 import { AlertService } from "src/app/shared/services/alert.service";
 import { Alert } from "src/app/shared/models/alert";
@@ -31,7 +32,7 @@ interface AttributesByPurpose {
 @Component({
     selector: "treatment-bmp-type-detail",
     standalone: true,
-    imports: [AsyncPipe, RouterLink, PageHeaderComponent, LoadingDirective, NeptuneGridComponent],
+    imports: [AsyncPipe, RouterLink, PageHeaderComponent, LoadingDirective, NeptuneGridComponent, AlertDisplayComponent],
     templateUrl: "./treatment-bmp-type-detail.component.html",
     styleUrl: "./treatment-bmp-type-detail.component.scss",
 })


### PR DESCRIPTION
## Summary

Addresses the remaining red items on NPT-1040 (Treatment BMP Type admin editor SPA migration) plus two related fixes surfaced during verification.

**Treatment BMP Type editor**
- Weight values now display/sum as whole percents in the UI and convert to/from the decimal 0–1 the API stores (fixes the decimal display and the broken "Total = 100%").
- Save button stays enabled; invalid input (missing name/description, weights ≠ 100%) surfaces a clear alert per failure instead of a silently-disabled button. Live weight total updates correctly via signal re-set.
- **Fixed FK conflict on save:** `UpdateAsync` now merges (upserts) the child observation-type / custom-attribute rows instead of delete-and-recreate. The old approach tripped `FK_TreatmentBMPObservation_...` on any type that already had field assessments; the merge updates rows in place and preserves their PK so existing assessment data stays valid. Matches the legacy MVC editor's behavior.
- **Fixed missing success alert:** the detail page now renders `<app-alert-display>`, and the success alert is pushed after navigation resolves so it survives the edit page's clear-alerts-on-destroy.

**Assessment score hardening (related, surfaced during testing)**
- Null-guarded the observation-value parsers in `ObservationTypeCollectionMethod` (Discrete/Percentage/PassFail) so a blank `ObservationValue` is skipped rather than throwing a `NullReferenceException` when computing the value/score.
- Visit summary now shows Initial and Post-Maintenance assessment scores to two decimal places.

## Test plan
- [ ] Edit a Treatment BMP Type that already has field assessments: change weights and save — succeeds (no FK error), values persist, existing observations intact.
- [ ] Weights display as whole percents; live Total matches the column sum; Save always clickable with validation alerts on bad input.
- [ ] After a valid save, land on the detail page and see the green success alert.
- [ ] Open an assessment with a blank observation value — loads without a 500/NRE.
- [ ] Visit summary shows assessment scores to 2 decimal places.