### PR TITLE
NPT-1069: Seed default Benchmark & Threshold values on API BMP creation

### DIFF
--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -469,13 +469,18 @@ public class TreatmentBMPController(
         var treatmentBmpsAdded = treatmentBMPs.Where(x => x.TreatmentBMPID <= 0).ToList();
         var treatmentBmpsUpdated = treatmentBMPs.Where(x => x.TreatmentBMPID > 0).ToList();
 
-        // NPT-1069: seed default Benchmark & Threshold rows on each newly-added BMP. One DB
-        // round-trip builds the templates for this type; existing BMPs (matched on name + jurisdiction
-        // by the parser) are deliberately left untouched so we don't clobber user-edited values.
-        var seedTemplates = await TreatmentBMPBenchmarkAndThresholds.BuildSeedTemplatesAsync(DbContext, form.TreatmentBMPTypeID);
-        foreach (var newBmp in treatmentBmpsAdded)
+        // NPT-1069: seed default Benchmark & Threshold rows on each newly-added BMP. Templates
+        // are built once for the type and shared across all new BMPs in this upload; existing
+        // BMPs (matched on name + jurisdiction by the parser) are deliberately left untouched so
+        // we don't clobber user-edited values. Skip the seed-template query entirely on
+        // update-only uploads.
+        if (treatmentBmpsAdded.Count > 0)
         {
-            TreatmentBMPBenchmarkAndThresholds.AttachSeedsToBMP(newBmp, seedTemplates);
+            var seedTemplates = await TreatmentBMPBenchmarkAndThresholds.BuildSeedTemplatesAsync(DbContext, form.TreatmentBMPTypeID);
+            foreach (var newBmp in treatmentBmpsAdded)
+            {
+                TreatmentBMPBenchmarkAndThresholds.AttachSeedsToBMP(newBmp, seedTemplates);
+            }
         }
 
         await DbContext.TreatmentBMPs.AddRangeAsync(treatmentBmpsAdded);

--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -469,6 +469,15 @@ public class TreatmentBMPController(
         var treatmentBmpsAdded = treatmentBMPs.Where(x => x.TreatmentBMPID <= 0).ToList();
         var treatmentBmpsUpdated = treatmentBMPs.Where(x => x.TreatmentBMPID > 0).ToList();
 
+        // NPT-1069: seed default Benchmark & Threshold rows on each newly-added BMP. One DB
+        // round-trip builds the templates for this type; existing BMPs (matched on name + jurisdiction
+        // by the parser) are deliberately left untouched so we don't clobber user-edited values.
+        var seedTemplates = await TreatmentBMPBenchmarkAndThresholds.BuildSeedTemplatesAsync(DbContext, form.TreatmentBMPTypeID);
+        foreach (var newBmp in treatmentBmpsAdded)
+        {
+            TreatmentBMPBenchmarkAndThresholds.AttachSeedsToBMP(newBmp, seedTemplates);
+        }
+
         await DbContext.TreatmentBMPs.AddRangeAsync(treatmentBmpsAdded);
         await DbContext.CustomAttributes.AddRangeAsync(customAttributes.Where(x => x.CustomAttributeID <= 0));
         await DbContext.CustomAttributeValues.AddRangeAsync(customAttributeValues.Where(x => x.CustomAttributeValueID <= 0));

--- a/Neptune.EFModels/Entities/TreatmentBMPBenchmarkAndThresholds.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPBenchmarkAndThresholds.cs
@@ -154,4 +154,77 @@ public static class TreatmentBMPBenchmarkAndThresholds
         }
         return true;
     }
