### PR TITLE
NPT-1071: Range-check numeric fields on Field Visit bulk upload

### DIFF
--- a/Neptune.EFModels/Entities/TrashScreenFieldVisitImporter.cs
+++ b/Neptune.EFModels/Entities/TrashScreenFieldVisitImporter.cs
@@ -348,6 +348,15 @@ public static class TrashScreenFieldVisitImporter
             return errors;
         }
 
+        // NPT-1071: range-check the numeric maintenance-record columns. Blank cells parse to empty
+        // string above and skip this check entirely; only non-empty out-of-range values are flagged.
+        var rangeError = ValidateMaintenanceRecordNumericRange(observationName, valueParsedForDataType, rowNumber);
+        if (rangeError != null)
+        {
+            errors.Add(rangeError);
+            return errors;
+        }
+
         if (maintenanceRecordObservation != null)
         {
             var maintenanceRecordObservationValue = maintenanceRecordObservation.MaintenanceRecordObservationValues.SingleOrDefault();
@@ -402,6 +411,18 @@ public static class TrashScreenFieldVisitImporter
             return errors;
         }
 
+        // NPT-1071: Material Accumulation % must be in [0, 100]. Other observation types in this
+        // method are Pass/Fail and don't need a numeric bound.
+        if (dataType == ObservationTypeDataTypeEnum.Numeric && observationTypeName == ACCUMULATION)
+        {
+            var accumRangeError = ValidatePercentRange($"{observationTypeName}{suffix}", rawValidationResult.ParsedValue?.ToString(), rowNumber);
+            if (accumRangeError != null)
+            {
+                errors.Add(accumRangeError);
+                return errors;
+            }
+        }
+
         var conditionBoxed = new
         {
             SingleValueObservations = new[]
@@ -437,6 +458,47 @@ public static class TrashScreenFieldVisitImporter
         }
 
         return errors;
