### PR TITLE
NPT-1073: Fix Simplified BMP XLSX upload validation gaps

### DIFF
--- a/Neptune.EFModels/Entities/SimplifiedBMPsExcelParserHelper.cs
+++ b/Neptune.EFModels/Entities/SimplifiedBMPsExcelParserHelper.cs
@@ -27,30 +27,16 @@ public static class SimplifiedBMPsExcelParserHelper
         var numColumns = dataTableFromExcel.Columns.Count;
         var numRows = dataTableFromExcel.Rows.Count;
 
-        // Upfront pre-pass: surface ALL missing-WQMP errors at once so users don't iterate
-        // (fix one, re-upload, see the next). Skip empty rows here — a trailing blank row in
-        // the spreadsheet would otherwise produce a "WQMP with name '' does not exist" error.
-        foreach (DataRow row in dataTableFromExcel.Rows)
-        {
-            var rowEmpty = true;
-            for (var j = 0; j < numColumns; j++)
-            {
-                if (!string.IsNullOrWhiteSpace(row[j].ToString()))
-                {
-                    rowEmpty = false;
-                    break;
-                }
-            }
-            if (rowEmpty) continue;
+        // NPT-1073: a pre-pass that re-emitted "WQMP does not exist" lived here. It duplicated
+        // every error the per-row parser already produces (with row-number context), so users saw
+        // each bad WQMP twice. Removed in favor of the single per-row check.
 
-            var wqmpName = row["WQMP Name"].ToString();
-            var wqmp = dbContext.WaterQualityManagementPlans.SingleOrDefault(x =>
-                x.WaterQualityManagementPlanName == wqmpName && x.StormwaterJurisdictionID == stormwaterJurisdictionID);
-            if (wqmp == null)
-            {
-                errors.Add($"WQMP with name {wqmpName} does not exist in given jurisdiction.");
-            }
-        }
+        // NPT-1073: hoist these out of the per-row loop. `quickBMPNamesInCsv` was being reset
+        // every row, so the in-CSV duplicate-name detection never fired and rows slipped through
+        // to SaveChanges as a UNIQUE constraint 500. `treatmentBMPTypes` was being re-fetched
+        // from the DB on every row.
+        var treatmentBMPTypes = TreatmentBMPTypes.List(dbContext);
+        var quickBMPNamesInCsv = new List<string>();
 
         var quickBMPs = new List<QuickBMP>();
         for (var i = 0; i < numRows; i++)
@@ -70,12 +56,10 @@ public static class SimplifiedBMPsExcelParserHelper
             {
                 continue;
             }
-            var treatmentBMPTypes = TreatmentBMPTypes.List(dbContext);
-            var quickBMPNamesInCsv = new List<string>();
             quickBMPs.Add(ParseRequiredAndOptionalFieldsAndCreateSimplifiedBMPs(dbContext, row, i+2, out var errorsList,
                 treatmentBMPTypes, quickBMPNamesInCsv, stormwaterJurisdictionID));
             errors.AddRange(errorsList);
-            
+
         }
 
         if (errors.Count > 0)
@@ -145,7 +129,16 @@ public static class SimplifiedBMPsExcelParserHelper
         var countOfBMPs = ExcelHelper.GetIntFieldValue(row, rowNumber, errorList, "Count of BMPs", true);
         if (countOfBMPs.HasValue)
         {
-            quickBMP.NumberOfIndividualBMPs = countOfBMPs.Value;
+            // NPT-1073: reject 0 (and negatives) at parse time — they previously slipped through
+            // as a valid count.
+            if (countOfBMPs.Value < 1)
+            {
+                errorList.Add($"Count of BMPs '{countOfBMPs.Value}' must be at least 1 at row: {rowNumber}");
+            }
+            else
+            {
+                quickBMP.NumberOfIndividualBMPs = countOfBMPs.Value;
+            }
         }
 
         var percentageOfSiteTreated = ExcelHelper.GetDecimalFieldValue(row, rowNumber, errorList, "% of Site Treated", false);
