### PR TITLE
NPT-998: Data Hub rework (KE 5/28/26 — 6 items)

### DIFF
--- a/Neptune.Database/Scripts/ReleaseScripts/030 - Seed ExportAssessmentGeospatialData rich text.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/030 - Seed ExportAssessmentGeospatialData rich text.sql
@@ -1,0 +1,26 @@
+DECLARE @MigrationName VARCHAR(200);
+SET @MigrationName = '030 - Seed ExportAssessmentGeospatialData rich text'
+IF NOT EXISTS(SELECT * FROM dbo.DatabaseMigration DM WHERE DM.ReleaseScriptFileName = @MigrationName)
+BEGIN
+
+    PRINT @MigrationName;
+
+    -- NPT-998 rework: the SPA Download OVTA Areas page binds <custom-rich-text> to
+    -- NeptunePageTypeID = 44 (ExportAssessmentGeospatialData), but the legacy MVC view rendered
+    -- the same instructions as hard-coded prose. The corresponding NeptunePage row was never
+    -- seeded, so the SPA renders a blank panel. Seed the content from the legacy MVC view.
+    -- Only fill blank/null rows so we don't clobber any admin edit made via the in-page editor.
+    DECLARE @Content NVARCHAR(MAX) = N'<p>Use this form to download OVTA Areas for a given jurisdiction:</p><ul><li>A single ArcGIS file geodatabase containing onland visual trash assessment area features will be produced for the selected jurisdiction.</li><li>It will contain attributes for Area ID, Area Name, Jurisdiction, and Description.</li><li>This file download is intended to support bulk editing in desktop GIS software and can be re-uploaded to the platform to replace the existing onland visual trash assessment areas utilized in trash results calculations.</li></ul>';
+
+    IF EXISTS (SELECT 1 FROM dbo.NeptunePage WHERE NeptunePageTypeID = 44)
+        UPDATE dbo.NeptunePage
+        SET NeptunePageContent = @Content
+        WHERE NeptunePageTypeID = 44
+          AND (NeptunePageContent IS NULL OR LTRIM(RTRIM(NeptunePageContent)) = '')
+    ELSE
+        INSERT INTO dbo.NeptunePage (NeptunePageTypeID, NeptunePageContent)
+        VALUES (44, @Content)
+
+    INSERT INTO dbo.DatabaseMigration(MigrationAuthorName, ReleaseScriptFileName, MigrationReason)
+    SELECT 'Ray Lee', @MigrationName, 'NPT-998 rework: seed help text for Download OVTA Areas (NeptunePageType 44) that was never populated when the SPA page replaced the MVC hard-coded prose with a rich-text panel'
+END

--- a/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -66,4 +66,6 @@ GO
 GO
 :r ".\029 - WQMP Verification Supporting Documentation help text.sql"
 GO
+:r ".\030 - Seed ExportAssessmentGeospatialData rich text.sql"
+GO
 

--- a/Neptune.Web/src/app/pages/data-hub/land-use-block-download/land-use-block-download.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/land-use-block-download/land-use-block-download.component.html
@@ -1,5 +1,7 @@
 <page-header pageTitle="Download Land Use Blocks">
     <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'trash' }">&laquo; Back to Data Hub</a>
+    &nbsp;|&nbsp;
+    <a class="back-link" [routerLink]="['/data-hub/land-use-block-upload']">Go to Upload Land Use Blocks &raquo;</a>
 </page-header>
 
 <section class="content-section">
@@ -7,12 +9,11 @@
 
     <div class="grid-12">
         <div class="g-col-6 instructions">
-            <p>Build a zipped File Geodatabase containing every Land Use Block for the selected jurisdiction. The export includes:</p>
+            <p>Use this form to download Land Use Blocks for a given jurisdiction:</p>
             <ul>
-                <li>Block identifier, priority land use type, land use description.</li>
-                <li>Block area in acres and computed trash generating unit area in acres.</li>
-                <li>Trash generation rate, land use for TGR, household income context fields, and permit type.</li>
-                <li>Polygon geometry in NAD 83 HARN California Zone VI (SRID 2771).</li>
+                <li>A single ArcGIS file geodatabase containing land use block features will be produced for the selected jurisdiction.</li>
+                <li>It will contain attributes for Block ID, Land Use Type, Jurisdiction, Block Area, Trash Generation Rate, Land Use Description, Median Household Income Residential, Median Household Income Retail, Trash Results Area, and Permit Type.</li>
+                <li>This file download is intended to support bulk editing in desktop GIS software and can be re-uploaded to the platform to replace the existing land use blocks utilized in trash results calculations.</li>
             </ul>
         </div>
         <div class="g-col-6">

