### PR TITLE
NPT-1076: Rework OVTA bulk XLSX uploader (Bugs #1-#4)

### DIFF
--- a/Neptune.EFModels/Entities/OvtaBulkUploadImporter.cs
+++ b/Neptune.EFModels/Entities/OvtaBulkUploadImporter.cs
@@ -45,6 +45,13 @@ public static class OvtaBulkUploadImporter
 
         var numRows = dataTable.Rows.Count;
         var numColumns = dataTable.Columns.Count;
+        // NPT-1076 Bug #2: header-only XLSX used to silently report "Successfully bulk uploaded
+        // OVTAs from 0 row(s)". Surface a row-error so the SPA renders an actionable message.
+        if (numRows == 0)
+        {
+            result.Errors.Add("The uploaded file had no data rows. Add at least one OVTA Assessment row beneath the header and try again.");
+            return result;
+        }
         var errors = new List<string>();
         var ovtaAreaIDsForScoreRecalculation = new List<int?>();
 
@@ -81,17 +88,25 @@ public static class OvtaBulkUploadImporter
                     foreach (var category in categories)
                     {
                         if (string.IsNullOrWhiteSpace(row[category].ToString())) continue;
-                        var identificationTypes = row[category].ToString().Trim().Split(',');
+                        // NPT-1076 Bug #1: previously `cell.Trim().Split(',')` only trimmed the
+                        // full cell, so "Parked Cars, Uncovered Loads" produced a leading-space
+                        // second entry that failed the `==` compare. Trim each entry and compare
+                        // case-insensitively so the template's display values round-trip cleanly.
+                        var identificationTypes = row[category].ToString()
+                            .Split(',')
+                            .Select(x => x.Trim())
+                            .Where(x => x.Length > 0)
+                            .ToList();
                         foreach (var identificationType in identificationTypes)
                         {
-                            if (identificationType.ToLower().Contains("other"))
+                            if (identificationType.Contains("other", StringComparison.OrdinalIgnoreCase))
                             {
-                                errors.Add($"Cannot use {identificationType.Trim()} in row {i + 1} as bulk uploader does not allow for Other as a preliminary type.");
+                                errors.Add($"Cannot use {identificationType} in row {i + 1} as bulk uploader does not allow for Other as a preliminary type.");
                                 continue;
                             }
                             var id = PreliminarySourceIdentificationType.All.SingleOrDefault(x =>
-                                x.PreliminarySourceIdentificationTypeDisplayName.Trim() == identificationType
-                                && x.PreliminarySourceIdentificationCategory.PreliminarySourceIdentificationCategoryDisplayName.Trim() == category);
+                                string.Equals(x.PreliminarySourceIdentificationTypeDisplayName.Trim(), identificationType, StringComparison.OrdinalIgnoreCase)
+                                && string.Equals(x.PreliminarySourceIdentificationCategory.PreliminarySourceIdentificationCategoryDisplayName.Trim(), category, StringComparison.OrdinalIgnoreCase));
                             if (id == null)
                             {
                                 errors.Add($"{identificationType} is not a valid Preliminary Source Identification Type for {category} in row {i + 1}");
@@ -195,6 +210,15 @@ public static class OvtaBulkUploadImporter
         if (string.IsNullOrWhiteSpace(scoreRaw) || !validScores.Contains(scoreRaw))
         {
             errors.Add($"Score is not a valid value in row {rowIndex + 1}. It must be one of the following A, B, C or D.");
+        }
+        // NPT-1076 Bug #3: a non-date Completed Date used to throw FormatException inside the
+        // OnlandVisualTrashAssessment initializer (line below) and fall through to the outer
+        // catch, which surfaced the generic "Unexpected error parsing Excel Spreadsheet upload"
+        // and bailed the whole upload. Pre-validate here so the user gets a row-scoped message.
+        var completedDateRaw = row["Completed Date"].ToString().Trim();
+        if (string.IsNullOrWhiteSpace(completedDateRaw) || !DateTime.TryParse(completedDateRaw, out _))
+        {
+            errors.Add($"Invalid Completed Date '{completedDateRaw}' in row {rowIndex + 1}.");
         }
         return errors;
     }

--- a/Neptune.EFModels/Entities/OvtaBulkUploadImporter.cs
+++ b/Neptune.EFModels/Entities/OvtaBulkUploadImporter.cs
@@ -45,15 +45,12 @@ public static class OvtaBulkUploadImporter
 
         var numRows = dataTable.Rows.Count;
         var numColumns = dataTable.Columns.Count;
-        // NPT-1076 Bug #2: header-only XLSX used to silently report "Successfully bulk uploaded
-        // OVTAs from 0 row(s)". Surface a row-error so the SPA renders an actionable message.
-        if (numRows == 0)
-        {
-            result.Errors.Add("The uploaded file had no data rows. Add at least one OVTA Assessment row beneath the header and try again.");
-            return result;
-        }
         var errors = new List<string>();
         var ovtaAreaIDsForScoreRecalculation = new List<int?>();
+        // NPT-1076 Bug #2: track actually-processed (non-blank) rows so we can surface a
+        // row-error when the file has nothing to import. Covers header-only XLSX and the case
+        // where Excel's used range stretches past data leaving trailing blank rows.
+        var processedRowCount = 0;
 
         try
         {
@@ -142,6 +139,7 @@ public static class OvtaBulkUploadImporter
                         IsTransectBackingAssessment = false,
                     };
                     dbContext.Add(assessment);
+                    processedRowCount++;
                 }
                 catch (InvalidOperationException ioe)
                 {
@@ -158,6 +156,14 @@ public static class OvtaBulkUploadImporter
         if (errors.Count > 0)
         {
             result.Errors = errors;
+            return result;
+        }
+
+        // NPT-1076 Bug #2: file had no actionable data (header-only or all-blank rows). Surface
+        // an error so the SPA doesn't show "Successfully bulk uploaded OVTAs from 0 row(s)".
+        if (processedRowCount == 0)
+        {
+            result.Errors.Add("The uploaded file had no data rows. Add at least one OVTA Assessment row beneath the header and try again.");
             return result;
         }
 

--- a/Neptune.Tests/OvtaBulkUploadImporterTests.cs
+++ b/Neptune.Tests/OvtaBulkUploadImporterTests.cs
@@ -342,6 +342,21 @@ namespace Neptune.Tests
         }
 
         [TestMethod]
+        public async Task AllBlankDataRows_Errors()
+        {
+            // Copilot review on PR #544: Excel's used range can stretch past actual data,
+            // producing blank data rows that the rowEmpty check skips. Previously this slipped
+            // through the upfront numRows == 0 guard and returned a false success. The
+            // post-loop processedRowCount guard now catches it too.
+            var blank = new string[BaseColumns.Length];
+            for (var i = 0; i < blank.Length; i++) blank[i] = "";
+            using var xlsx = BuildXlsx(BaseColumns, new[] { blank, blank, blank });
+            var result = await OvtaBulkUploadImporter.BulkUploadAsync(_dbContext, xlsx, GetAdminPerson());
+            Assert.AreEqual(1, result.Errors.Count, string.Join("; ", result.Errors));
+            Assert.IsTrue(result.Errors[0].Contains("no data rows"), result.Errors[0]);
+        }
+
+        [TestMethod]
         public async Task InvalidCompletedDate_RowScopedError()
         {
             // Bug #3: garbage Completed Date used to fall through to the outer catch and surface

--- a/Neptune.Tests/OvtaBulkUploadImporterTests.cs
+++ b/Neptune.Tests/OvtaBulkUploadImporterTests.cs
@@ -326,5 +326,80 @@ namespace Neptune.Tests
             Assert.IsTrue(result.Errors.Any(x => x.Contains("does not allow for Other")),
                 string.Join("; ", result.Errors));
         }
+
+        // ----- NPT-1076 rework -----
+
+        [TestMethod]
+        public async Task EmptyDataRows_Errors()
+        {
+            // Header row only, no data rows. Previously this silently reported "successfully bulk
+            // uploaded OVTAs from 0 row(s)"; now it should surface an actionable error.
+            using var xlsx = BuildXlsx(BaseColumns, Array.Empty<string[]>());
+            var result = await OvtaBulkUploadImporter.BulkUploadAsync(_dbContext, xlsx, GetAdminPerson());
+            Assert.AreEqual(1, result.Errors.Count, string.Join("; ", result.Errors));
+            Assert.IsTrue(result.Errors[0].Contains("no data rows"), result.Errors[0]);
+            Assert.AreEqual(0, result.RowsProcessed);
+        }
+
+        [TestMethod]
+        public async Task InvalidCompletedDate_RowScopedError()
+        {
+            // Bug #3: garbage Completed Date used to fall through to the outer catch and surface
+            // the generic "Unexpected error parsing Excel Spreadsheet upload". Should now be a
+            // row-scoped, field-specific message like Score/Status/etc.
+            var area = _dbContext.OnlandVisualTrashAssessmentAreas.AsNoTracking().FirstOrDefault();
+            if (area == null)
+            {
+                Assert.Inconclusive("No OVTA areas in dev DB.");
+                return;
+            }
+            var creator = GetAdminPerson();
+            var jurisdiction = _dbContext.StormwaterJurisdictions.Include(x => x.Organization).AsNoTracking().First();
+            var validScore = OnlandVisualTrashAssessmentScore.All.First().OnlandVisualTrashAssessmentScoreDisplayName;
+
+            var row = new[]
+            {
+                area.OnlandVisualTrashAssessmentAreaName, jurisdiction.Organization.OrganizationName, creator.Email,
+                "Finalized", "not-a-date", validScore, "Yes",
+                "", "", "", "",
+            };
+            using var xlsx = BuildXlsx(BaseColumns, new[] { row });
+
+            var result = await OvtaBulkUploadImporter.BulkUploadAsync(_dbContext, xlsx, creator);
+            Assert.IsTrue(result.Errors.Any(x => x.Contains("Invalid Completed Date") && x.Contains("row 1")),
+                $"Expected row-scoped Completed Date error. Got: {string.Join("; ", result.Errors)}");
+            Assert.IsFalse(result.Errors.Any(x => x.Contains("Unexpected error parsing")),
+                $"Generic outer-catch message should no longer surface. Got: {string.Join("; ", result.Errors)}");
+        }
+
+        [TestMethod]
+        public async Task PSIWhitespaceAndCasing_Accepted()
+        {
+            // Bug #1: mixed-case + leading/trailing whitespace around comma-separated PSI values
+            // used to produce "X is not a valid Preliminary Source Identification Type for ..."
+            // even when X was present in the DB seed. Trimmed + case-insensitive match now.
+            var area = _dbContext.OnlandVisualTrashAssessmentAreas.AsNoTracking().FirstOrDefault();
+            if (area == null)
+            {
+                Assert.Inconclusive("No OVTA areas in dev DB.");
+                return;
+            }
+            var creator = GetAdminPerson();
+            var jurisdiction = _dbContext.StormwaterJurisdictions.Include(x => x.Organization).AsNoTracking().First();
+            var validScore = OnlandVisualTrashAssessmentScore.All.First().OnlandVisualTrashAssessmentScoreDisplayName;
+
+            var row = new[]
+            {
+                area.OnlandVisualTrashAssessmentAreaName, jurisdiction.Organization.OrganizationName, creator.Email,
+                "Finalized", "06/15/2024", validScore, "Yes",
+                "parked cars, UNCOVERED LOADS " /* Vehicles col: mixed case + trailing space + leading space after comma */,
+                "", "", "",
+            };
+            using var xlsx = BuildXlsx(BaseColumns, new[] { row });
+
+            var result = await OvtaBulkUploadImporter.BulkUploadAsync(_dbContext, xlsx, creator);
+            Assert.AreEqual(0, result.Errors.Count,
+                $"Expected casing/whitespace-tolerant PSI matching. Got: {string.Join("; ", result.Errors)}");
+        }
     }
 }

