### PR TITLE
NPT-1072: Fix WQMP XLSX upload validation gaps

### DIFF
--- a/Neptune.EFModels/Entities/WQMPXSLXParserHelper.cs
+++ b/Neptune.EFModels/Entities/WQMPXSLXParserHelper.cs
@@ -290,11 +290,14 @@ namespace Neptune.EFModels.Entities
             var approvalDateString = ExcelHelper.SetStringValue(row, rowNumber, errorList, "Approval Date", 100, false);
             if (!string.IsNullOrWhiteSpace(approvalDateString))
             {
+                // NPT-1072: show the user's raw input + expected format hint. The previous message
+                // interpolated `approvalDateParsed`, which is DateTime.MinValue on a failed TryParse
+                // — so users saw "01/01/0001 00:00:00" instead of the value they actually entered.
                 if (!DateTime.TryParse(approvalDateString,
                         out var approvalDateParsed))
                 {
                     errorList.Add(
-                        $"{approvalDateParsed} can not be converted to Date Time format at row: {rowNumber}");
+                        $"Approval Date '{approvalDateString}' is not a valid date (expected mm/dd/yyyy) at row: {rowNumber}");
                 }
                 else
                 {
@@ -327,13 +330,32 @@ namespace Neptune.EFModels.Entities
             var recordedWqmpArea = ExcelHelper.GetOptionalDecimalFieldValue(row, rowNumber, errorList, "Recorded WQMP Area (Acres)");
             if (recordedWqmpArea.HasValue)
             {
-                wqmp.RecordedWQMPAreaInAcres = recordedWqmpArea;
+                // NPT-1072: reject negative acreage at parse time. Previously a negative value was
+                // silently accepted into the entity.
+                if (recordedWqmpArea < 0)
+                {
+                    errorList.Add($"Recorded WQMP Area (Acres) '{recordedWqmpArea}' cannot be negative at row: {rowNumber}");
+                }
+                else
+                {
+                    wqmp.RecordedWQMPAreaInAcres = recordedWqmpArea;
+                }
             }
 
             var trashCaptureEffectiveness = ExcelHelper.GetOptionalIntFieldValue(row, rowNumber, errorList, "Trash Capture Effectiveness");
             if (trashCaptureEffectiveness.HasValue)
             {
-                wqmp.TrashCaptureEffectiveness = trashCaptureEffectiveness;
+                // NPT-1072: enforce the 0–100 percentage range here so out-of-range values surface as
+                // a clean parser-level validation error instead of propagating to SaveChangesAsync
+                // and emerging as a generic 500.
+                if (trashCaptureEffectiveness < 0 || trashCaptureEffectiveness > 100)
+                {
+                    errorList.Add($"Trash Capture Effectiveness '{trashCaptureEffectiveness}' must be between 0 and 100 at row: {rowNumber}");
+                }
+                else
+                {
+                    wqmp.TrashCaptureEffectiveness = trashCaptureEffectiveness;
+                }
             }
 
             var modelingApproach = row["Modeling Approach"].ToString();
@@ -354,11 +376,12 @@ namespace Neptune.EFModels.Entities
             var constructionDateString = ExcelHelper.SetStringValue(row, rowNumber, errorList, "Date of Construction", 100, false);
             if (!string.IsNullOrWhiteSpace(constructionDateString))
             {
+                // NPT-1072: same fix as Approval Date above — show the raw input + format hint.
                 if (!DateTime.TryParse(constructionDateString,
                         out var constructionDateParsed))
                 {
                     errorList.Add(
-                        $"{constructionDateParsed} can not be converted to Date Time format at row: {rowNumber}");
+                        $"Date of Construction '{constructionDateString}' is not a valid date (expected mm/dd/yyyy) at row: {rowNumber}");
                 }
                 else
                 {

--- a/Neptune.Tests/WQMPXSLXParserHelperTests.cs
+++ b/Neptune.Tests/WQMPXSLXParserHelperTests.cs
@@ -269,7 +269,8 @@ namespace Neptune.Tests
             row[Array.IndexOf(AllCols, "Approval Date")] = "not a date";
             var dt = BuildDataTable(AllCols, row.ToArray());
             var result = WQMPXSLXParserHelper.ParseWQMPRowsFromXLSX(_dbContext, dt, GetAnyJurisdictionID(), out var errors);
-            Assert.IsTrue(errors.Any(x => x.Contains("can not be converted to Date Time format")));
+            // NPT-1072: error wording now echoes the user's raw input + the expected mm/dd/yyyy format.
+            Assert.IsTrue(errors.Any(x => x.Contains("Approval Date") && x.Contains("not a date") && x.Contains("mm/dd/yyyy")));
             Assert.AreEqual(0, result.Count, "Top-level returns empty list when any row had errors.");
         }
 
@@ -299,6 +300,98 @@ namespace Neptune.Tests
             Assert.AreEqual("___NPT_998_TEST_MIN_COLS___", result[0].WaterQualityManagementPlanName);
             Assert.IsNull(result[0].MaintenanceContactName);
             Assert.IsNull(result[0].ApprovalDate);
+        }
+
+        // ----- NPT-1072 -----
+
+        [TestMethod]
+        public void InvalidApprovalDate_ErrorContainsRawValueAndFormatHint_NotMinValue()
+        {
+            var dt = BuildDataTable(AllCols, RowWithOverride("___NPT_1072_BAD_APPROVAL_DATE___", "Approval Date", "not-a-date"));
+            WQMPXSLXParserHelper.ParseWQMPRowsFromXLSX(_dbContext, dt, GetAnyJurisdictionID(), out var errors);
+            var dateError = errors.SingleOrDefault(x => x.Contains("Approval Date") && x.Contains("not a valid date"));
+            Assert.IsNotNull(dateError, "Expected an Approval Date validation error mentioning the bad value.");
+            Assert.IsTrue(dateError.Contains("not-a-date"), "Error should echo the user's raw input.");
+            Assert.IsTrue(dateError.Contains("mm/dd/yyyy"), "Error should hint at the expected format.");
+            Assert.IsFalse(dateError.Contains("01/01/0001"), "Error should not leak DateTime.MinValue.");
+        }
+
+        [TestMethod]
+        public void InvalidDateOfConstruction_ErrorContainsRawValueAndFormatHint_NotMinValue()
+        {
+            var dt = BuildDataTable(AllCols, RowWithOverride("___NPT_1072_BAD_CONSTRUCTION_DATE___", "Date of Construction", "garbage"));
+            WQMPXSLXParserHelper.ParseWQMPRowsFromXLSX(_dbContext, dt, GetAnyJurisdictionID(), out var errors);
+            var dateError = errors.SingleOrDefault(x => x.Contains("Date of Construction") && x.Contains("not a valid date"));
+            Assert.IsNotNull(dateError, "Expected a Date of Construction validation error mentioning the bad value.");
+            Assert.IsTrue(dateError.Contains("garbage"));
+            Assert.IsTrue(dateError.Contains("mm/dd/yyyy"));
+            Assert.IsFalse(dateError.Contains("01/01/0001"));
+        }
+
+        [TestMethod]
+        public void IsoFormatApprovalDate_StillAccepted()
+        {
+            // Ray + KE decided to keep accepting ISO silently (only the error wording was the bug).
+            // This is a regression guard so a future strict-format change doesn't quietly land.
+            var dt = BuildDataTable(AllCols, RowWithOverride("___NPT_1072_ISO_DATE___", "Approval Date", "2021-06-15"));
+            var result = WQMPXSLXParserHelper.ParseWQMPRowsFromXLSX(_dbContext, dt, GetAnyJurisdictionID(), out var errors);
+            Assert.AreEqual(0, errors.Count, string.Join("; ", errors));
+            Assert.AreEqual(1, result.Count);
+            Assert.IsNotNull(result[0].ApprovalDate);
+            // PST → UTC conversion shifts the day forward by the offset.
+            Assert.AreEqual(2021, result[0].ApprovalDate!.Value.Year);
+            Assert.AreEqual(6, result[0].ApprovalDate!.Value.Month);
+        }
+
+        [TestMethod]
+        public void NegativeRecordedAreaInAcres_Rejected()
+        {
+            var dt = BuildDataTable(AllCols, RowWithOverride("___NPT_1072_NEG_ACREAGE___", "Recorded WQMP Area (Acres)", "-1.5"));
+            var result = WQMPXSLXParserHelper.ParseWQMPRowsFromXLSX(_dbContext, dt, GetAnyJurisdictionID(), out var errors);
+            Assert.IsTrue(errors.Any(x => x.Contains("Recorded WQMP Area") && x.Contains("-1.5") && x.Contains("cannot be negative")),
+                "Expected a clear negative-acreage validation error.");
+            // Field should not be set on the entity for the bad row.
+            var bmp = result.SingleOrDefault(x => x.WaterQualityManagementPlanName == "___NPT_1072_NEG_ACREAGE___");
+            Assert.IsTrue(bmp == null || bmp.RecordedWQMPAreaInAcres == null,
+                "Negative acreage must not be assigned to the WQMP entity.");
+        }
+
+        [TestMethod]
+        public void TrashCaptureEffectiveness_AboveOneHundred_Rejected()
+        {
+            var dt = BuildDataTable(AllCols, RowWithOverride("___NPT_1072_TCE_HIGH___", "Trash Capture Effectiveness", "150"));
+            var result = WQMPXSLXParserHelper.ParseWQMPRowsFromXLSX(_dbContext, dt, GetAnyJurisdictionID(), out var errors);
+            Assert.IsTrue(errors.Any(x => x.Contains("Trash Capture Effectiveness") && x.Contains("150") && x.Contains("between 0 and 100")),
+                "Expected a clear range-violation error for effectiveness > 100.");
+            var bmp = result.SingleOrDefault(x => x.WaterQualityManagementPlanName == "___NPT_1072_TCE_HIGH___");
+            Assert.IsTrue(bmp == null || bmp.TrashCaptureEffectiveness == null,
+                "Out-of-range effectiveness must not reach the WQMP entity (which would 500 in SaveChanges).");
+        }
+
+        [TestMethod]
+        public void TrashCaptureEffectiveness_Negative_Rejected()
+        {
+            var dt = BuildDataTable(AllCols, RowWithOverride("___NPT_1072_TCE_NEG___", "Trash Capture Effectiveness", "-5"));
+            var result = WQMPXSLXParserHelper.ParseWQMPRowsFromXLSX(_dbContext, dt, GetAnyJurisdictionID(), out var errors);
+            Assert.IsTrue(errors.Any(x => x.Contains("Trash Capture Effectiveness") && x.Contains("-5") && x.Contains("between 0 and 100")),
+                "Expected a clear range-violation error for effectiveness < 0.");
+            var bmp = result.SingleOrDefault(x => x.WaterQualityManagementPlanName == "___NPT_1072_TCE_NEG___");
+            Assert.IsTrue(bmp == null || bmp.TrashCaptureEffectiveness == null);
+        }
+
+        [TestMethod]
+        public void TrashCaptureEffectiveness_InclusiveBoundaries_Accepted()
+        {
+            // 0 and 100 are both valid.
+            var dt = BuildDataTable(AllCols,
+                RowWithOverride("___NPT_1072_TCE_ZERO___", "Trash Capture Effectiveness", "0"),
+                RowWithOverride("___NPT_1072_TCE_HUNDRED___", "Trash Capture Effectiveness", "100"));
+            var result = WQMPXSLXParserHelper.ParseWQMPRowsFromXLSX(_dbContext, dt, GetAnyJurisdictionID(), out var errors);
+            Assert.AreEqual(0, errors.Count, string.Join("; ", errors));
+            var zero = result.Single(x => x.WaterQualityManagementPlanName == "___NPT_1072_TCE_ZERO___");
+            var hundred = result.Single(x => x.WaterQualityManagementPlanName == "___NPT_1072_TCE_HUNDRED___");
+            Assert.AreEqual(0, zero.TrashCaptureEffectiveness);
+            Assert.AreEqual(100, hundred.TrashCaptureEffectiveness);
         }
     }
 }

