### PR TITLE
NPT-1073: Accept Yes/No shorthand for DryWeatherFlowOverride (round 2)

### DIFF
--- a/Neptune.EFModels/Entities/DryWeatherFlowOverride.StaticHelpers.cs
+++ b/Neptune.EFModels/Entities/DryWeatherFlowOverride.StaticHelpers.cs
@@ -1,0 +1,19 @@
+namespace Neptune.EFModels.Entities;
+
+public abstract partial class DryWeatherFlowOverride
+{
+    /// <summary>
+    /// Resolves a user-supplied value to a <see cref="DryWeatherFlowOverride"/>. Accepts either
+    /// the full display name ("Yes - DWF Effectively Eliminated") or the shorthand name
+    /// ("Yes" / "No"). Case-insensitive and trims whitespace — NPT-1073 KE round 2 ask, so
+    /// XLSX uploaders don't have to type the long display name verbatim.
+    /// </summary>
+    public static DryWeatherFlowOverride? GetByDisplayNameOrShorthand(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return null;
+        var trimmed = input.Trim();
+        return All.SingleOrDefault(x =>
+            string.Equals(x.DryWeatherFlowOverrideDisplayName, trimmed, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(x.DryWeatherFlowOverrideName, trimmed, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/Neptune.EFModels/Entities/SimplifiedBMPsExcelParserHelper.cs
+++ b/Neptune.EFModels/Entities/SimplifiedBMPsExcelParserHelper.cs
@@ -172,7 +172,7 @@ public static class SimplifiedBMPsExcelParserHelper
         var dryWeatherFlowOverrideName = row["Dry Weather Flow Override?"].ToString();
         if (!string.IsNullOrWhiteSpace(dryWeatherFlowOverrideName))
         {
-            var dryWeatherFlowOverride = DryWeatherFlowOverride.All.SingleOrDefault(x => x.DryWeatherFlowOverrideDisplayName == dryWeatherFlowOverrideName);
+            var dryWeatherFlowOverride = DryWeatherFlowOverride.GetByDisplayNameOrShorthand(dryWeatherFlowOverrideName);
             if (dryWeatherFlowOverride == null)
             {
                 // NPT-1073: was mis-labelled "BMP Type" (copy-paste from the BMP Type branch above).

--- a/Neptune.Tests/SimplifiedBMPsExcelParserHelperTests.cs
+++ b/Neptune.Tests/SimplifiedBMPsExcelParserHelperTests.cs
@@ -305,5 +305,84 @@ namespace Neptune.Tests
             Assert.AreEqual(1, result.Count);
             Assert.AreEqual(1, result[0].NumberOfIndividualBMPs);
         }
+
+        // ----- NPT-1073 round 2 -----
+
+        [TestMethod]
+        public void DryWeatherFlowOverride_AcceptsYesShorthand()
+        {
+            // NPT-1073 round 2: KE asked us to accept the shorthand "Yes"/"No" in the DWF Override
+            // column so uploaders don't have to type the full display name (e.g. "Yes - DWF
+            // Effectively Eliminated"). The shorthand maps to DryWeatherFlowOverrideName.
+            var existingWqmp = _dbContext.WaterQualityManagementPlans.AsNoTracking().FirstOrDefault();
+            if (existingWqmp == null)
+            {
+                Assert.Inconclusive("No existing WQMP in dev DB.");
+                return;
+            }
+            var dt = BuildDataTable(AllCols,
+                new[] { existingWqmp.WaterQualityManagementPlanName, "___NPT_1073_DWF_YES___", GetAnyBMPTypeName(), "1", "", "", "", "Yes", "" });
+            var result = SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, existingWqmp.StormwaterJurisdictionID, dt, out var errors);
+
+            Assert.AreEqual(0, errors.Count, string.Join("; ", errors));
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(DryWeatherFlowOverride.Yes.DryWeatherFlowOverrideID, result[0].DryWeatherFlowOverrideID);
+        }
+
+        [TestMethod]
+        public void DryWeatherFlowOverride_AcceptsNoShorthand()
+        {
+            var existingWqmp = _dbContext.WaterQualityManagementPlans.AsNoTracking().FirstOrDefault();
+            if (existingWqmp == null)
+            {
+                Assert.Inconclusive("No existing WQMP in dev DB.");
+                return;
+            }
+            var dt = BuildDataTable(AllCols,
+                new[] { existingWqmp.WaterQualityManagementPlanName, "___NPT_1073_DWF_NO___", GetAnyBMPTypeName(), "1", "", "", "", "No", "" });
+            var result = SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, existingWqmp.StormwaterJurisdictionID, dt, out var errors);
+
+            Assert.AreEqual(0, errors.Count, string.Join("; ", errors));
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(DryWeatherFlowOverride.No.DryWeatherFlowOverrideID, result[0].DryWeatherFlowOverrideID);
+        }
+
+        [TestMethod]
+        public void DryWeatherFlowOverride_AcceptsFullDisplayName()
+        {
+            // Backwards-compat guard: the original behaviour (full display name) still works.
+            var existingWqmp = _dbContext.WaterQualityManagementPlans.AsNoTracking().FirstOrDefault();
+            if (existingWqmp == null)
+            {
+                Assert.Inconclusive("No existing WQMP in dev DB.");
+                return;
+            }
+            var dt = BuildDataTable(AllCols,
+                new[] { existingWqmp.WaterQualityManagementPlanName, "___NPT_1073_DWF_FULL___", GetAnyBMPTypeName(), "1", "", "", "", DryWeatherFlowOverride.Yes.DryWeatherFlowOverrideDisplayName, "" });
+            var result = SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, existingWqmp.StormwaterJurisdictionID, dt, out var errors);
+
+            Assert.AreEqual(0, errors.Count, string.Join("; ", errors));
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(DryWeatherFlowOverride.Yes.DryWeatherFlowOverrideID, result[0].DryWeatherFlowOverrideID);
+        }
+
+        [TestMethod]
+        public void DryWeatherFlowOverride_CaseInsensitive()
+        {
+            // Lowercase "yes" / mixed case should still resolve — Excel users paste from anywhere.
+            var existingWqmp = _dbContext.WaterQualityManagementPlans.AsNoTracking().FirstOrDefault();
+            if (existingWqmp == null)
+            {
+                Assert.Inconclusive("No existing WQMP in dev DB.");
+                return;
+            }
+            var dt = BuildDataTable(AllCols,
+                new[] { existingWqmp.WaterQualityManagementPlanName, "___NPT_1073_DWF_LOWER___", GetAnyBMPTypeName(), "1", "", "", "", "yes", "" });
+            var result = SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX(_dbContext, existingWqmp.StormwaterJurisdictionID, dt, out var errors);
+
+            Assert.AreEqual(0, errors.Count, string.Join("; ", errors));
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(DryWeatherFlowOverride.Yes.DryWeatherFlowOverrideID, result[0].DryWeatherFlowOverrideID);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Rework round 2 on NPT-1073 — KE flagged a "nit" on Bug 4: the Simplified BMP XLSX uploader requires the full `DryWeatherFlowOverride` display name (`"Yes - DWF Effectively Eliminated"` / `"No - As Modeled"`); KE asked us to also accept the shorter `"Yes"` / `"No"` shorthand.
- New `DryWeatherFlowOverride.GetByDisplayNameOrShorthand(string?)` partial-class helper. Accepts either the full display name OR the shorthand `DryWeatherFlowOverrideName` value. Case-insensitive + trim whitespace, since Excel users paste from anywhere.
- `SimplifiedBMPsExcelParserHelper` swaps its inline `DryWeatherFlowOverride.All.SingleOrDefault(...)` lookup for the new helper. Error message and DTO shape unchanged.
- 4 new MSTest cases cover the shorthand acceptance (`Yes`, `No`), backwards-compat (full display name still works), and lowercase case-insensitivity. The existing Bug 4 regression guard (`InvalidDryWeatherFlowOverride_ErrorMentionsCorrectField`) is untouched.

## Test plan

- [ ] `dotnet build Neptune.sln` clean
- [ ] `dotnet test Neptune.Tests --filter "FullyQualifiedName~SimplifiedBMPsExcelParserHelperTests"` — all 18 tests pass (14 prior + 4 new)
- [ ] Manual: download the Simplified BMPs upload template, fill in `Yes` and `No` (try mixed case too) in the "Dry Weather Flow Override?" column, upload via SPA Data Hub → Upload Simplified BMPs. Confirm rows persist with the correct `DryWeatherFlowOverrideID` (1 for No, 2 for Yes).
- [ ] Negative: upload a row with `maybe` in the DWF column → confirm the error message is still `"Dry Weather Flow Override 'maybe' does not exist in row number: N"` (no regression on Bug 4 round 1 wording fix).
- [ ] KE flips Bug 4's red status → green on NPT-1073 once verified.

## Notes for reviewers

- Helper lives at `Neptune.EFModels/Entities/DryWeatherFlowOverride.StaticHelpers.cs` per the project convention for partial-class extensions (never edit `Generated/.../Binding.cs`).
- Single parser call site change covers both the SPA upload path (`Neptune.API/Controllers/WaterQualityManagementPlanController.cs:994`) and the legacy WebMvc path (`Neptune.WebMvc/Controllers/WaterQualityManagementPlanController.cs:1088`) — both call the same `SimplifiedBMPsExcelParserHelper.ParseWQMPRowsFromXLSX`.
- The `.xlsx` template lives in Azure Blob Storage, not the repo. No template change needed — the template can continue to advertise the full display name as canonical; users can now type either form.