+    }
+
+    /// <summary>
+    /// NPT-1071: range-check for the numeric maintenance-record columns. Volumes must be ≥ 0;
+    /// percent columns must be in [0, 100]. Returns the user-facing error string or null when the
+    /// value is in range (or blank / unparseable — unparseable values are caught upstream).
+    /// Exposed for unit testing.
+    /// </summary>
+    public static string? ValidateMaintenanceRecordNumericRange(string observationName, string? parsedValue, int rowNumber)
+    {
+        if (!decimal.TryParse(parsedValue, out var value))
+        {
+            return null;
+        }
+        return observationName switch
+        {
+            TRASH or GREEN_WASTE or SEDIMENT when value < 0 || value > 100
+                => $"{observationName} '{value}' must be between 0 and 100 at row {rowNumber + 2}",
+            VOLUME_CUFT or VOLUME_GAL when value < 0
+                => $"{observationName} '{value}' must be 0 or greater at row {rowNumber + 2}",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// NPT-1071: range-check for percentage observations on the assessment blocks (currently just
+    /// Material Accumulation %). Same shape as ValidateMaintenanceRecordNumericRange so the
+    /// user-facing error wording stays consistent across the two parse paths. Exposed for unit
+    /// testing.
+    /// </summary>
+    public static string? ValidatePercentRange(string fieldName, string? parsedValue, int rowNumber)
+    {
+        if (!decimal.TryParse(parsedValue, out var value))
+        {
+            return null;
+        }
+        if (value < 0 || value > 100)
+        {
+            return $"{fieldName} '{value}' must be between 0 and 100 at row {rowNumber + 2}";
+        }
+        return null;
     }
 
     private static async Task<TreatmentBMPObservation> GetExistingTreatmentBMPObservationOrCreateNew(

--- a/Neptune.Tests/TrashScreenFieldVisitImporterTests.cs
+++ b/Neptune.Tests/TrashScreenFieldVisitImporterTests.cs
@@ -320,5 +320,83 @@ namespace Neptune.Tests
             Assert.AreEqual(beforeCount + 1, afterCount,
                 "Exactly one new FieldVisit should have been added for this BMP.");
         }
+
+        // ----- NPT-1071 Bug #2: numeric range validation (pure helpers) -----
+
+        [TestMethod]
+        public void ValidateMaintenanceRecordNumericRange_PercentTrashOver100_Errors()
+        {
+            var result = TrashScreenFieldVisitImporter.ValidateMaintenanceRecordNumericRange("Percent Trash", "150", 3);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result!.Contains("Percent Trash"));
+            Assert.IsTrue(result.Contains("150"));
+            Assert.IsTrue(result.Contains("between 0 and 100"));
+            Assert.IsTrue(result.Contains("row 5"), $"Expected 1-indexed row (rowNumber+2). Got: {result}");
+        }
+
+        [TestMethod]
+        public void ValidateMaintenanceRecordNumericRange_NegativePercentSediment_Errors()
+        {
+            var result = TrashScreenFieldVisitImporter.ValidateMaintenanceRecordNumericRange("Percent Sediment", "-5", 0);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result!.Contains("Percent Sediment"));
+            Assert.IsTrue(result.Contains("-5"));
+        }
+
+        [TestMethod]
+        public void ValidateMaintenanceRecordNumericRange_NegativeVolumeGal_Errors()
+        {
+            var result = TrashScreenFieldVisitImporter.ValidateMaintenanceRecordNumericRange("Total Material Volume Removed (gal)", "-1.5", 0);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result!.Contains("0 or greater"), $"Volumes use the >= 0 message, not the percent message. Got: {result}");
+        }
+
+        [TestMethod]
+        public void ValidateMaintenanceRecordNumericRange_VolumeOver100_NoError()
+        {
+            // Volumes have no upper bound — 1000 cu-ft is legitimate.
+            var result = TrashScreenFieldVisitImporter.ValidateMaintenanceRecordNumericRange("Total Material Volume Removed (cu-ft)", "1000", 0);
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void ValidateMaintenanceRecordNumericRange_PercentZeroAndHundred_BoundaryOk()
+        {
+            // Inclusive bounds.
+            Assert.IsNull(TrashScreenFieldVisitImporter.ValidateMaintenanceRecordNumericRange("Percent Green Waste", "0", 0));
+            Assert.IsNull(TrashScreenFieldVisitImporter.ValidateMaintenanceRecordNumericRange("Percent Green Waste", "100", 0));
+        }
+
+        [TestMethod]
+        public void ValidateMaintenanceRecordNumericRange_BlankValue_NoError()
+        {
+            // Blank cells are valid (the maintenance-record columns are all optional).
+            Assert.IsNull(TrashScreenFieldVisitImporter.ValidateMaintenanceRecordNumericRange("Percent Trash", "", 0));
+            Assert.IsNull(TrashScreenFieldVisitImporter.ValidateMaintenanceRecordNumericRange("Percent Trash", null, 0));
+        }
+
+        [TestMethod]
+        public void ValidatePercentRange_AccumulationOver100_Errors()
+        {
+            var result = TrashScreenFieldVisitImporter.ValidatePercentRange("Material Accumulation as Percent of Total System Volume", "120", 1);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result!.Contains("between 0 and 100"));
+            Assert.IsTrue(result.Contains("row 3"));
+        }
+
+        [TestMethod]
+        public void ValidatePercentRange_NegativeAccumulation_Errors()
+        {
+            var result = TrashScreenFieldVisitImporter.ValidatePercentRange("Material Accumulation as Percent of Total System Volume", "-1", 0);
+            Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
+        public void ValidatePercentRange_InRange_NoError()
+        {
+            Assert.IsNull(TrashScreenFieldVisitImporter.ValidatePercentRange("Anything", "50", 0));
+            Assert.IsNull(TrashScreenFieldVisitImporter.ValidatePercentRange("Anything", "0", 0));
+            Assert.IsNull(TrashScreenFieldVisitImporter.ValidatePercentRange("Anything", "100", 0));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Addresses Bug #2 from KE's NPT-1071 test pass (negatives / percentages > 100 were silently accepted by the bulk XLSX importer).
- New validation in `TrashScreenFieldVisitImporter`:
  - `Percent Trash`, `Percent Green Waste`, `Percent Sediment` — must be in `[0, 100]`
  - `Total Material Volume Removed (cu-ft)`, `Total Material Volume Removed (gal)` — must be `>= 0` (no upper bound)
  - `Material Accumulation as Percent of Total System Volume` (Initial + Post-Maintenance assessment blocks) — must be in `[0, 100]`
- Blank cells stay blank — all five maintenance-record columns are optional, and the accumulation field is only validated when the assessment block is filled in.
- Range checks live in two new pure static helpers (`ValidateMaintenanceRecordNumericRange`, `ValidatePercentRange`), covered by 9 new unit tests.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ValidateMaintenanceRecordNumericRange|FullyQualifiedName~ValidatePercentRange"` — 9/9 passing.
- [ ] Upload XLSX with `Percent Trash = 150` → error: `Percent Trash '150' must be between 0 and 100 at row N`.
- [ ] Upload XLSX with `Total Material Volume Removed (gal) = -1` → error: `Total Material Volume Removed (gal) '-1' must be 0 or greater at row N`.
- [ ] Upload XLSX with `Material Accumulation as Percent of Total System Volume = 120` in the Initial block → error references the field with `(Post-Maintenance)` suffix only when on the post-maintenance side.
- [ ] Boundary check: `0` and `100` accepted on the percent columns; `0` accepted on the volume columns.
- [ ] Volume > 100 (e.g. `1000` cu-ft) still accepted — there is no upper bound on volumes.