--- a/Neptune.Tests/WQMPXSLXParserHelperTests.cs
+++ b/Neptune.Tests/WQMPXSLXParserHelperTests.cs
@@ -338,7 +338,10 @@ namespace Neptune.Tests
             Assert.AreEqual(0, errors.Count, string.Join("; ", errors));
             Assert.AreEqual(1, result.Count);
             Assert.IsNotNull(result[0].ApprovalDate);
-            // PST → UTC conversion shifts the day forward by the offset.
+            // Assert year/month only — the parser converts PST→UTC, which shifts the clock by
+            // the offset (7-8 hours) but leaves the calendar year/month unchanged for a midnight
+            // input. Day-of-month is intentionally not asserted to avoid coupling to whichever
+            // DST window the test runs in.
             Assert.AreEqual(2021, result[0].ApprovalDate!.Value.Year);
             Assert.AreEqual(6, result[0].ApprovalDate!.Value.Month);
         }

--- a/Neptune.Web/src/app/pages/data-hub/wqmp-upload/wqmp-upload.component.ts
+++ b/Neptune.Web/src/app/pages/data-hub/wqmp-upload/wqmp-upload.component.ts
@@ -62,6 +62,9 @@ export class WqmpUploadComponent implements OnInit {
 
     public submit(): void {
         if (this.fileControl.invalid || this.jurisdictionControl.invalid) return;
+        // NPT-1072: drop any banners from prior attempts (file-rejection + upload-failed pushAlerts
+        // accumulated across submits, so KE was seeing "Showing 3 of 4 alerts" after one good run).
+        this.alertService.clearAlerts();
         this.errors.set([]);
         this.successMessage.set(null);
         this.isUploading.set(true);
@@ -73,6 +76,7 @@ export class WqmpUploadComponent implements OnInit {
                     this.errors.set(result.Errors);
                     return;
                 }
+                this.alertService.clearAlerts();
                 this.successMessage.set(`Upload successful: ${result.AddedCount} WQMPs added, ${result.UpdatedCount} WQMPs updated.`);
                 this.fileControl.reset();
             },


### PR DESCRIPTION
## Summary

Address the bugs KE flagged on 2026-06-01 in the WQMP XLSX upload validation. Ray + KE settled the one semantic ambiguity (ISO dates): keep accepting them silently; only fix the error wording.

## Parser fixes — `Neptune.EFModels/Entities/WQMPXSLXParserHelper.cs`
- **Date error messages** — Approval Date and Date of Construction error text now echoes the user's raw input and the expected `mm/dd/yyyy` format hint. Previously both interpolated the `out var` from a failed `TryParse`, which is `DateTime.MinValue`, so users saw `"01/01/0001 00:00:00"` in the error.
- **Negative `Recorded WQMP Area (Acres)`** — rejected at parse time with a clear message; previously silently accepted onto the entity.
- **`Trash Capture Effectiveness` out of `0–100`** — rejected at parse time with a clear range message; previously propagated to `SaveChangesAsync` and surfaced as a generic 500 (CHECK-constraint hit).
- ISO date format (`2021-06-15`) **deliberately remains accepted** — only the error wording was the bug per Ray + KE.

## SPA upload page — `Neptune.Web/.../wqmp-upload.component.ts`
- `submit()` now clears `AlertService` at the top and again on a successful upload, so the file-rejection / upload-failed banners pushed on prior attempts don't accumulate across submits (KE's *"Showing 3 of 4 alerts"* symptom).

