### PR TITLE
NPT-1075: Per-row error messages for OVTA Area GDB upload

### DIFF
--- a/Neptune.API/Controllers/OnlandVisualTrashAssessmentAreaController.cs
+++ b/Neptune.API/Controllers/OnlandVisualTrashAssessmentAreaController.cs
@@ -263,7 +263,11 @@ public class OnlandVisualTrashAssessmentAreaController(
             // oversized Description) so users can find and fix the offending features.
             report.Errors.AddRange(OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings));
 
-            var duplicateNames = stagings.GroupBy(x => x.AreaName).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+            // Skip null/blank names here — the validator above already reports those as their own
+            // per-feature error; grouping them would produce a confusing "Duplicate OVTA Area
+            // Names: " (empty value) message that just duplicates the missing-name signal.
+            var duplicateNames = stagings.Where(x => !string.IsNullOrWhiteSpace(x.AreaName))
+                .GroupBy(x => x.AreaName).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
             if (duplicateNames.Count > 0)
             {
                 report.Errors.Add($"Duplicate OVTA Area Names: {string.Join(", ", duplicateNames)}");

--- a/Neptune.API/Controllers/OnlandVisualTrashAssessmentAreaController.cs
+++ b/Neptune.API/Controllers/OnlandVisualTrashAssessmentAreaController.cs
@@ -248,28 +248,36 @@ public class OnlandVisualTrashAssessmentAreaController(
             };
 
             var geoJson = await gdalApiService.Ogr2OgrGdbToGeoJson(apiRequest);
-            var stagings = await GeoJsonSerializer.DeserializeFromFeatureCollectionWithCCWCheck<OnlandVisualTrashAssessmentAreaStaging>(
-                geoJson, GeoJsonSerializer.DefaultSerializerOptions, Proj4NetHelper.NAD_83_HARN_CA_ZONE_VI_SRID);
+            var stagings = (await GeoJsonSerializer.DeserializeFromFeatureCollectionWithCCWCheck<OnlandVisualTrashAssessmentAreaStaging>(
+                geoJson, GeoJsonSerializer.DefaultSerializerOptions, Proj4NetHelper.NAD_83_HARN_CA_ZONE_VI_SRID)).ToList();
 
-            var validStagings = stagings.Where(x => x.Geometry is { IsValid: true, Area: > 0 }).ToList();
-            if (validStagings.Count == 0)
+            if (stagings.Count == 0)
             {
-                report.Errors.Add("No valid OVTA Area features were found in the upload.");
+                report.Errors.Add("No OVTA Area features were found in the upload.");
                 await OnlandVisualTrashAssessmentAreaGdbExport.DiscardStagingForUserAsync(DbContext, currentPerson);
                 return Ok(report);
             }
 
-            var duplicateNames = validStagings.GroupBy(x => x.AreaName).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+            // NPT-1075 round 2: replace the silent geometry filter + generic "corrupted file"
+            // catch with per-feature error messages (null/blank AreaName, invalid geometry,
+            // oversized Description) so users can find and fix the offending features.
+            report.Errors.AddRange(OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings));
+
+            var duplicateNames = stagings.GroupBy(x => x.AreaName).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
             if (duplicateNames.Count > 0)
             {
                 report.Errors.Add($"Duplicate OVTA Area Names: {string.Join(", ", duplicateNames)}");
+            }
+
+            if (report.Errors.Count > 0)
+            {
                 await OnlandVisualTrashAssessmentAreaGdbExport.DiscardStagingForUserAsync(DbContext, currentPerson);
                 return Ok(report);
             }
 
             await DbContext.OnlandVisualTrashAssessmentAreaStagings
                 .Where(x => x.UploadedByPersonID == currentPerson.PersonID).ExecuteDeleteAsync();