+
+    /// <summary>
+    /// One row's worth of default-value data, ready to be cloned onto a freshly-created
+    /// TreatmentBMP. Decoupled from the TreatmentBMP so the caller can build the templates once
+    /// per bulk upload (single DB round-trip) and stamp them onto every new BMP in the batch.
+    /// </summary>
+    public sealed record TreatmentBMPBenchmarkAndThresholdSeed(
+        int TreatmentBMPTypeID,
+        int TreatmentBMPTypeAssessmentObservationTypeID,
+        int TreatmentBMPAssessmentObservationTypeID,
+        double BenchmarkValue,
+        double ThresholdValue);
+
+    /// <summary>
+    /// Build the set of default benchmark/threshold rows the BMP type would seed on a brand-new
+    /// BMP. Ports <c>NewViewModel.UpdateModel</c> (Neptune.WebMvc/Views/TreatmentBMP/NewViewModel.cs:113-129).
+    /// Uses focused queries instead of an Include() graph: one query for the type's observation-type
+    /// join rows that have both defaults, then a single dictionary lookup of the referenced OT
+    /// entities (needed for the schema-driven <c>GetHasBenchmarkAndThreshold()</c> check). NPT-1069.
+    /// </summary>
+    public static async Task<List<TreatmentBMPBenchmarkAndThresholdSeed>> BuildSeedTemplatesAsync(NeptuneDbContext dbContext, int treatmentBMPTypeID)
+    {
+        var joinRows = await dbContext.TreatmentBMPTypeAssessmentObservationTypes
+            .AsNoTracking()
+            .Where(x => x.TreatmentBMPTypeID == treatmentBMPTypeID
+                     && x.DefaultBenchmarkValue.HasValue
+                     && x.DefaultThresholdValue.HasValue)
+            .ToListAsync();
+        if (joinRows.Count == 0)
+        {
+            return new List<TreatmentBMPBenchmarkAndThresholdSeed>();
+        }
+
+        var observationTypeIDs = joinRows
+            .Select(x => x.TreatmentBMPAssessmentObservationTypeID)
+            .Distinct()
+            .ToList();
+        var observationTypes = await dbContext.TreatmentBMPAssessmentObservationTypes
+            .AsNoTracking()
+            .Where(x => observationTypeIDs.Contains(x.TreatmentBMPAssessmentObservationTypeID))
+            .ToDictionaryAsync(x => x.TreatmentBMPAssessmentObservationTypeID);
+
+        return joinRows
+            .Where(j => observationTypes.TryGetValue(j.TreatmentBMPAssessmentObservationTypeID, out var ot) && ot.GetHasBenchmarkAndThreshold())
+            .Select(j => new TreatmentBMPBenchmarkAndThresholdSeed(
+                TreatmentBMPTypeID: treatmentBMPTypeID,
+                TreatmentBMPTypeAssessmentObservationTypeID: j.TreatmentBMPTypeAssessmentObservationTypeID,
+                TreatmentBMPAssessmentObservationTypeID: j.TreatmentBMPAssessmentObservationTypeID,
+                BenchmarkValue: j.DefaultBenchmarkValue!.Value,
+                ThresholdValue: j.DefaultThresholdValue!.Value))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Attach one TreatmentBMPBenchmarkAndThreshold row per template to the BMP's navigation
+    /// collection. The BMP must be tracked (or about to be added); EF cascades the inserts via
+    /// the navigation when SaveChangesAsync runs on the parent context.
+    /// </summary>
+    public static void AttachSeedsToBMP(TreatmentBMP treatmentBMP, IEnumerable<TreatmentBMPBenchmarkAndThresholdSeed> templates)
+    {
+        foreach (var template in templates)
+        {
+            treatmentBMP.TreatmentBMPBenchmarkAndThresholds.Add(new TreatmentBMPBenchmarkAndThreshold
+            {
+                TreatmentBMP = treatmentBMP,
+                TreatmentBMPTypeID = template.TreatmentBMPTypeID,
+                TreatmentBMPTypeAssessmentObservationTypeID = template.TreatmentBMPTypeAssessmentObservationTypeID,
+                TreatmentBMPAssessmentObservationTypeID = template.TreatmentBMPAssessmentObservationTypeID,
+                BenchmarkValue = template.BenchmarkValue,
+                ThresholdValue = template.ThresholdValue,
+            });
+        }
+    }
 }

--- a/Neptune.EFModels/Entities/TreatmentBMPs.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPs.cs
@@ -102,6 +102,13 @@ public static class TreatmentBMPs
         }
 
         await dbContext.TreatmentBMPs.AddAsync(treatmentBMP);
+
+        // NPT-1069: seed default Benchmark & Threshold rows from the BMP type's observation-type
+        // configuration, mirroring the legacy MVC NewViewModel.UpdateModel behavior so BMPs created
+        // through the API land with the same defaults as MVC-created ones.
+        var seedTemplates = await TreatmentBMPBenchmarkAndThresholds.BuildSeedTemplatesAsync(dbContext, createDto.TreatmentBMPTypeID);
+        TreatmentBMPBenchmarkAndThresholds.AttachSeedsToBMP(treatmentBMP, seedTemplates);
+
         await dbContext.SaveChangesAsync();
         await dbContext.Entry(treatmentBMP).ReloadAsync();
 

