### PR TITLE
NPT-1074: Clearer empty-result message on WQMP boundary-from-APNs upload

### DIFF
--- a/Neptune.Web/src/app/pages/data-hub/wqmp-locations-upload/wqmp-locations-upload.component.ts
+++ b/Neptune.Web/src/app/pages/data-hub/wqmp-locations-upload/wqmp-locations-upload.component.ts
@@ -63,6 +63,9 @@ export class WqmpLocationsUploadComponent implements OnInit {
 
     public submit(): void {
         if (this.fileControl.invalid || this.jurisdictionControl.invalid) return;
+        // NPT-1074: clear stale banners from prior attempts so file-rejection / upload-failed
+        // alerts don't stack across submits. Same shape as the NPT-1072 + NPT-1073 fixes.
+        this.alertService.clearAlerts();
         this.errors.set([]);
         this.missingApns.set([]);
         this.successMessage.set(null);
@@ -78,7 +81,15 @@ export class WqmpLocationsUploadComponent implements OnInit {
                 }
                 const added = result.AddedCount ?? 0;
                 const updated = result.UpdatedCount ?? 0;
-                this.successMessage.set(`Upload successful: ${added} WQMP boundaries added, ${updated} updated.`);
+                this.alertService.clearAlerts();
+                // NPT-1074 TC11: server returns no Errors when all APNs are unmatched (it's a
+                // soft-miss per the spec, not a row-level error), so we land here with 0/0.
+                // Be explicit that nothing was created rather than calling it "successful".
+                if (added === 0 && updated === 0) {
+                    this.successMessage.set("Upload completed: 0 boundaries created - all APNs unmatched.");
+                } else {
+                    this.successMessage.set(`Upload successful: ${added} WQMP boundaries added, ${updated} updated.`);
+                }
                 this.missingApns.set(result.MissingApns ?? []);
                 this.fileControl.reset();
             },


### PR DESCRIPTION
## Summary

KE flagged on 2026-06-01 (NPT-1074 / TC11) that when every APN in an upload is unmatched, the server returns *0 added / 0 updated* with the missing-APN list (no errors — soft-miss per the spec), but the page still printed *"Upload successful: 0 added, 0 updated"* — misleading because nothing actually succeeded.

This PR also folds in the same `AlertService.clearAlerts()` guard we shipped on the WQMP uploader (NPT-1072) and the Simplified BMP uploader (NPT-1073), to close the same banner-stacking gap on this third upload page preemptively.

TC13 was green on the card — KE confirmed the spec interpretation (partial success applies only to missing APNs; WQMP-name problems block). No change needed.

## Frontend change — `Neptune.Web/.../wqmp-locations-upload.component.ts`

- **TC11 — empty-result message.** `submit()`'s success branch now reads:
  - `0 added && 0 updated` → *"Upload completed: 0 boundaries created - all APNs unmatched."*
  - otherwise → existing *"Upload successful: N WQMP boundaries added, M updated."*
  The missing-APN list continues to render below either message via the existing `missingApns` signal.
- **Banner-stacking guard.** `alertService.clearAlerts()` at the top of `submit()` and again on a successful response, matching the NPT-1072 / NPT-1073 fixes.

## No backend, DTO, endpoint, codegen, or test changes
No `.spec.ts` infrastructure exists in `src/app` (`npm test` is wired to `ng test` but there are zero specs); the prior two upload-page PRs shipped with browser verification too. Adding Karma scaffolding just for this 6-line change wasn't worth it; if we want SPA component coverage we should file a dedicated test-infra story.

## Test plan
- [ ] At `/data-hub/wqmp-locations-upload`, upload a CSV where every APN is unmatched → page reads *"Upload completed: 0 boundaries created - all APNs unmatched."* with the missing-APN list below.
- [ ] Upload a normal CSV with at least one valid APN → still reads *"Upload successful: N WQMP boundaries added, M updated."*
- [ ] Drag a non-CSV in (file-rejection alert) then do a successful upload → previous banner gone after the success.