--- a/Neptune.Web/src/app/pages/data-hub/land-use-block-download/land-use-block-download.component.scss
+++ b/Neptune.Web/src/app/pages/data-hub/land-use-block-download/land-use-block-download.component.scss
@@ -1,0 +1,16 @@
+@use "/src/scss/abstracts" as *;
+
+.back-link {
+    font-size: $type-size-200;
+}
+
+.instructions {
+    ul {
+        list-style: disc;
+        margin-top: $spacing-100;
+        padding-left: 1.5rem;
+    }
+    li + li {
+        margin-top: $spacing-100;
+    }
+}

--- a/Neptune.Web/src/app/pages/data-hub/land-use-block-download/land-use-block-download.component.ts
+++ b/Neptune.Web/src/app/pages/data-hub/land-use-block-download/land-use-block-download.component.ts
@@ -18,6 +18,7 @@ import { AlertService } from "src/app/shared/services/alert.service";
     standalone: true,
     imports: [AsyncPipe, FormsModule, ReactiveFormsModule, RouterLink, PageHeaderComponent, AlertDisplayComponent, FormFieldComponent],
     templateUrl: "./land-use-block-download.component.html",
+    styleUrl: "./land-use-block-download.component.scss",
 })
 export class LandUseBlockDownloadComponent implements OnInit {
     public FormFieldType = FormFieldType;

--- a/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.html
@@ -20,7 +20,7 @@
                 </li>
                 <li>
                     Geodatabases using ESRI Smart Database Compression (SDC) are not supported. Please
-                    <a href="http://desktop.arcgis.com/en/arcmap/10.3/tools/data-management-toolbox/uncompress-file-geodatabase-data.htm" target="_blank" rel="noopener noreferrer">uncompress</a>
+                    <a href="https://desktop.arcgis.com/en/arcmap/10.3/tools/data-management-toolbox/uncompress-file-geodatabase-data.htm" target="_blank" rel="noopener noreferrer">uncompress</a>
                     before zipping and uploading.
                 </li>
                 <li>Version 10.1+ file geodatabases are supported.</li>

--- a/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.html
@@ -1,5 +1,7 @@
 <page-header pageTitle="Upload Land Use Blocks">
     <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'trash' }">&laquo; Back to Data Hub</a>
+    &nbsp;|&nbsp;
+    <a class="back-link" [routerLink]="['/data-hub/land-use-block-download']">Go to Download Land Use Blocks &raquo;</a>
 </page-header>
 
 <section class="content-section">
@@ -7,12 +9,23 @@
 
     <div class="grid-12">
         <div class="g-col-6 instructions">
-            <p>Use this form to bulk upload Land Use Blocks for a jurisdiction from a zipped File Geodatabase. Requirements:</p>
+            <p>Use this form to bulk upload Land Use Blocks. Requirements:</p>
             <ul>
-                <li>A single ArcGIS file geodatabase (.gdb inside a .zip) containing exactly one Land Use Block feature class.</li>
-                <li>The feature class must include attributes: PriorityLandUseType, LandUseDescription, TrashGenerationRate, LandUseForTGR, MedianHouseholdIncomeResidential, MedianHouseholdIncomeRetail, PermitType.</li>
-                <li>Validated rows are written to the staging table; a background job then processes them and emails the result to you. You can close this page once the upload is staged.</li>
+                <li>A single ArcGIS file geodatabase containing only Land Use Block features.</li>
+                <li>The file geodatabase (.gdb) must be contained within a compressed zip file (.zip).</li>
+                <li>The zip file must contain only one file geodatabase and no other data.</li>
+                <li>The file geodatabase must contain only one feature class.</li>
+                <li>
+                    The feature class must include attributes <code>PriorityLandUseType</code>, <code>LandUseDescription</code>, <code>TrashGenerationRate</code>, <code>LandUseForTGR</code>, <code>MedianHouseholdIncomeResidential</code>, <code>MedianHouseholdIncomeRetail</code>, and <code>PermitType</code>. All required values must be present.
+                </li>
+                <li>
+                    Geodatabases using ESRI Smart Database Compression (SDC) are not supported. Please
+                    <a href="http://desktop.arcgis.com/en/arcmap/10.3/tools/data-management-toolbox/uncompress-file-geodatabase-data.htm" target="_blank" rel="noopener noreferrer">uncompress</a>
+                    before zipping and uploading.
+                </li>
+                <li>Version 10.1+ file geodatabases are supported.</li>
             </ul>
