### PR TITLE
NPT-1071: Clear alerts before pushing upload error banners

### DIFF
--- a/Neptune.Web/src/app/pages/data-hub/trash-screen-field-visit-upload/trash-screen-field-visit-upload.component.ts
+++ b/Neptune.Web/src/app/pages/data-hub/trash-screen-field-visit-upload/trash-screen-field-visit-upload.component.ts
@@ -40,6 +40,7 @@ export class TrashScreenFieldVisitUploadComponent {
     public onFileChange(file: File | null): void {
         if (!file) return;
         if (!file.name.toLowerCase().endsWith(".xlsx")) {
+            this.alertService.clearAlerts();
             this.alertService.pushAlert(new Alert("Only XLSX files are accepted.", AlertContext.Danger, true));
             this.fileControl.setValue(null);
         }
@@ -47,6 +48,7 @@ export class TrashScreenFieldVisitUploadComponent {
 
     public submit(): void {
         if (this.fileControl.invalid) return;
+        this.alertService.clearAlerts();
         this.errors.set([]);
         this.successMessage.set(null);
         this.isUploading.set(true);


### PR DESCRIPTION
## Summary
- Field Visit bulk XLSX uploader's `submit()` and `onFileChange()` now call `alertService.clearAlerts()` before pushing a new error banner, so retries / re-picks no longer stack duplicate banners.
- Same cross-cutting fix already shipped on the Land Use Block uploader (NPT-1077) and the OVTA / Delineation uploaders (NPT-1072/1073/1074/1076).
- Addresses KE's only red rework item on NPT-1071 (6/2/26). Bug #2 (numeric range validation) was yellow / nice-to-have and is intentionally not bundled here.

## Test plan
- [ ] Pick a non-`.xlsx` twice in a row → only one "Only XLSX files are accepted" banner at a time.
- [ ] Force a network/500 on submit, then submit again → only one "Upload failed" banner, not stacked.
- [ ] Upload an XLSX that returns row errors → local per-row error list under the field still renders; no duplicate global banner.