### PR TITLE
NPT-1061: Round-2 rework on Jurisdiction detail

### DIFF
--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-detail.component.ts
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-detail.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnChanges, SimpleChanges, ViewChild, TemplateRef, Input, inject } from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
 import { AsyncPipe, CommonModule } from "@angular/common";
-import { catchError, EMPTY, Observable, tap } from "rxjs";
+import { BehaviorSubject, catchError, EMPTY, Observable, shareReplay, switchMap, tap } from "rxjs";
 import { DialogService } from "@ngneat/dialog";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
@@ -9,6 +9,8 @@ import { ColDef } from "ag-grid-community";
 import { UtilityFunctionsService } from "src/app/services/utility-functions.service";
 import { AuthenticationService } from "src/app/services/authentication.service";
 import { AlertService } from "src/app/shared/services/alert.service";
+import { Alert } from "src/app/shared/models/alert";
+import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 import { NeptuneGridComponent } from "src/app/shared/components/neptune-grid/neptune-grid.component";
 import { IconComponent } from "src/app/shared/components/icon/icon.component";
 import { PersonDisplayDto, StormwaterJurisdictionGridDto, TreatmentBMPGridDto } from "src/app/shared/generated/model/models";
@@ -32,12 +34,20 @@ export class JurisdictionDetailComponent implements OnInit, OnChanges {
     public currentJurisdiction: StormwaterJurisdictionGridDto;
     private assignedPersonIDs: number[] = [];
 
+    // NPT-1061-2: zoneless Angular doesn't re-bind the template's async pipe when we reassign
+    // `this.foo$ = ...` inside a `.subscribe()` callback, so the previous loadData() reassign
+    // pattern left the page showing stale data after the Basics / Users modals closed. Driving
+    // the three template observables off this BehaviorSubject + switchMap means modal-close
+    // handlers just call `reload$.next()` and the async pipe stays bound across refreshes.
+    private reload$ = new BehaviorSubject<void>(undefined);
+
     public get canManage(): boolean {
         return this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission();
     }
+
     ngOnChanges(changes: SimpleChanges): void {
         if (changes["jurisdictionID"] && !changes["jurisdictionID"].firstChange) {
-            this.loadData();
+            this.reload$.next();
         }
     }
 
@@ -81,29 +91,42 @@ export class JurisdictionDetailComponent implements OnInit, OnChanges {
             this.utilityFunctionsService.createBasicColumnDef("Trash Capture Effectiveness (%)", "TrashCaptureEffectiveness"),
             this.utilityFunctionsService.createBasicColumnDef("Delineation Type", "DelineationTypeDisplayName"),
         ];
-        this.loadData();
-    }
 