+            <p>After you upload your file the new Land Use Blocks will be staged for review. Once approved, they replace any existing Land Use Blocks for your Jurisdiction. It may take up to twenty-four hours to see updated Trash Results on the home page.</p>
         </div>
         <div class="g-col-6">
             @if (jurisdictionOptions$ | async; as opts) {

--- a/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.scss
+++ b/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.scss
@@ -1,0 +1,16 @@
+@use "/src/scss/abstracts" as *;
+
+.back-link {
+    font-size: $type-size-200;
+}
+
+.instructions {
+    ul {
+        list-style: disc;
+        margin-top: $spacing-100;
+        padding-left: 1.5rem;
+    }
+    li + li {
+        margin-top: $spacing-100;
+    }
+}

--- a/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.ts
+++ b/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.ts
@@ -17,6 +17,7 @@ import { AlertService } from "src/app/shared/services/alert.service";
     standalone: true,
     imports: [AsyncPipe, FormsModule, ReactiveFormsModule, RouterLink, PageHeaderComponent, AlertDisplayComponent, FormFieldComponent],
     templateUrl: "./land-use-block-upload.component.html",
+    styleUrl: "./land-use-block-upload.component.scss",
 })
 export class LandUseBlockUploadComponent implements OnInit {
     public FormFieldType = FormFieldType;

--- a/Neptune.Web/src/app/pages/data-hub/ovta-area-download/ovta-area-download.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/ovta-area-download/ovta-area-download.component.html
@@ -1,5 +1,7 @@
 <page-header pageTitle="Download OVTA Assessment Areas">
     <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'trash' }">&laquo; Back to Data Hub</a>
+    &nbsp;|&nbsp;
+    <a class="back-link" [routerLink]="['/data-hub/ovta-area-upload']">Go to Upload OVTA Assessment Areas &raquo;</a>
 </page-header>
 
 <section class="content-section">

--- a/Neptune.Web/src/app/pages/data-hub/ovta-area-upload/ovta-area-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/ovta-area-upload/ovta-area-upload.component.html
@@ -18,7 +18,7 @@
                 <li>You must supply the name of the attribute representing the area name. The default is <code>OVTAAreaName</code>.</li>
                 <li>
                     Geodatabases using ESRI Smart Database Compression (SDC) are not supported. Please
-                    <a href="http://desktop.arcgis.com/en/arcmap/10.3/tools/data-management-toolbox/uncompress-file-geodatabase-data.htm" target="_blank" rel="noopener noreferrer">uncompress</a>
+                    <a href="https://desktop.arcgis.com/en/arcmap/10.3/tools/data-management-toolbox/uncompress-file-geodatabase-data.htm" target="_blank" rel="noopener noreferrer">uncompress</a>
                     before zipping and uploading.
                 </li>
                 <li>Version 10.1+ file geodatabases are supported.</li>

--- a/Neptune.Web/src/app/pages/data-hub/ovta-area-upload/ovta-area-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/ovta-area-upload/ovta-area-upload.component.html
@@ -1,5 +1,7 @@
 <page-header pageTitle="Upload OVTA Assessment Areas">
     <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'trash' }">&laquo; Back to Data Hub</a>
+    &nbsp;|&nbsp;
+    <a class="back-link" [routerLink]="['/data-hub/ovta-area-download']">Go to Download OVTA Assessment Areas &raquo;</a>
 </page-header>
 
 <section class="content-section">
@@ -7,11 +9,19 @@
 
     <div class="grid-12">
         <div class="g-col-6 instructions">
-            <p>Use this form to bulk upload OVTA assessment areas from a zipped File Geodatabase. Requirements:</p>
+            <p>Use this form to bulk upload Onland Visual Trash Assessment Areas. Requirements:</p>
             <ul>