@@ -172,7 +165,8 @@ public static class SimplifiedBMPsExcelParserHelper
             var dryWeatherFlowOverride = DryWeatherFlowOverride.All.SingleOrDefault(x => x.DryWeatherFlowOverrideDisplayName == dryWeatherFlowOverrideName);
             if (dryWeatherFlowOverride == null)
             {
-                errorList.Add($"BMP Type {dryWeatherFlowOverrideName} does not exist");
+                // NPT-1073: was mis-labelled "BMP Type" (copy-paste from the BMP Type branch above).
+                errorList.Add($"Dry Weather Flow Override '{dryWeatherFlowOverrideName}' does not exist in row number: {rowNumber}");
             }
             else
             {

--- a/Neptune.EFModels/Entities/SimplifiedBMPsExcelParserHelper.cs
+++ b/Neptune.EFModels/Entities/SimplifiedBMPsExcelParserHelper.cs
@@ -31,12 +31,16 @@ public static class SimplifiedBMPsExcelParserHelper
         // every error the per-row parser already produces (with row-number context), so users saw
         // each bad WQMP twice. Removed in favor of the single per-row check.
 
-        // NPT-1073: hoist these out of the per-row loop. `quickBMPNamesInCsv` was being reset
-        // every row, so the in-CSV duplicate-name detection never fired and rows slipped through
-        // to SaveChanges as a UNIQUE constraint 500. `treatmentBMPTypes` was being re-fetched
-        // from the DB on every row.
+        // NPT-1073: hoist these out of the per-row loop. The names tracker was being reset every
+        // row, so the in-CSV duplicate-name detection never fired and rows slipped through to
+        // SaveChanges as a UNIQUE constraint 500. `treatmentBMPTypes` was being re-fetched from
+        // the DB on every row.
+        // Track names *per WQMP* — QuickBMP uniqueness is scoped by
+        // (WaterQualityManagementPlanID, QuickBMPName), so the same BMP Name under two different
+        // WQMPs in one upload is legitimate and must not be flagged. Case-insensitive comparison
+        // matches the default SQL Server collation.
         var treatmentBMPTypes = TreatmentBMPTypes.List(dbContext);
-        var quickBMPNamesInCsv = new List<string>();
+        var quickBMPNamesByWqmpID = new Dictionary<int, HashSet<string>>();
 
         var quickBMPs = new List<QuickBMP>();
         for (var i = 0; i < numRows; i++)
@@ -57,7 +61,7 @@ public static class SimplifiedBMPsExcelParserHelper
                 continue;
             }
             quickBMPs.Add(ParseRequiredAndOptionalFieldsAndCreateSimplifiedBMPs(dbContext, row, i+2, out var errorsList,
-                treatmentBMPTypes, quickBMPNamesInCsv, stormwaterJurisdictionID));
+                treatmentBMPTypes, quickBMPNamesByWqmpID, stormwaterJurisdictionID));
             errors.AddRange(errorsList);
 
         }
@@ -70,7 +74,7 @@ public static class SimplifiedBMPsExcelParserHelper
         return quickBMPs;
     }
 