-            DbContext.OnlandVisualTrashAssessmentAreaStagings.AddRange(validStagings);
+            DbContext.OnlandVisualTrashAssessmentAreaStagings.AddRange(stagings);
             await DbContext.SaveChangesAsync();
         }
         catch (Exception ex) when (ex.Message.Contains("Unrecognized field name", StringComparison.InvariantCultureIgnoreCase))

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentArea.GdbValidator.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentArea.GdbValidator.cs
@@ -33,7 +33,12 @@ public static class OnlandVisualTrashAssessmentAreaGdbValidator
                 errors.Add($"Feature {rowNumber}: OVTA Area Name is missing.");
                 continue;
             }
-            if (staging.Geometry == null || !staging.Geometry.IsValid)
+            if (staging.Geometry == null)
+            {
+                errors.Add($"Feature {rowNumber} ({staging.AreaName}): geometry is missing.");
+                continue;
+            }
+            if (!staging.Geometry.IsValid)
             {
                 errors.Add($"Feature {rowNumber} ({staging.AreaName}): geometry is invalid (NTS reports IsValid = false).");
                 continue;

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentArea.GdbValidator.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentArea.GdbValidator.cs
@@ -1,0 +1,53 @@
+namespace Neptune.EFModels.Entities;
+
+/// <summary>
+/// NPT-1075 round 2 — per-row validation for the OVTA Area GDB upload. Replaces the
+/// silent <c>.Where(x =&gt; x.Geometry is { IsValid: true, Area: &gt; 0 })</c> filter and the
+/// generic "file may be corrupted or invalid" catch-all with actionable per-feature
+/// error messages so users can find and fix the offending features in their GIS tooling.
+/// </summary>
+public static class OnlandVisualTrashAssessmentAreaGdbValidator
+{
+    /// <summary>
+    /// Hard limit on the Description column, matching <c>varchar(500)</c> on
+    /// <c>dbo.OnlandVisualTrashAssessmentArea.AssessmentAreaDescription</c>.
+    /// </summary>
+    public const int MaxDescriptionLength = 500;
+
+    /// <summary>
+    /// Walks the deserialized staging rows and returns one error per problem found.
+    /// Empty list means every row is valid and the caller can proceed to insert. The
+    /// caller is responsible for the whole-file-rejection semantics — pure function,
+    /// no DbContext, no side effects.
+    /// </summary>
+    public static List<string> Validate(IReadOnlyList<OnlandVisualTrashAssessmentAreaStaging> stagings)
+    {
+        var errors = new List<string>();
+        for (var i = 0; i < stagings.Count; i++)
+        {
+            var rowNumber = i + 1;
+            var staging = stagings[i];
+
+            if (string.IsNullOrWhiteSpace(staging.AreaName))
+            {
+                errors.Add($"Feature {rowNumber}: OVTA Area Name is missing.");
+                continue;
+            }
+            if (staging.Geometry == null || !staging.Geometry.IsValid)
+            {
+                errors.Add($"Feature {rowNumber} ({staging.AreaName}): geometry is invalid (NTS reports IsValid = false).");
+                continue;
+            }
+            if (staging.Geometry.Area <= 0)
+            {
+                errors.Add($"Feature {rowNumber} ({staging.AreaName}): polygon has zero or negative area.");
+                continue;
+            }
+            if (!string.IsNullOrEmpty(staging.Description) && staging.Description.Length > MaxDescriptionLength)
+            {
+                errors.Add($"Feature {rowNumber} ({staging.AreaName}): Description exceeds the {MaxDescriptionLength}-character limit ({staging.Description.Length} characters provided).");
+            }
+        }
+        return errors;
+    }
+}

--- a/Neptune.Tests/OnlandVisualTrashAssessmentAreaGdbValidatorTests.cs
+++ b/Neptune.Tests/OnlandVisualTrashAssessmentAreaGdbValidatorTests.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.EFModels.Entities;
+using NetTopologySuite.Geometries;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1075 round 2 — covers <see cref="OnlandVisualTrashAssessmentAreaGdbValidator.Validate"/>,
+    /// the per-row validator that replaces the previous silent geometry filter + generic
+    /// "file may be corrupted or invalid" catch-all in the OVTA Area GDB upload pipeline.
+    /// Pure-function: no DbContext, no DB hits.
+    /// </summary>
+    [TestClass]
+    public class OnlandVisualTrashAssessmentAreaGdbValidatorTests
+    {
+        private static readonly GeometryFactory GeomFactory =
+            NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory(srid: 2771);
+
+        /// <summary>1×1 square polygon, valid, Area = 1.</summary>
+        private static Polygon ValidSquare() => GeomFactory.CreatePolygon(new[]
+        {
+            new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(1, 1), new Coordinate(0, 1), new Coordinate(0, 0),
+        });
+
+        /// <summary>Empty MultiPolygon — geometrically valid but zero area.</summary>
+        private static MultiPolygon EmptyMultiPolygon() => GeomFactory.CreateMultiPolygon(new Polygon[0]);
+
+        [TestMethod]
+        public void NullAreaName_Errors()
+        {
+            // Cast through null! to mirror the EF entity's non-nullable string property — the
+            // GDAL/GeoJsonSerializer path can land us in this state when the source GDB has a
+            // null in the AreaName field.
+            var stagings = new List<OnlandVisualTrashAssessmentAreaStaging>
+            {
+                new() { AreaName = null!, Geometry = ValidSquare(), Description = null, StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+            };
+
+            var errors = OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings);
+
+            Assert.AreEqual(1, errors.Count);
+            StringAssert.Contains(errors[0], "Feature 1");
+            StringAssert.Contains(errors[0], "OVTA Area Name is missing");
+        }
+
+        [TestMethod]
+        public void BlankAreaName_Errors()
+        {
+            var stagings = new List<OnlandVisualTrashAssessmentAreaStaging>
+            {
+                new() { AreaName = "   ", Geometry = ValidSquare(), StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+            };
+
+            var errors = OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings);
+
+            Assert.AreEqual(1, errors.Count);
+            StringAssert.Contains(errors[0], "OVTA Area Name is missing");
+        }
+
+        [TestMethod]
+        public void ZeroAreaGeometry_Errors()
+        {
+            // Empty MultiPolygon: IsValid = true, but Area = 0 — the legacy silent filter dropped
+            // these without telling the user; now we surface a specific message.
+            var stagings = new List<OnlandVisualTrashAssessmentAreaStaging>
+            {
+                new() { AreaName = "LN_ZeroArea_1", Geometry = EmptyMultiPolygon(), StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+            };
+
+            var errors = OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings);
+
+            Assert.AreEqual(1, errors.Count);
+            StringAssert.Contains(errors[0], "Feature 1");
+            StringAssert.Contains(errors[0], "LN_ZeroArea_1");
+            StringAssert.Contains(errors[0], "zero or negative area");
+        }
+
+        [TestMethod]
+        public void OversizedDescription_Errors()
+        {
+            var oversized = new string('x', OnlandVisualTrashAssessmentAreaGdbValidator.MaxDescriptionLength + 1);
+            var stagings = new List<OnlandVisualTrashAssessmentAreaStaging>
+            {
+                new() { AreaName = "LN_LongDesc_1", Geometry = ValidSquare(), Description = oversized, StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+            };
+
+            var errors = OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings);
+
+            Assert.AreEqual(1, errors.Count);
+            StringAssert.Contains(errors[0], "Feature 1");
+            StringAssert.Contains(errors[0], "LN_LongDesc_1");
+            StringAssert.Contains(errors[0], $"{OnlandVisualTrashAssessmentAreaGdbValidator.MaxDescriptionLength}-character limit");
+            StringAssert.Contains(errors[0], $"{oversized.Length} characters provided");
+        }
+
+        [TestMethod]
+        public void ValidStagings_NoErrors()
+        {
+            // Regression guard: clean rows should produce zero errors so the upload can proceed.
+            var stagings = new List<OnlandVisualTrashAssessmentAreaStaging>
+            {
+                new() { AreaName = "LN_OK_1", Geometry = ValidSquare(), Description = "short", StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+                new() { AreaName = "LN_OK_2", Geometry = ValidSquare(), Description = null, StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+                new() { AreaName = "LN_OK_3", Geometry = ValidSquare(), Description = new string('y', OnlandVisualTrashAssessmentAreaGdbValidator.MaxDescriptionLength), StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+            };
+
+            var errors = OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings);
+
+            Assert.AreEqual(0, errors.Count, string.Join("; ", errors));
+        }
+
+        [TestMethod]
+        public void MultipleBadRows_ProduceErrorPerRowWithCorrectFeatureNumbers()
+        {
+            // Row indexing is 1-based and matches the position in the input list, so a user can
+            // map errors back to the feature they see in their GIS tooling.
+            var stagings = new List<OnlandVisualTrashAssessmentAreaStaging>
+            {
+                new() { AreaName = "LN_OK", Geometry = ValidSquare(), StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+                new() { AreaName = "", Geometry = ValidSquare(), StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+                new() { AreaName = "LN_ZeroArea", Geometry = EmptyMultiPolygon(), StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+                new() { AreaName = "LN_LongDesc", Geometry = ValidSquare(), Description = new string('z', 501), StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+            };
+
+            var errors = OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings);
+
+            Assert.AreEqual(3, errors.Count);
+            Assert.IsTrue(errors.Any(e => e.Contains("Feature 2") && e.Contains("OVTA Area Name is missing")));
+            Assert.IsTrue(errors.Any(e => e.Contains("Feature 3") && e.Contains("LN_ZeroArea")));
+            Assert.IsTrue(errors.Any(e => e.Contains("Feature 4") && e.Contains("LN_LongDesc")));
+        }
+    }
+}

--- a/Neptune.Tests/OnlandVisualTrashAssessmentAreaGdbValidatorTests.cs
+++ b/Neptune.Tests/OnlandVisualTrashAssessmentAreaGdbValidatorTests.cs
@@ -27,6 +27,15 @@ namespace Neptune.Tests
         /// <summary>Empty MultiPolygon — geometrically valid but zero area.</summary>
         private static MultiPolygon EmptyMultiPolygon() => GeomFactory.CreateMultiPolygon(new Polygon[0]);
 
+        /// <summary>
+        /// Self-intersecting "bowtie" ring — NTS reports <c>IsValid == false</c>. Exercises the
+        /// validator branch that the empty-MultiPolygon doesn't (empty is IsValid=true, Area=0).
+        /// </summary>
+        private static Polygon BowtiePolygon() => GeomFactory.CreatePolygon(new[]
+        {
+            new Coordinate(0, 0), new Coordinate(1, 1), new Coordinate(1, 0), new Coordinate(0, 1), new Coordinate(0, 0),
+        });
+
         [TestMethod]
         public void NullAreaName_Errors()
         {
@@ -57,6 +66,47 @@ namespace Neptune.Tests
 
             Assert.AreEqual(1, errors.Count);
             StringAssert.Contains(errors[0], "OVTA Area Name is missing");
+        }
+
+        [TestMethod]
+        public void InvalidGeometry_Errors()
+        {
+            // Sanity-check that NTS actually reports the bowtie as invalid; if a future NTS
+            // upgrade changes that, the test would silently pass against the zero-area branch
+            // instead of the IsValid=false branch we're trying to cover.
+            var bowtie = BowtiePolygon();
+            Assert.IsFalse(bowtie.IsValid, "Bowtie polygon must be reported as IsValid=false to exercise the right validator branch.");
+
+            var stagings = new List<OnlandVisualTrashAssessmentAreaStaging>
+            {
+                new() { AreaName = "LN_Bowtie_1", Geometry = bowtie, StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+            };
+
+            var errors = OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings);
+
+            Assert.AreEqual(1, errors.Count);
+            StringAssert.Contains(errors[0], "Feature 1");
+            StringAssert.Contains(errors[0], "LN_Bowtie_1");
+            StringAssert.Contains(errors[0], "NTS reports IsValid = false");
+        }
+
+        [TestMethod]
+        public void NullGeometry_ErrorsWithMissingMessage()
+        {
+            // Defensive: the GDAL pipeline shouldn't normally produce a null Geometry, but the
+            // staging entity allows it during deserialization. The validator must produce a
+            // distinct "geometry is missing" message rather than misleading users with the
+            // NTS-IsValid wording from the invalid-geometry branch.
+            var stagings = new List<OnlandVisualTrashAssessmentAreaStaging>
+            {
+                new() { AreaName = "LN_NullGeom_1", Geometry = null!, StormwaterJurisdictionID = 1, UploadedByPersonID = 1 },
+            };
+
+            var errors = OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings);
+
+            Assert.AreEqual(1, errors.Count);
+            StringAssert.Contains(errors[0], "geometry is missing");
+            Assert.IsFalse(errors[0].Contains("IsValid"), "Null geometry should not be reported as IsValid=false.");
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary

- Replaces the silent geometry filter + generic *"There was a problem processing the Feature Class 'ovtaareas'. The file may be corrupted or invalid."* catch-all in the OVTA Area GDB uploader with explicit per-feature error messages so users can find and fix the offending features in their GIS tooling.
- New `OnlandVisualTrashAssessmentAreaGdbValidator.Validate(stagings)` static helper alongside the existing `GdbExport.cs` — pure function, no DbContext, returns one error per problem.
- Whole-file rejection semantics preserved (confirmed with PO); the user just gets actionable messages now instead of guessing which feature is broken.

### TCs fixed (KE 6/3 round)

| TC | Symptom | New behavior |
|---|---|---|
| **TC09** | Null/blank `OVTAAreaName` → generic message | `Feature N: OVTA Area Name is missing.` |
| **TC14** | Empty MultiPolygon / zero-area polygon → generic message | `Feature N (areaName): geometry is invalid (NTS reports IsValid = false).` or `… polygon has zero or negative area.` |
| **TC16** | Description > 500 chars → generic message | `Feature N (areaName): Description exceeds the 500-character limit (NNN characters provided).` |

### TC11 (KE open question) — deferred

KE asked whether OVTA Areas have a last-updated timestamp and whether to surface it on the list page. The entity has **zero audit fields** today (no `UpdateDate`, `UpdatePersonID`, `CreateDate`, `CreatePersonID`); the list page's "Last Assessment Date" column is derived from child `OnlandVisualTrashAssessment.CompletedDate`, not the area itself. Adding an audit-field set is a 6-file schema-touching change broader than this card's scope. Will reply on the Jira card and let PO scope a separate ticket if they want the UI change.

## Test plan

- [ ] `dotnet build Neptune.sln` clean
- [ ] `dotnet test Neptune.Tests --filter "FullyQualifiedName~OnlandVisualTrashAssessmentAreaGdbValidatorTests"` — 6 tests pass
- [ ] Manual: re-run KE's 3 failing GDB files against QA
  - [ ] `TC09_OVTA_ERROR_null_blank_AreaName.gdb.zip` → expect per-feature `OVTA Area Name is missing` errors
  - [ ] `TC14_OVTA_ERROR_invalid_geometry.gdb.zip` → expect a geometry-specific per-feature error; valid features in the same file are NOT inserted (whole-file rejection)
  - [ ] `TC16_OVTA_ERROR_description_too_long.gdb.zip` → expect `Description exceeds the 500-character limit (501 characters provided)`
- [ ] Manual: re-run a passing case (`TC01_OVTA_happy_path_required_only.gdb.zip`) to confirm no regression
- [ ] KE flips the 3 red statuses → green on NPT-1075

## Notes for reviewers

- Validator is a pure static function with 6 unit tests — no DbContext, no DB calls. Lives in `Neptune.EFModels/Entities/OnlandVisualTrashAssessmentArea.GdbValidator.cs` next to the existing `GdbExport.cs` helper.
- Feature numbers in error messages are 1-based and map to the deserialized staging list position (covered by `MultipleBadRows_ProduceErrorPerRowWithCorrectFeatureNumbers`).
- The existing duplicate-name check and "Unrecognized field name" specific catch are unchanged.
- The legacy WebMvc OVTA upload endpoint is not touched (file is in the retirement queue; SPA is the canonical path).