-                <li>A single ArcGIS file geodatabase containing only OVTA Area features (.gdb inside a .zip).</li>
-                <li>The feature class must contain a unique area-name attribute and an optional Description attribute.</li>
-                <li>The default area-name field is <code>OVTAAreaName</code> &mdash; supply the field name your GDB uses if different.</li>
+                <li>A single ArcGIS file geodatabase containing only Onland Visual Trash Assessment Area features.</li>
+                <li>The file geodatabase (.gdb) must be contained within a compressed zip file (.zip).</li>
+                <li>The zip file must contain only one file geodatabase and no other data.</li>
+                <li>The file geodatabase must contain only one feature class.</li>
+                <li>You must supply the name of the attribute representing the area name. The default is <code>OVTAAreaName</code>.</li>
+                <li>
+                    Geodatabases using ESRI Smart Database Compression (SDC) are not supported. Please
+                    <a href="http://desktop.arcgis.com/en/arcmap/10.3/tools/data-management-toolbox/uncompress-file-geodatabase-data.htm" target="_blank" rel="noopener noreferrer">uncompress</a>
+                    before zipping and uploading.
+                </li>
+                <li>Version 10.1+ file geodatabases are supported.</li>
                 <li>Areas with names that already exist in the selected jurisdiction will have their geometry and description updated; new names are created.</li>
                 <li>After upload you'll be taken to a review page to confirm before any changes commit.</li>
             </ul>

--- a/Neptune.Web/src/app/pages/data-hub/ovta-area-upload/ovta-area-upload.component.scss
+++ b/Neptune.Web/src/app/pages/data-hub/ovta-area-upload/ovta-area-upload.component.scss
@@ -1,0 +1,16 @@
+@use "/src/scss/abstracts" as *;
+
+.back-link {
+    font-size: $type-size-200;
+}
+
+.instructions {
+    ul {
+        list-style: disc;
+        margin-top: $spacing-100;
+        padding-left: 1.5rem;
+    }
+    li + li {
+        margin-top: $spacing-100;
+    }
+}

--- a/Neptune.Web/src/app/pages/data-hub/ovta-area-upload/ovta-area-upload.component.ts
+++ b/Neptune.Web/src/app/pages/data-hub/ovta-area-upload/ovta-area-upload.component.ts
@@ -17,6 +17,7 @@ import { AlertService } from "src/app/shared/services/alert.service";
     standalone: true,
     imports: [AsyncPipe, FormsModule, ReactiveFormsModule, RouterLink, PageHeaderComponent, AlertDisplayComponent, FormFieldComponent],
     templateUrl: "./ovta-area-upload.component.html",
+    styleUrl: "./ovta-area-upload.component.scss",
 })
 export class OvtaAreaUploadComponent implements OnInit {
     public FormFieldType = FormFieldType;

--- a/Neptune.Web/src/app/pages/data-hub/treatment-bmp-download/treatment-bmp-download.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/treatment-bmp-download/treatment-bmp-download.component.html
@@ -1,5 +1,7 @@
 <page-header pageTitle="Download Treatment BMPs">
     <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'bmps' }">&laquo; Back to Data Hub</a>
+    &nbsp;|&nbsp;
+    <a class="back-link" [routerLink]="['/data-hub/treatment-bmp-upload']">Go to Upload Treatment BMPs &raquo;</a>
 </page-header>
 
 <section class="content-section">

--- a/Neptune.Web/src/app/pages/data-hub/treatment-bmp-upload/treatment-bmp-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/treatment-bmp-upload/treatment-bmp-upload.component.html
@@ -1,5 +1,7 @@
 <page-header pageTitle="Upload Treatment BMPs">
     <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'bmps' }">&laquo; Back to Data Hub</a>
+    &nbsp;|&nbsp;
+    <a class="back-link" [routerLink]="['/data-hub/treatment-bmp-download']">Go to Download Treatment BMPs &raquo;</a>
 </page-header>
 
 <section class="content-section">