--- a/Neptune.Tests/TreatmentBMPBenchmarkAndThresholdDefaultsTests.cs
+++ b/Neptune.Tests/TreatmentBMPBenchmarkAndThresholdDefaultsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -23,6 +24,9 @@ namespace Neptune.Tests
             optionsBuilder.UseSqlServer(
                 "Data Source=localhost;Initial Catalog=NeptuneDB;Persist Security Info=True;Integrated Security=true;Encrypt=False;", x =>
                 {
+                    // Match the existing test DbContext pattern (TestTreatmentCSVParser, etc.) — keep
+                    // the suite from going flaky on slower dev DBs.
+                    x.CommandTimeout((int)TimeSpan.FromMinutes(3).TotalSeconds);
                     x.UseNetTopologySuite();
                 });
             return new NeptuneDbContext(optionsBuilder.Options);
@@ -62,6 +66,14 @@ namespace Neptune.Tests
             var expectedQualifying = joinRowsWithDefaults
                 .Where(j => observationTypes[j.TreatmentBMPAssessmentObservationTypeID].GetHasBenchmarkAndThreshold())
                 .ToList();
+            if (expectedQualifying.Count == 0)
+            {
+                // The candidate type's join rows all reference OTs that aren't benchmark/threshold-bearing,
+                // so the helper correctly returns zero seeds — but we wouldn't be exercising the positive
+                // seeding path. Mark inconclusive rather than passing trivially.
+                Assert.Inconclusive($"Candidate TreatmentBMPTypeID={candidateTypeID} has join rows with defaults but no benchmark/threshold-bearing observation types — positive seeding path not exercised.");
+                return;
+            }
 
             var seedTemplates = await TreatmentBMPBenchmarkAndThresholds.BuildSeedTemplatesAsync(_dbContext, candidateTypeID);
 