## Tests — `Neptune.Tests/WQMPXSLXParserHelperTests.cs`
Seven new tests under a `// ----- NPT-1072 -----` divider:
- Date error wording (Approval Date + Date of Construction): asserts raw input + `mm/dd/yyyy` are present and `01/01/0001` is **not**.
- ISO date regression guard: `2021-06-15` still accepted.
- Negative acreage rejected with a clear message; not assigned to the entity.
- Trash Capture Effectiveness `>100` and `<0` rejected with clean messages; not assigned to the entity.
- Inclusive boundaries `0` and `100` accepted.

Pre-existing `OptionalApprovalDate_InvalidString_NoEntityProduced` updated to assert the new wording. **24/24** tests in the file pass.

## Not in this PR (KE action item)
**Trash Capture Effectiveness missing from the Optional Properties list** on the upload page is CMS content rendered through `<custom-rich-text>`, which supports admin inline editing. KE can open `/data-hub/wqmp-upload` as Admin/SitkaAdmin, click the edit pencil on the help block, add the bullet, and Save — no commit needed.

## Test plan
- [ ] `dotnet test Neptune.Tests/Neptune.Tests.csproj --filter "FullyQualifiedName~WQMPXSLXParserHelperTests"` — 24 pass.
- [ ] At `/data-hub/wqmp-upload`:
  - Bad date (`"not-a-date"`): error mentions the value + `mm/dd/yyyy`, no `01/01/0001`.
  - ISO date (`"2021-06-15"`): accepted.
  - Negative acreage (`-1.5`): clean validation error.
  - Effectiveness `150` and `-5`: clean validation errors (no 500).
  - Bad-then-good upload: previous banner gone after the success.
- [ ] KE edits the inline help block to add "Trash Capture Effectiveness" under Optional Properties.