--- a/Neptune.Web/src/app/pages/planning-module/planning-site-layout/planning-site-layout.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/planning-site-layout/planning-site-layout.component.html
@@ -17,7 +17,7 @@
                     <ul class="site-nav__links site-nav__main">
                         @if (isAuthenticated() && isNotUnassigned(currentUser)) {
                             <li class="nav-item" routerLinkActive="active">
-                                <a [href]="siteUrl + '/DataHub/Index'" class="nav-link" role="button"> Data Hub </a>
+                                <a [routerLink]="['/data-hub']" class="nav-link" role="button"> Data Hub </a>
                             </li>
                             <li class="nav-item" routerLinkActive="active">
                                 <a [routerLink]="['/planning/projects']" class="nav-link" role="button"> Projects </a>

--- a/Neptune.Web/src/app/pages/planning-module/planning-site-layout/planning-site-layout.component.ts
+++ b/Neptune.Web/src/app/pages/planning-module/planning-site-layout/planning-site-layout.component.ts
@@ -17,7 +17,6 @@ import { environment } from "src/environments/environment";
 })
 export class PlanningSiteLayoutComponent implements OnInit {
     public currentUser$: Observable<PersonDto>;
-    public siteUrl = environment.ocStormwaterToolsBaseUrl;
 
     constructor(private authenticationService: AuthenticationService) {}
 

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.html
@@ -2,10 +2,10 @@
 
 <ng-template #templateRight>
   @if (currentUserHasJurisdictionManagePermission()) {
-    <a class="float-right btn btn-primary-outline mr-2" [href]="url + '/OnlandVisualTrashAssessmentArea/BulkUploadOVTAAreas'"> <icon [icon]="'Upload'"></icon> Upload OVTA Areas </a>
+    <a class="float-right btn btn-primary-outline mr-2" [routerLink]="['/data-hub/ovta-area-upload']"> <icon [icon]="'Upload'"></icon> Upload OVTA Areas </a>
   }
   @if (currentUserHasJurisdictionEditPermission()) {
-    <a class="float-right btn btn-primary-outline mr-2" [href]="url + '/OnlandVisualTrashAssessmentExport/ExportAssessmentGeospatialData'">
+    <a class="float-right btn btn-primary-outline mr-2" [routerLink]="['/data-hub/ovta-area-download']">
       <icon [icon]="'Download'"></icon> Download OVTA Areas
     </a>
   }

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.ts
@@ -8,7 +8,6 @@ import { OnlandVisualTrashAssessmentAreaService } from "src/app/shared/generated
 import { OnlandVisualTrashAssessmentAreaGridDto } from "src/app/shared/generated/model/onland-visual-trash-assessment-area-grid-dto";
 import { AsyncPipe } from "@angular/common";
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
-import { environment } from "src/environments/environment";
 import { IconComponent } from "../../../../shared/components/icon/icon.component";
 import { HybridMapGridComponent } from "../../../../shared/components/hybrid-map-grid/hybrid-map-grid.component";
 import { NeptuneMapInitEvent } from "src/app/shared/components/leaflet/neptune-map/neptune-map.component";
@@ -36,7 +35,6 @@ export class TrashOvtaAreaIndexComponent {
     public onlandVisualTrashAssessmentAreas$: Observable<OnlandVisualTrashAssessmentAreaGridDto[]>;
     public ovtaAreaColumnDefs: ColDef[];
     public isLoading: boolean = true;
-    public url = environment.ocStormwaterToolsBaseUrl;
     public ovtaAreaID: number;
     public selectionFromMap: boolean;
 

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-index/trash-ovta-index.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-index/trash-ovta-index.component.html
@@ -3,7 +3,7 @@
 <ng-template #templateRight>
   <a class="float-right btn btn-orange mr-2" [routerLink]="['new/instructions']">Add New OVTA</a>
   @if (currentUserHasJurisdictionManagePermission()) {
-    <a class="float-right btn btn-primary-outline mr-2" [href]="url + '/OnlandVisualTrashAssessment/BulkUploadOTVAs'"> <icon [icon]="'Upload'"></icon> Upload OVTAs </a>
+    <a class="float-right btn btn-primary-outline mr-2" [routerLink]="['/data-hub/ovta-upload']"> <icon [icon]="'Upload'"></icon> Upload OVTAs </a>
   }
 </ng-template>
 

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-index/trash-ovta-index.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-index/trash-ovta-index.component.ts
@@ -10,7 +10,6 @@ import { AsyncPipe, DatePipe } from "@angular/common";
 import { OnlandVisualTrashAssessmentGridDto } from "src/app/shared/generated/model/onland-visual-trash-assessment-grid-dto";
 import { NeptunePageTypeEnum } from "src/app/shared/generated/enum/neptune-page-type-enum";
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
-import { environment } from "src/environments/environment";
 import { IconComponent } from "../../../../shared/components/icon/icon.component";
 import { Router, RouterLink } from "@angular/router";
 import { OnlandVisualTrashAssessmentStatusEnum } from "src/app/shared/generated/enum/onland-visual-trash-assessment-status-enum";
@@ -32,7 +31,6 @@ export class TrashOvtaIndexComponent {
     public ovtaColumnDefs: ColDef[];
     public customRichTextID = NeptunePageTypeEnum.OVTAIndex;
     public isLoading: boolean = true;
-    public url = environment.ocStormwaterToolsBaseUrl;
 
     private refreshGridTrigger$ = new BehaviorSubject<void>(null);
 

--- a/Neptune.Web/src/app/pages/trash-module/trash-land-use-block-index/trash-land-use-block-index.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/trash-land-use-block-index/trash-land-use-block-index.component.html
@@ -2,9 +2,9 @@
 
 <ng-template #templateRight>
     @if (currentUserHasJurisdictionEditPermission()) {
-    <a class="float-right btn btn-primary mr-2" [href]="url + '/LandUseBlockGeometry/UpdateLandUseBlockGeometry'"> <icon [icon]="'Upload'"></icon> Upload Land Use Blocks </a>
+    <a class="float-right btn btn-primary mr-2" [routerLink]="['/data-hub/land-use-block-upload']"> <icon [icon]="'Upload'"></icon> Upload Land Use Blocks </a>
     } @if (currentUserHasJurisdictionEditPermission()) {
-    <a class="float-right btn btn-primary" [href]="url + '/LandUseBlockGeometry/DownloadLandUseBlockGeometry'"> <icon [icon]="'Download'"></icon> Download Land Use Blocks </a>
+    <a class="float-right btn btn-primary" [routerLink]="['/data-hub/land-use-block-download']"> <icon [icon]="'Download'"></icon> Download Land Use Blocks </a>
     }
 </ng-template>
 

--- a/Neptune.Web/src/app/pages/trash-module/trash-land-use-block-index/trash-land-use-block-index.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/trash-land-use-block-index/trash-land-use-block-index.component.ts
@@ -10,7 +10,7 @@ import { LandUseBlockGridDto } from "../../../shared/generated/model/land-use-bl
 import { NeptunePageTypeEnum } from "src/app/shared/generated/enum/neptune-page-type-enum";
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
 import { IconComponent } from "../../../shared/components/icon/icon.component";
-import { environment } from "src/environments/environment";
+import { RouterLink } from "@angular/router";
 import { AuthenticationService } from "src/app/services/authentication.service";
 import { NeptuneMapInitEvent } from "src/app/shared/components/leaflet/neptune-map/neptune-map.component";
 import { HybridMapGridComponent } from "src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component";
@@ -43,6 +43,7 @@ import { OverlayMode } from "src/app/shared/components/leaflet/layers/generic-wm
         JurisdictionsLayerComponent,
         WqmpsLayerComponent,
         DelineationsLayerComponent,
+        RouterLink,
     ],
     templateUrl: "./trash-land-use-block-index.component.html",
     styleUrl: "./trash-land-use-block-index.component.scss",
@@ -53,7 +54,6 @@ export class TrashLandUseBlockIndexComponent {
     public landUseBlockColumnDefs: ColDef[];
     public richTextID = NeptunePageTypeEnum.LandUseBlock;
     public isLoading: boolean = true;
-    public url = environment.ocStormwaterToolsBaseUrl;
     public landUseBlockID: number;
     /** Stable reference for the layer's [selectedLandUseBlockIDs] @Input. Built inline as
      * `landUseBlockID ? [landUseBlockID] : []` would allocate a new array every change-detection

--- a/Neptune.Web/src/app/pages/trash-module/trash-site-layout/trash-site-layout.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/trash-site-layout/trash-site-layout.component.html
@@ -17,7 +17,7 @@
                     <ul class="site-nav__links site-nav__main nav navbar-nav navbar-left">
                         @if (isAuthenticated() && isNotUnassigned(currentUser)) {
                             <li class="nav-item" routerLinkActive="active">
-                                <a [href]="siteUrl + '/DataHub/Index'" class="nav-link" role="button"> Data Hub </a>
+                                <a [routerLink]="['/data-hub']" class="nav-link" role="button"> Data Hub </a>
                             </li>
                             <li class="nav-item dropdown" routerLinkActive="active">
                                 <a

--- a/Neptune.Web/src/app/pages/trash-module/trash-site-layout/trash-site-layout.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/trash-site-layout/trash-site-layout.component.ts
@@ -17,7 +17,6 @@ import { environment } from "src/environments/environment";
 })
 export class TrashSiteLayoutComponent implements OnInit {
     public currentUser$: Observable<PersonDto>;
-    public siteUrl = environment.ocStormwaterToolsBaseUrl;
 
     constructor(private authenticationService: AuthenticationService) {}
 


### PR DESCRIPTION
## Summary

Addresses KE's 6 red items on NPT-998 (5/28/26 rework pass) so the legacy MVC `/DataHub/Index` retirement can land cleanly.

### Bug #1 — Re-target hardcoded /DataHub MVC links to the SPA
5 hrefs converted to `[routerLink]`:
- Planning module nav: "Data Hub" → `/data-hub`
- Trash module nav: "Data Hub" → `/data-hub`
- `/trash/land-use-blocks` Upload/Download buttons → `/data-hub/land-use-block-upload` + `/data-hub/land-use-block-download`
- `/trash/onland-visual-trash-assessment-areas` Upload/Download Areas → `/data-hub/ovta-area-upload` + `/data-hub/ovta-area-download`
- `/trash/onland-visual-trash-assessments` Upload OVTAs → `/data-hub/ovta-upload`

Drops the now-dead `siteUrl` / `url = environment.ocStormwaterToolsBaseUrl` component properties along with their unused `environment` imports.

### Bug #2 — Cross-nav between sibling upload/download pages
3 page pairs (`treatment-bmp`, `ovta-area`, `land-use-block`) now show a "Go to {sibling} »" link next to the existing "« Back to Data Hub" so users don't have to bounce through the Data Hub shell.

### Bug #3 — Seed Download OVTA Areas rich-text content
Release script `030 - Seed ExportAssessmentGeospatialData rich text.sql` populates `dbo.NeptunePage.NeptunePageContent` for `NeptunePageTypeID = 44`. The SPA's `<custom-rich-text>` was rendering blank because the row was never seeded when the SPA replaced the legacy MVC hard-coded prose with a rich-text panel. Script is an upsert that only fills blank/null rows so an admin's in-page edit isn't clobbered.

### Bug #4 / #5 / #6 — Restore legacy bullet lists
Replaces the SPA's compressed prose on Upload OVTA Areas, Upload Land Use Blocks, and Download Land Use Blocks with the legacy MVC bullet lists (the Download Land Use Blocks copy also diverged from the documented schema). Bullet styling needs a scoped rule because `src/scss/base/_normalize.scss` strips `list-style` globally — adds a small per-page SCSS mirroring the existing `lat-lon-picker` pattern.

## Out of scope (deferred)
- Building entirely new download pages where none exist today (OVTA, WQMP, Simplified BMP, WQMP Locations, Trash Screen Field Visit). Tester's note was about cross-linking *existing* pairs, not creating new ones.
- Auditing other blank `<custom-rich-text>` rows across the data-hub tabs. This PR seeds only the one tester named.
- The yellow / "optional" note about expanding OVTA Upload to Editors — separate decision.

## Test plan
- [ ] Planning + Trash module nav: "Data Hub" link routes via SPA (no full page reload).
- [ ] `/trash/land-use-blocks` Upload/Download buttons → new SPA routes.
- [ ] `/trash/onland-visual-trash-assessment-areas` Upload/Download Areas → new SPA routes.
- [ ] `/trash/onland-visual-trash-assessments` Upload OVTAs → `/data-hub/ovta-upload`.
- [ ] On the 6 data-hub pages, header shows `« Back to Data Hub | Go to {sibling} »` and the cross-link navigates correctly.
- [ ] After applying release script `030`, `/data-hub/ovta-area-download` renders the seeded prose where the panel was blank.
- [ ] Upload OVTA Areas, Upload Land Use Blocks, Download Land Use Blocks instructions render with visible bullet markers.