--- a/Neptune.Tests/TreatmentBMPBenchmarkAndThresholdDefaultsTests.cs
+++ b/Neptune.Tests/TreatmentBMPBenchmarkAndThresholdDefaultsTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1069: helpers that seed default Benchmark & Threshold rows when a Treatment BMP is
+    /// created via the API single-create or bulk-upload paths. Mirrors the legacy MVC behavior
+    /// in <c>Neptune.WebMvc/Views/TreatmentBMP/NewViewModel.cs:113-129</c>.
+    /// </summary>
+    [TestClass]
+    public class TreatmentBMPBenchmarkAndThresholdDefaultsTests
+    {
+        private NeptuneDbContext _dbContext = GetDbContext();
+
+        private static NeptuneDbContext GetDbContext()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<NeptuneDbContext>();
+            optionsBuilder.UseSqlServer(
+                "Data Source=localhost;Initial Catalog=NeptuneDB;Persist Security Info=True;Integrated Security=true;Encrypt=False;", x =>
+                {
+                    x.UseNetTopologySuite();
+                });
+            return new NeptuneDbContext(optionsBuilder.Options);
+        }
+
+        [TestMethod]
+        public async Task BuildSeedTemplatesAsync_TypeWithQualifyingObservationTypes_ReturnsExpectedTemplates()
+        {
+            // Find any TreatmentBMPType whose join has at least one row with both defaults set; if none
+            // exists in this environment the test is inconclusive rather than failing — the seeding
+            // logic is the same regardless and the negative-case test below still exercises the empty path.
+            var candidateTypeID = await _dbContext.TreatmentBMPTypeAssessmentObservationTypes
+                .AsNoTracking()
+                .Where(x => x.DefaultBenchmarkValue.HasValue && x.DefaultThresholdValue.HasValue)
+                .Select(x => x.TreatmentBMPTypeID)
+                .FirstOrDefaultAsync();
+            if (candidateTypeID == 0)
+            {
+                Assert.Inconclusive("No TreatmentBMPType in this database has any TreatmentBMPTypeAssessmentObservationType with both default values populated — cannot exercise the positive seeding path.");
+                return;
+            }
+
+            // Independent baseline: enumerate the join rows for the type that have both defaults set
+            // AND whose OT entity reports GetHasBenchmarkAndThreshold(). Materialize then filter so
+            // GetHasBenchmarkAndThreshold (which parses the OT schema JSON) runs in-memory.
+            var joinRowsWithDefaults = await _dbContext.TreatmentBMPTypeAssessmentObservationTypes
+                .AsNoTracking()
+                .Where(x => x.TreatmentBMPTypeID == candidateTypeID
+                         && x.DefaultBenchmarkValue.HasValue
+                         && x.DefaultThresholdValue.HasValue)
+                .ToListAsync();
+            var observationTypeIDs = joinRowsWithDefaults.Select(x => x.TreatmentBMPAssessmentObservationTypeID).Distinct().ToList();
+            var observationTypes = await _dbContext.TreatmentBMPAssessmentObservationTypes
+                .AsNoTracking()
+                .Where(x => observationTypeIDs.Contains(x.TreatmentBMPAssessmentObservationTypeID))
+                .ToDictionaryAsync(x => x.TreatmentBMPAssessmentObservationTypeID);
+            var expectedQualifying = joinRowsWithDefaults
+                .Where(j => observationTypes[j.TreatmentBMPAssessmentObservationTypeID].GetHasBenchmarkAndThreshold())
+                .ToList();
+
+            var seedTemplates = await TreatmentBMPBenchmarkAndThresholds.BuildSeedTemplatesAsync(_dbContext, candidateTypeID);
+
+            Assert.AreEqual(expectedQualifying.Count, seedTemplates.Count,
+                "Helper should return one template per join row with both defaults set AND a benchmark/threshold-bearing collection method.");
+            foreach (var template in seedTemplates)
+            {
+                Assert.AreEqual(candidateTypeID, template.TreatmentBMPTypeID);
+                var matchedJoin = expectedQualifying.Single(j => j.TreatmentBMPTypeAssessmentObservationTypeID == template.TreatmentBMPTypeAssessmentObservationTypeID);
+                Assert.AreEqual(matchedJoin.TreatmentBMPAssessmentObservationTypeID, template.TreatmentBMPAssessmentObservationTypeID);
+                Assert.AreEqual(matchedJoin.DefaultBenchmarkValue!.Value, template.BenchmarkValue);
+                Assert.AreEqual(matchedJoin.DefaultThresholdValue!.Value, template.ThresholdValue);
+            }
+        }
+
+        [TestMethod]
+        public async Task BuildSeedTemplatesAsync_TypeWithNoQualifyingObservationTypes_ReturnsEmpty()
+        {
+            // -1 is guaranteed not to be a real TreatmentBMPTypeID — exercises the "no qualifying join
+            // rows" early-return without depending on a particular database state.
+            var seedTemplates = await TreatmentBMPBenchmarkAndThresholds.BuildSeedTemplatesAsync(_dbContext, -1);
+
+            Assert.IsNotNull(seedTemplates);
+            Assert.AreEqual(0, seedTemplates.Count, "Unknown TreatmentBMPTypeID should yield an empty (not null) list.");
+        }
+
+        [TestMethod]
+        public void AttachSeedsToBMP_AppendsOneEntityPerTemplate_WithCorrectFKsAndValues()
+        {
+            var bmp = new TreatmentBMP { TreatmentBMPName = "Test", TreatmentBMPTypeID = 99, StormwaterJurisdictionID = 1 };
+            var templates = new List<TreatmentBMPBenchmarkAndThresholds.TreatmentBMPBenchmarkAndThresholdSeed>
+            {
+                new(TreatmentBMPTypeID: 99, TreatmentBMPTypeAssessmentObservationTypeID: 10, TreatmentBMPAssessmentObservationTypeID: 1, BenchmarkValue: 1.5, ThresholdValue: 2.5),
+                new(TreatmentBMPTypeID: 99, TreatmentBMPTypeAssessmentObservationTypeID: 11, TreatmentBMPAssessmentObservationTypeID: 2, BenchmarkValue: 3.0, ThresholdValue: 4.0),
+            };
+
+            TreatmentBMPBenchmarkAndThresholds.AttachSeedsToBMP(bmp, templates);
+
+            Assert.AreEqual(2, bmp.TreatmentBMPBenchmarkAndThresholds.Count);
+            var first = bmp.TreatmentBMPBenchmarkAndThresholds.Single(x => x.TreatmentBMPAssessmentObservationTypeID == 1);
+            Assert.AreSame(bmp, first.TreatmentBMP);
+            Assert.AreEqual(99, first.TreatmentBMPTypeID);
+            Assert.AreEqual(10, first.TreatmentBMPTypeAssessmentObservationTypeID);
+            Assert.AreEqual(1.5, first.BenchmarkValue);
+            Assert.AreEqual(2.5, first.ThresholdValue);
+        }
+
+        [TestMethod]
+        public void AttachSeedsToBMP_EmptyTemplates_LeavesCollectionUnchanged()
+        {
+            var bmp = new TreatmentBMP { TreatmentBMPName = "Test", TreatmentBMPTypeID = 99, StormwaterJurisdictionID = 1 };
+
+            TreatmentBMPBenchmarkAndThresholds.AttachSeedsToBMP(bmp, new List<TreatmentBMPBenchmarkAndThresholds.TreatmentBMPBenchmarkAndThresholdSeed>());
+
+            Assert.AreEqual(0, bmp.TreatmentBMPBenchmarkAndThresholds.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Port the legacy MVC "New Treatment BMP" seeding logic (`Neptune.WebMvc/Views/TreatmentBMP/NewViewModel.cs:113-129`) so BMPs created via the API **single-create** and **bulk-upload** paths land with the same default `TreatmentBMPBenchmarkAndThreshold` rows as MVC-created ones. Closes the gap that makes API-created BMPs show *"No benchmark and threshold values have been set"* on the detail page even when their type has defaults configured. Blocker for retiring the MVC creation paths (NPT-1068).

No database / DTO / endpoint / codegen changes.

## Approach

Focused queries + a static helper (no `.Include()` graph), matching the project's `DtoProjections` / `StaticHelpers` patterns.

New helpers on `TreatmentBMPBenchmarkAndThresholds`:
- **`BuildSeedTemplatesAsync(dbContext, treatmentBMPTypeID)`** — one DB round-trip per upload; returns the seed-row templates for a type, filtered to OTs with both `DefaultBenchmarkValue` and `DefaultThresholdValue` set AND `GetHasBenchmarkAndThreshold()` true.
- **`AttachSeedsToBMP(treatmentBMP, templates)`** — synchronous; appends a `TreatmentBMPBenchmarkAndThreshold` per template to the BMP's navigation collection, so the cascade fires on the parent `SaveChangesAsync`.

Wirings:
- `TreatmentBMPs.CreateAsync` calls both helpers before `SaveChangesAsync`.
- `TreatmentBMPController.BulkUpload` calls `BuildSeedTemplatesAsync` once per upload, then `AttachSeedsToBMP` per new BMP. Existing matched BMPs are deliberately untouched so user-edited values aren't clobbered.
- `TreatmentBMPCsvParserHelper` stays a pure CSV parser — no schema knowledge added.

## Tests

`Neptune.Tests/TreatmentBMPBenchmarkAndThresholdDefaultsTests.cs` covers:
- `BuildSeedTemplatesAsync` for a type with qualifying OTs (positive case, asserts count + per-row values against an independent baseline query).
- `BuildSeedTemplatesAsync` for an unknown type ID (empty-list path, no NRE).
- `AttachSeedsToBMP` correct FK + value assignment.
- `AttachSeedsToBMP` empty input is a no-op.

All 4 pass against the local Neptune DB.

## Test plan
- [ ] Single create: SPA "Create New Treatment BMP" with a type that has defaults configured → detail page's B&T panel shows seeded values, not the empty-state message.
- [ ] Bulk upload at `/data-hub/treatment-bmp-upload` with new + existing rows for the same type → new rows get seeded; existing matched rows keep their previously-stored B&T values untouched.
- [ ] Edge: create / bulk-upload for a type with no qualifying OTs (e.g. only pass/fail). Succeeds; detail page shows the appropriate empty state.
- [ ] `dotnet test Neptune.Tests/Neptune.Tests.csproj --filter "FullyQualifiedName~TreatmentBMPBenchmarkAndThresholdDefaultsTests"` — all 4 pass.