-    private static QuickBMP ParseRequiredAndOptionalFieldsAndCreateSimplifiedBMPs(NeptuneDbContext dbContext, DataRow row, int rowNumber, out List<string> errorList, List<TreatmentBMPType> treatmentBMPTypes, List<string> quickBMPNamesInCsv, int stormwaterJurisdictionID)
+    private static QuickBMP ParseRequiredAndOptionalFieldsAndCreateSimplifiedBMPs(NeptuneDbContext dbContext, DataRow row, int rowNumber, out List<string> errorList, List<TreatmentBMPType> treatmentBMPTypes, Dictionary<int, HashSet<string>> quickBMPNamesByWqmpID, int stormwaterJurisdictionID)
     {
         errorList = new List<string>();
 
@@ -99,12 +103,18 @@ public static class SimplifiedBMPsExcelParserHelper
 
         if (!string.IsNullOrWhiteSpace(bmpName))
         {
-            if (quickBMPNamesInCsv.Contains(bmpName))
+            // Duplicate-name detection is scoped to (WQMP, BMP Name) to match the SQL UNIQUE index;
+            // same BMP Name under different WQMPs is fine. Case-insensitive set matches SQL collation.
+            if (!quickBMPNamesByWqmpID.TryGetValue(wqmp.WaterQualityManagementPlanID, out var namesForThisWqmp))
+            {
+                namesForThisWqmp = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                quickBMPNamesByWqmpID[wqmp.WaterQualityManagementPlanID] = namesForThisWqmp;
+            }
+            if (!namesForThisWqmp.Add(bmpName))
             {
                 errorList.Add(
                     $"The Simplified BMP with Name '{bmpName}' was already added in this upload, duplicate name is found at row: {rowNumber}");
             }
-            quickBMPNamesInCsv.Add(bmpName);
             quickBMP.QuickBMPName = bmpName;
         }
 

--- a/Neptune.Tests/SimplifiedBMPsExcelParserHelperTests.cs
+++ b/Neptune.Tests/SimplifiedBMPsExcelParserHelperTests.cs
@@ -236,6 +236,58 @@ namespace Neptune.Tests
         }
 
         [TestMethod]
+        public void SameBMPNameAcrossDifferentWQMPs_NotFlaggedAsDuplicate()
+        {
+            // NPT-1073 follow-up (Copilot review on PR #539): QuickBMP uniqueness is scoped by
+            // (WaterQualityManagementPlanID, QuickBMPName), so the same BMP Name under two
+            // *different* WQMPs in one upload is legitimate. The duplicate tracker must be
+            // per-WQMP, not global.
+            var pair = _dbContext.WaterQualityManagementPlans
+                .AsNoTracking()
+                .GroupBy(x => x.StormwaterJurisdictionID)
+                .Where(g => g.Count() >= 2)
+                .Select(g => new { JurisdictionID = g.Key, Wqmps = g.Take(2).ToList() })
+                .FirstOrDefault();
+            if (pair == null)
+            {
+                Assert.Inconclusive("No jurisdiction has at least 2 WQMPs in dev DB; cross-WQMP same-name path cannot be exercised.");
+                return;
+            }
+            var bmpType = GetAnyBMPTypeName();
+            const string sharedBmpName = "___NPT_1073_CROSS_WQMP_NAME___";
+            var dt = BuildDataTable(AllCols,
+                new[] { pair.Wqmps[0].WaterQualityManagementPlanName, sharedBmpName, bmpType, "1", "", "", "", "", "" },
+                new[] { pair.Wqmps[1].WaterQualityManagementPlanName, sharedBmpName, bmpType, "1", "", "", "", "", "" });
+            var result = SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, pair.JurisdictionID, dt, out var errors);
+
+            Assert.AreEqual(0, errors.Count, $"Same BMP Name under different WQMPs is legitimate. Errors: {string.Join("; ", errors)}");
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count);
+        }
+
+        [TestMethod]
+        public void DuplicateBMPName_CaseInsensitive_WithinSameWQMP_ProducesError()
+        {
+            // SQL Server's default collation is case-insensitive, so two BMPs that differ only in
+            // case under the same WQMP would still violate the UNIQUE constraint. The parser must
+            // catch these the same way it catches exact-case duplicates.
+            var existingWqmp = _dbContext.WaterQualityManagementPlans.AsNoTracking().FirstOrDefault();
+            if (existingWqmp == null)
+            {
+                Assert.Inconclusive("No existing WQMP in dev DB.");
+                return;
+            }
+            var bmpType = GetAnyBMPTypeName();
+            var dt = BuildDataTable(AllCols,
+                new[] { existingWqmp.WaterQualityManagementPlanName, "___NPT_1073_CASE_TEST___", bmpType, "1", "", "", "", "", "" },
+                new[] { existingWqmp.WaterQualityManagementPlanName, "___npt_1073_case_test___", bmpType, "2", "", "", "", "", "" });
+            SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, existingWqmp.StormwaterJurisdictionID, dt, out var errors);
+
+            Assert.IsTrue(errors.Any(x => x.Contains("duplicate name is found at row: 3")),
+                $"Case-insensitive duplicate within a WQMP should be flagged. Got: {string.Join("; ", errors)}");
+        }
+
+        [TestMethod]
         public void CountOfBMPsOne_AcceptedBoundary()
         {
             // Inclusive lower-bound guard — 1 is valid.

--- a/Neptune.Tests/SimplifiedBMPsExcelParserHelperTests.cs
+++ b/Neptune.Tests/SimplifiedBMPsExcelParserHelperTests.cs
@@ -150,5 +150,108 @@ namespace Neptune.Tests
             SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, existingWqmp.StormwaterJurisdictionID, dt, out var errors);
             Assert.IsTrue(errors.Any(x => x.Contains("Count of BMPs")));
         }