--- a/Neptune.Web/src/app/pages/data-hub/ovta-upload/ovta-upload.component.ts
+++ b/Neptune.Web/src/app/pages/data-hub/ovta-upload/ovta-upload.component.ts
@@ -39,6 +39,7 @@ export class OvtaUploadComponent {
     public onFileChange(file: File | null): void {
         if (!file) return;
         if (!file.name.toLowerCase().endsWith(".xlsx")) {
+            this.alertService.clearAlerts();
             this.alertService.pushAlert(new Alert("Only XLSX files are accepted.", AlertContext.Danger, true));
             this.fileControl.setValue(null);
         }
@@ -46,6 +47,7 @@ export class OvtaUploadComponent {
 
     public submit(): void {
         if (this.fileControl.invalid) return;
+        this.alertService.clearAlerts();
         this.errors.set([]);
         this.successMessage.set(null);
         this.isUploading.set(true);


### PR DESCRIPTION
## Summary

Addresses KE's four rework items on NPT-1076 against the SPA Data Hub OVTA bulk XLSX uploader.

### Bug #1 — PSI values rejected even when present in DB
The importer split comma-separated PSI values without trimming each entry and compared case-sensitively. `"Parked Cars, Uncovered Loads"` → the second value carried a leading space and failed the `==` check; any casing drift between the template and the DB seed produced false rejections. Now: trim each split entry, drop empties, and compare case-insensitively on both type display name and category. No template re-upload required — the DB seed already contains the correct values.

### Bug #2 — Empty XLSX silently accepted
A header-only XLSX used to report "Successfully bulk uploaded OVTAs from 0 row(s)". `OvtaBulkUploadImporter` now surfaces a row-scoped error when `numRows == 0`, and the SPA's existing `result.Errors` branch renders it.

### Bug #3 — Generic catch-all for invalid Completed Date
A non-date Completed Date threw `FormatException` inside the `OnlandVisualTrashAssessment` initializer (`DateTime.Parse` deep in an object initializer), which fell through to the outer `catch (Exception)` and surfaced the generic "Unexpected error parsing Excel Spreadsheet upload" + bailed the whole upload. `CheckDataFromRow` now pre-validates Completed Date with `DateTime.TryParse` and emits a row-scoped `Invalid Completed Date '{value}' in row {N}` matching the Score / Status / Person / Area Name pattern.

### Bug #4 — UI error banner stacking
Same one-line `alertService.clearAlerts()` fix mirrored from NPT-1071 / 1072 / 1073 / 1074 / 1077, applied to both `submit()` and `onFileChange()` so neither the "Upload failed" banner nor the "Only XLSX files are accepted" rejection stacks across retries.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~OvtaBulkUpload"` — 12/12 passing (9 existing + 3 new: `EmptyDataRows_Errors`, `InvalidCompletedDate_RowScopedError`, `PSIWhitespaceAndCasing_Accepted`).
- [ ] Upload XLSX with only a header row → row-error list shows "The uploaded file had no data rows…", no false success banner.
- [ ] Upload XLSX with `Completed Date = garbage` in one row → `Invalid Completed Date 'garbage' in row N`, no generic catch-all surfacing.
- [ ] Upload XLSX with `"parked cars, UNCOVERED LOADS"` (mixed case + whitespace) in the Vehicles PSI column → accepted; both PSI rows attach to the OVTA.
- [ ] Trigger a network/500 then resubmit → only one "Upload failed" banner.
- [ ] Pick a non-`.xlsx` twice → only one "Only XLSX files are accepted" banner.