-    private loadData(): void {
-        this.jurisdiction$ = this.stormwaterJurisdictionService.getStormwaterJurisdiction(this.jurisdictionID).pipe(
-            tap((jurisdiction) => (this.currentJurisdiction = jurisdiction)),
-            // NPT-1061 item 4c: JE/JM hitting a jurisdiction they're not assigned to get a 403 from
-            // the API; show the standard not-found/unauthorized alert and bounce to the list.
-            catchError(() => {
-                this.router.navigate(["/jurisdictions"]).then(() => this.alertService.pushNotFoundUnauthorizedAlert());
-                return EMPTY;
-            })
+        this.jurisdiction$ = this.reload$.pipe(
+            switchMap(() =>
+                this.stormwaterJurisdictionService.getStormwaterJurisdiction(this.jurisdictionID).pipe(
+                    tap((jurisdiction) => (this.currentJurisdiction = jurisdiction)),
+                    // NPT-1061 item 4c: JE/JM hitting a jurisdiction they're not assigned to get a
+                    // 403 from the API; show the standard not-found/unauthorized alert and bounce
+                    // to the list.
+                    catchError(() => {
+                        this.router.navigate(["/jurisdictions"]).then(() => this.alertService.pushNotFoundUnauthorizedAlert());
+                        return EMPTY;
+                    })
+                )
+            ),
+            shareReplay(1)
         );
-        this.users$ = this.stormwaterJurisdictionService.listUsersStormwaterJurisdiction(this.jurisdictionID).pipe(
-            tap((users) => {
-                this.assignedPersonIDs = users.map((u) => u.PersonID);
-                const third = Math.ceil(users.length / 3);
-                this.usersCol1 = users.slice(0, third);
-                this.usersCol2 = users.slice(third, third * 2);
-                this.usersCol3 = users.slice(third * 2);
-            })
+
+        this.users$ = this.reload$.pipe(
+            switchMap(() =>
+                this.stormwaterJurisdictionService.listUsersStormwaterJurisdiction(this.jurisdictionID).pipe(
+                    tap((users) => {
+                        this.assignedPersonIDs = users.map((u) => u.PersonID);
+                        const third = Math.ceil(users.length / 3);
+                        this.usersCol1 = users.slice(0, third);
+                        this.usersCol2 = users.slice(third, third * 2);
+                        this.usersCol3 = users.slice(third * 2);
+                    })
+                )
+            ),
+            shareReplay(1)
         );
-        this.treatmentBMPs$ = this.stormwaterJurisdictionService.listTreatmentBMPsStormwaterJurisdiction(this.jurisdictionID);
+
+        this.treatmentBMPs$ = this.reload$.pipe(
+            switchMap(() => this.stormwaterJurisdictionService.listTreatmentBMPsStormwaterJurisdiction(this.jurisdictionID)),
+            shareReplay(1)
+        );
     }
 
     public openBasicsModal(): void {
@@ -112,7 +135,10 @@ export class JurisdictionDetailComponent implements OnInit, OnChanges {
             data: { jurisdiction: this.currentJurisdiction } as JurisdictionBasicsModalContext,
         });
         ref.afterClosed$.subscribe((result) => {
-            if (result) this.loadData();
+            if (result) {
+                this.reload$.next();
+                this.alertService.pushAlert(new Alert("Jurisdiction basics updated.", AlertContext.Success));
+            }
         });
     }
 
@@ -126,7 +152,10 @@ export class JurisdictionDetailComponent implements OnInit, OnChanges {
             } as JurisdictionUsersModalContext,
         });
         ref.afterClosed$.subscribe((result) => {
-            if (result) this.loadData();
+            if (result) {
+                this.reload$.next();
+                this.alertService.pushAlert(new Alert("Assigned users updated.", AlertContext.Success));
+            }
         });
     }
 }

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.html
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.html
@@ -6,18 +6,35 @@
         @if (errorMessage(); as msg) {
             <div class="alert alert-danger">{{ msg }}</div>
         }