+
+        // ----- NPT-1073 -----
+
+        [TestMethod]
+        public void NonexistentWQMP_ProducesSingleErrorWithRowNumber()
+        {
+            // NPT-1073 Bug 1 regression guard: the redundant pre-pass loop was removed, so a row
+            // referencing an unknown WQMP should produce exactly one error from the per-row parser
+            // (with row number), not two (one from the pre-pass, one from the per-row).
+            var dt = BuildDataTable(AllCols,
+                new[] { "___NPT_1073_MISSING_WQMP___", "BMP-A", GetAnyBMPTypeName(), "1", "", "", "", "", "" });
+            SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, GetAnyJurisdictionID(), dt, out var errors);
+
+            var wqmpErrors = errors.Where(x => x.Contains("___NPT_1073_MISSING_WQMP___")).ToList();
+            Assert.AreEqual(1, wqmpErrors.Count, $"Expected one WQMP-not-found error, got {wqmpErrors.Count}: {string.Join("; ", wqmpErrors)}");
+            Assert.IsTrue(wqmpErrors[0].Contains("row 2"), $"Per-row error should include row number. Got: {wqmpErrors[0]}");
+            Assert.IsFalse(errors.Any(x => x.Contains("does not exist in given jurisdiction")),
+                "Pre-pass error wording should no longer appear.");
+        }
+
+        [TestMethod]
+        public void DuplicateBMPName_WithinUpload_ProducesParserErrorWithRow()
+        {
+            // NPT-1073 Bug 3 regression guard: quickBMPNamesInCsv was being re-initialized inside the
+            // per-row loop, so the in-CSV duplicate-name check never fired and rows slipped through
+            // to SaveChanges as a UNIQUE constraint 500. With the list hoisted out, the parser now
+            // catches duplicates and reports the row number.
+            var existingWqmp = _dbContext.WaterQualityManagementPlans.AsNoTracking().FirstOrDefault();
+            if (existingWqmp == null)
+            {
+                Assert.Inconclusive("No existing WQMP in dev DB.");
+                return;
+            }
+            var bmpType = GetAnyBMPTypeName();
+            var bmpName = "___NPT_1073_DUPLICATE_NAME___";
+            var dt = BuildDataTable(AllCols,
+                new[] { existingWqmp.WaterQualityManagementPlanName, bmpName, bmpType, "1", "", "", "", "", "" },
+                new[] { existingWqmp.WaterQualityManagementPlanName, bmpName, bmpType, "2", "", "", "", "", "" });
+            var result = SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, existingWqmp.StormwaterJurisdictionID, dt, out var errors);
+
+            Assert.IsTrue(errors.Any(x => x.Contains(bmpName) && x.Contains("duplicate name is found at row: 3")),
+                $"Expected duplicate-name error naming row 3. Got: {string.Join("; ", errors)}");
+            Assert.IsNull(result, "Parser must return null when any errors are present so SaveChanges is never reached.");
+        }
+
+        [TestMethod]
+        public void InvalidDryWeatherFlowOverride_ErrorMentionsCorrectField()
+        {
+            // NPT-1073 Bug 4 regression guard: error was mis-labelled "BMP Type ..." due to copy-paste.
+            var existingWqmp = _dbContext.WaterQualityManagementPlans.AsNoTracking().FirstOrDefault();
+            if (existingWqmp == null)
+            {
+                Assert.Inconclusive("No existing WQMP in dev DB.");
+                return;
+            }
+            var dt = BuildDataTable(AllCols,
+                new[] { existingWqmp.WaterQualityManagementPlanName, "BMP-BadDWF", GetAnyBMPTypeName(), "1", "", "", "", "___NOT_A_DWF_OVERRIDE___", "" });
+            SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, existingWqmp.StormwaterJurisdictionID, dt, out var errors);
+
+            var dwfError = errors.SingleOrDefault(x => x.Contains("___NOT_A_DWF_OVERRIDE___"));
+            Assert.IsNotNull(dwfError, "Expected an error referencing the bad DWF value.");
+            Assert.IsTrue(dwfError.Contains("Dry Weather Flow Override"), $"Error must name the correct field. Got: {dwfError}");
+            Assert.IsFalse(dwfError.StartsWith("BMP Type"), $"Error must not mis-label the field as 'BMP Type'. Got: {dwfError}");
+        }
+
+        [TestMethod]
+        public void CountOfBMPsZero_Rejected()
+        {
+            // NPT-1073 Bug 5 regression guard: 0 was silently accepted; now must be rejected with a
+            // clear "at least 1" message. The entity's NumberOfIndividualBMPs must not be set on
+            // the bad row.
+            var existingWqmp = _dbContext.WaterQualityManagementPlans.AsNoTracking().FirstOrDefault();
+            if (existingWqmp == null)
+            {
+                Assert.Inconclusive("No existing WQMP in dev DB.");
+                return;
+            }
+            var dt = BuildDataTable(AllCols,
+                new[] { existingWqmp.WaterQualityManagementPlanName, "___NPT_1073_ZERO_COUNT___", GetAnyBMPTypeName(), "0", "", "", "", "", "" });
+            SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, existingWqmp.StormwaterJurisdictionID, dt, out var errors);
+
+            Assert.IsTrue(errors.Any(x => x.Contains("Count of BMPs") && x.Contains("at least 1") && x.Contains("row: 2")),
+                $"Expected a clear 'at least 1' validation error for count = 0. Got: {string.Join("; ", errors)}");
+        }
+
+        [TestMethod]
+        public void CountOfBMPsOne_AcceptedBoundary()
+        {
+            // Inclusive lower-bound guard — 1 is valid.
+            var existingWqmp = _dbContext.WaterQualityManagementPlans.AsNoTracking().FirstOrDefault();
+            if (existingWqmp == null)
+            {
+                Assert.Inconclusive("No existing WQMP in dev DB.");
+                return;
+            }
+            var dt = BuildDataTable(AllCols,
+                new[] { existingWqmp.WaterQualityManagementPlanName, "___NPT_1073_ONE_COUNT___", GetAnyBMPTypeName(), "1", "", "", "", "", "" });
+            var result = SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, existingWqmp.StormwaterJurisdictionID, dt, out var errors);
+
+            Assert.AreEqual(0, errors.Count, string.Join("; ", errors));
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(1, result[0].NumberOfIndividualBMPs);
+        }
     }
 }

--- a/Neptune.Web/src/app/pages/data-hub/simplified-bmp-upload/simplified-bmp-upload.component.ts
+++ b/Neptune.Web/src/app/pages/data-hub/simplified-bmp-upload/simplified-bmp-upload.component.ts
@@ -62,6 +62,9 @@ export class SimplifiedBmpUploadComponent implements OnInit {
 
     public submit(): void {
         if (this.fileControl.invalid || this.jurisdictionControl.invalid) return;
+        // NPT-1073: clear stale banners from prior attempts so the "Upload failed" / file-rejection
+        // alerts don't stack across submits. Same fix as the WQMP uploader (NPT-1072).
+        this.alertService.clearAlerts();
         this.errors.set([]);
         this.successMessage.set(null);
         this.isUploading.set(true);
@@ -73,6 +76,7 @@ export class SimplifiedBmpUploadComponent implements OnInit {
                     this.errors.set(result.Errors);
                     return;
                 }
+                this.alertService.clearAlerts();
                 this.successMessage.set(`Upload successful: ${result.AddedCount} Simplified BMPs added, ${result.UpdatedCount} Simplified BMPs updated.`);
                 this.fileControl.reset();
             },


### PR DESCRIPTION
## Summary

Address the five bugs KE flagged on 2026-06-02 in the Simplified BMP XLSX upload validation. Sibling story to NPT-1072 (WQMP uploader, just merged) — one of the five is the same SPA alert-stacking issue we fixed there.

## Parser fixes — `Neptune.EFModels/Entities/SimplifiedBMPsExcelParserHelper.cs`

- **Bug 1 (TC07/08/11) — duplicate error messages.** Removed the redundant pre-pass loop that emitted *"WQMP does not exist in given jurisdiction"* for every bad row. The per-row parser already covers the same check with row-number context.
- **Bug 3 (TC10) — duplicate BMP-name detection silently doing nothing.** `quickBMPNamesInCsv` was declared **inside** the per-row loop, so it was re-initialized every iteration and the in-CSV duplicate check never fired. Rows with duplicate names slipped through to `SaveChangesAsync` and hit the UNIQUE constraint on `(WaterQualityManagementPlanID, QuickBMPName)` as a generic 500 with no detail. Moved the list (and `treatmentBMPTypes`, which was also being re-fetched per row) out of the loop.
- **Bug 4 (TC13) — wrong field label in DWF Override error.** Was *"BMP Type \<value\> does not exist"* from a copy-paste. Now reads *"Dry Weather Flow Override '<value>' does not exist in row number: <n>"*.
- **Bug 5 (TC11) — `Count of BMPs = 0` silently accepted.** Added `< 1` validation with a clear *"Count of BMPs '0' must be at least 1 at row: 2"* message.

## SPA upload page — `Neptune.Web/.../simplified-bmp-upload.component.ts`

- **Bug 2 (TC10) — banner stacking.** `submit()` now clears `AlertService` at the top and again on a successful upload, so file-rejection / upload-failed banners pushed on prior attempts no longer accumulate across submits. Same shape as the NPT-1072 fix.

## Tests — `Neptune.Tests/SimplifiedBMPsExcelParserHelperTests.cs`

Five new tests under a `// ----- NPT-1073 -----` divider, one per parser bug:
- `NonexistentWQMP_ProducesSingleErrorWithRowNumber` (Bug 1)
- `DuplicateBMPName_WithinUpload_ProducesParserErrorWithRow` (Bug 3)
- `InvalidDryWeatherFlowOverride_ErrorMentionsCorrectField` (Bug 4)
- `CountOfBMPsZero_Rejected` and `CountOfBMPsOne_AcceptedBoundary` (Bug 5 + boundary)

**12/12** in the file pass.

## Test plan
- [ ] `dotnet test Neptune.Tests/Neptune.Tests.csproj --filter "FullyQualifiedName~SimplifiedBMPsExcelParserHelperTests"` — 12 pass.
- [ ] At `/data-hub/simplified-bmp-upload`:
  - Bad WQMP name: **one** error per row (with row number), not two.
  - Two rows w/ same BMP Name in same WQMP: clean parser error (no 500), naming the duplicate and the second row's number.
  - `Dry Weather Flow Override? = "BadValue"`: error names the correct field.
  - `Count of BMPs = 0`: clean *"...must be at least 1..."* error.
  - File-rejection then a successful upload: previous banner gone after the success.