-        <p>Select the users assigned to this jurisdiction.</p>
-        @if (options$ | async; as options) {
+        <div class="picker-row mb-3">
+            <ng-select
+                [items]="availablePeople()"
+                bindValue="PersonID"
+                bindLabel="FullName"
+                [(ngModel)]="pickerPersonID"
+                [searchable]="true"
+                [clearable]="true"
+                appendTo="body"
+                placeholder="Search for a user...">
+            </ng-select>
+            <button type="button" class="btn btn-primary-outline btn-sm" (click)="addPerson()" [disabled]="pickerPersonID == null">
+                <i class="fa fa-plus"></i> Add
+            </button>
+        </div>
+
+        @if (assignedPeople().length) {
             <ul class="user-list">
-                @for (option of options; track option.PersonID) {
-                    <li>
-                        <label>
-                            <input type="checkbox" [checked]="option.selected" (change)="toggle(option)" />
-                            {{ option.Label }}
-                        </label>
+                @for (person of assignedPeople(); track person.PersonID) {
+                    <li style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin-bottom: 0.25rem">
+                        <span><strong>{{ person.FullName }}</strong> ({{ person.OrganizationName }})</span>
+                        <button type="button" class="remove-btn" (click)="removePerson(person.PersonID)" title="Remove">
+                            <i class="fa fa-trash"></i>
+                        </button>
                     </li>
                 }
             </ul>
+        } @else {
+            <p class="system-text">No users assigned.</p>
         }
     </div>
     <div class="modal-footer">

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.html
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.html
@@ -27,8 +27,8 @@
                 @for (person of assignedPeople(); track person.PersonID) {
                     <li style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin-bottom: 0.25rem">
                         <span><strong>{{ person.FullName }}</strong> ({{ person.OrganizationName }})</span>
-                        <button type="button" class="remove-btn" (click)="removePerson(person.PersonID)" title="Remove">
-                            <i class="fa fa-trash"></i>
+                        <button type="button" class="remove-btn" (click)="removePerson(person.PersonID)" [attr.aria-label]="'Remove ' + person.FullName" [title]="'Remove ' + person.FullName">
+                            <i class="fa fa-trash" aria-hidden="true"></i>
                         </button>
                     </li>
                 }

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.scss
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.scss
@@ -1,0 +1,40 @@
+@use "/src/scss/abstracts" as *;
+
+// Use the project's table-size type so more assigned users fit without scrolling.
+.picker-row,
+.user-list {
+    font-size: $type-size-200;
+}
+
+// Search dropdown + Add button share one row; the dropdown grows to fill, the button hugs its content.
+.picker-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    ng-select {
+        flex: 1;
+        min-width: 0;
+    }
+}
+
+.user-list {
+    list-style: none;
+    padding-left: 0;
+    margin-bottom: 0;
+
+    // Plain trash glyph — no button chrome — so the row stays compact alongside the small text.
+    .remove-btn {
+        background: none;
+        border: none;
+        padding: 0;
+        color: $danger;
+        cursor: pointer;
+        font-size: $type-size-200;
+        line-height: 1;
+
+        &:hover {
+            color: darken($danger, 10%);
+        }
+    }
+}

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.ts
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.ts
@@ -1,9 +1,11 @@
-import { AsyncPipe } from "@angular/common";
-import { Component, inject, OnInit, signal } from "@angular/core";
+import { Component, computed, inject, OnInit, signal } from "@angular/core";
+import { FormsModule } from "@angular/forms";
 import { DialogRef } from "@ngneat/dialog";
-import { map, Observable } from "rxjs";
+import { NgSelectModule } from "@ng-select/ng-select";
 import { StormwaterJurisdictionService } from "src/app/shared/generated/api/stormwater-jurisdiction.service";
 import { UserService } from "src/app/shared/generated/api/user.service";
+import { PersonSimpleDto } from "src/app/shared/generated/model/person-simple-dto";
+import { RoleEnum } from "src/app/shared/generated/enum/role-enum";
 
 export interface JurisdictionUsersModalContext {
     jurisdictionID: number;
@@ -11,59 +13,73 @@ export interface JurisdictionUsersModalContext {
     assignedPersonIDs: number[];
 }
 
-interface PersonOption {
-    PersonID: number;
-    Label: string;
-    selected: boolean;
-}
-
 @Component({
     selector: "jurisdiction-users-modal",
     standalone: true,
-    imports: [AsyncPipe],
+    imports: [FormsModule, NgSelectModule],
     templateUrl: "./jurisdiction-users-modal.component.html",
+    styleUrl: "./jurisdiction-users-modal.component.scss",
 })
 export class JurisdictionUsersModalComponent implements OnInit {
     public ref: DialogRef<JurisdictionUsersModalContext, boolean> = inject(DialogRef);
     private userService = inject(UserService);
     private jurisdictionService = inject(StormwaterJurisdictionService);
 
-    public options$: Observable<PersonOption[]>;
-    public selectedIDs = new Set<number>();
+    // NPT-1061-2 (KE 5/27): the old checkbox-of-everyone UX was unusable at scale. New shape:
+    // searchable picker → Add → list-with-remove. Admin and SitkaAdmin users are filtered out
+    // because they implicitly view/manage every jurisdiction and shouldn't be assigned per-row.
+    private allPeople = signal<PersonSimpleDto[]>([]);
+    public assignedPersonIDs = signal<Set<number>>(new Set());
+    public pickerPersonID: number | null = null;
     public isSaving = signal(false);
     public errorMessage = signal<string | null>(null);
 
-    ngOnInit(): void {
-        const assignedIDs = new Set(this.ref.data.assignedPersonIDs ?? []);
-        this.selectedIDs = new Set(assignedIDs);
+    // People not yet assigned — what the dropdown offers.
+    public availablePeople = computed(() => {
+        const assigned = this.assignedPersonIDs();
+        return this.allPeople()
+            .filter((p) => !assigned.has(p.PersonID))
+            .sort((a, b) => (a.FullName ?? "").localeCompare(b.FullName ?? ""));
+    });
 
-        this.options$ = this.userService.listUser().pipe(
-            map((people) =>
-                people
-                    .map((p) => ({
-                        PersonID: p.PersonID,
-                        Label: `${p.FullName} (${p.OrganizationName})`,
-                        selected: assignedIDs.has(p.PersonID),
-                    }))
-                    .sort((a, b) => a.Label.localeCompare(b.Label))
-            )
-        );
+    // People currently assigned — rendered as the editable list below the picker.
+    public assignedPeople = computed(() => {
+        const assigned = this.assignedPersonIDs();
+        return this.allPeople()
+            .filter((p) => assigned.has(p.PersonID))
+            .sort((a, b) => (a.FullName ?? "").localeCompare(b.FullName ?? ""));
+    });
+
+    ngOnInit(): void {
+        this.assignedPersonIDs.set(new Set(this.ref.data.assignedPersonIDs ?? []));
+        this.userService.listUser().subscribe((people) => {
+            // Admins and SitkaAdmins are filtered out per KE — they have implicit access already.
+            // Pre-existing assignments to those roles (legacy data) stay in `assignedPersonIDs`
+            // but won't render because they aren't in `allPeople`; save still preserves them.
+            const filtered = people.filter((p) => p.RoleID !== RoleEnum.Admin && p.RoleID !== RoleEnum.SitkaAdmin);
+            this.allPeople.set(filtered);
+        });
     }
 
-    public toggle(option: PersonOption): void {
-        option.selected = !option.selected;
-        if (option.selected) {
-            this.selectedIDs.add(option.PersonID);
-        } else {
-            this.selectedIDs.delete(option.PersonID);
-        }
+    public addPerson(): void {
+        if (this.pickerPersonID == null) return;
+        const next = new Set(this.assignedPersonIDs());
+        next.add(this.pickerPersonID);
+        this.assignedPersonIDs.set(next);
+        this.pickerPersonID = null;
+    }
+
+    public removePerson(personID: number): void {
+        const next = new Set(this.assignedPersonIDs());
+        next.delete(personID);
+        this.assignedPersonIDs.set(next);
     }
 
     public save(): void {
         this.isSaving.set(true);
         this.errorMessage.set(null);
         this.jurisdictionService
-            .updateUsersStormwaterJurisdiction(this.ref.data.jurisdictionID, { PersonIDs: Array.from(this.selectedIDs) })
+            .updateUsersStormwaterJurisdiction(this.ref.data.jurisdictionID, { PersonIDs: Array.from(this.assignedPersonIDs()) })
             .subscribe({
                 next: () => {
                     this.isSaving.set(false);

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdictions.component.html
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdictions.component.html
@@ -10,7 +10,7 @@
         entityIDField="StormwaterJurisdictionID"
         (onMapLoad)="handleMapReady($event, boundingBox)"
         [selectedValue]="selectedJurisdictionID"
-        [selectionFromMap]="true"
+        [selectionFromMap]="selectionFromMap"
         (selectedValueChange)="onSelectedJurisdictionIDChanged($event)">
         <jurisdictions-layer
             [map]="map"

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdictions.component.ts
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdictions.component.ts
@@ -32,6 +32,12 @@ export class JurisdictionsComponent {
     public mapIsReady: boolean = false;
     public boundingBox$: Observable<BoundingBoxDto>;
     public selectedJurisdictionID: number;
+    // NPT-1061-2: track whether the latest selection came from the map vs the grid. When `true`
+    // hybrid-map-grid programmatically re-selects + scrolls the matching row, which is what we
+    // want for map clicks but destroys the row's link cell-renderer mid-click for grid clicks
+    // (causing plain clicks on the Name link to no-op while ctrl+click still works). Same shape
+    // as treatment-bmps.component.ts.
+    public selectionFromMap: boolean = false;
     public isLoading: boolean = true;
     public OverlayMode = OverlayMode;
 
@@ -67,6 +73,7 @@ export class JurisdictionsComponent {
         if (this.selectedJurisdictionID == selectedJurisdictionID) {
             return;
         }
+        this.selectionFromMap = fromMap;
         this.selectedJurisdictionID = selectedJurisdictionID;
         return this.selectedJurisdictionID;
     }


### PR DESCRIPTION
## Summary

Round-2 rework on NPT-1061 covering the lozenges KE flagged on 5/27 (Jurisdiction detail modals), plus a related list-page click bug we surfaced during verification.

## Jurisdiction detail modals
- **Refresh-on-close (ID-7 + ID-9):** drive `jurisdiction$`, `users$`, and `treatmentBMPs$` through a `reload$ = new BehaviorSubject<void>()` + `switchMap` + `shareReplay(1)`. The Basics and Users modal close handlers call `reload$.next()` — reassigning observables inside `.subscribe()` callbacks doesn't re-bind the template's `async` pipe in zoneless Angular, which is why the panels were showing stale data.
- **Success alerts** after each modal save ("Jurisdiction basics updated.", "Assigned users updated.") via the existing `<app-alert-display>` already on the detail page.
- **Users-assigned modal redesign (ID-8):** ng-select searchable picker + "Add" button on one row, assigned-users list below with a bare trash glyph remove button. Filters out Admin / SitkaAdmin users from the picker via `PersonSimpleDto.RoleID`.
- **Compact styling:** scoped SCSS using `$type-size-200` on the picker + list so more rows fit at a glance; remove control is icon-only (no button chrome).

## Jurisdictions list page (related find during verification)
- Plain-click on a row's Name link wasn't navigating to the detail page (ctrl+click did). Root cause: `[selectionFromMap]="true"` was hardcoded, so every grid row click also took the programmatic `setSelected` + `ensureIndexVisible` path on `hybrid-map-grid`, which tore down the link cell-renderer mid-click and silently dropped the navigation. RouterLink lets ctrl+click pass through to the browser's native anchor, so ctrl+click still worked.
- Fix: track `selectionFromMap` as a dynamic flag (`true` from the map's emit, `false` from the grid's emit), matching the working `treatment-bmps.component.ts` shape.

No backend / codegen changes.

## Test plan
- [ ] `/jurisdictions/16` — Edit Basics → Save → page reflects the new visibility values without a manual refresh; green "Jurisdiction basics updated." alert shows.
- [ ] `/jurisdictions/16` — Edit Users → picker hides Admins/SitkaAdmins, type-to-filter works, Add appends, trash-icon removes, Save → assigned-users panel updates without manual refresh; green "Assigned users updated." alert shows.
- [ ] Users modal density: more rows visible without scrolling thanks to the smaller `$type-size-200` text + icon-only remove.
- [ ] Jurisdictions list → plain-click on a Name link navigates to that jurisdiction's detail page; ctrl+click still opens it in a new tab.
- [ ] As JurisdictionEditor (view-only), no edit pencils on the detail page; as a JurisdictionManager-with-jurisdiction, both pencils work; as a JE/JM hitting another jurisdiction's URL, still redirects to `/jurisdictions` with the unauthorized alert.