### PR TITLE
NPT-1076: Fix inflated row count in OVTA XLSX bulk upload success banner

### DIFF
--- a/Neptune.EFModels/Entities/OvtaBulkUploadImporter.cs
+++ b/Neptune.EFModels/Entities/OvtaBulkUploadImporter.cs
@@ -186,8 +186,8 @@ public static class OvtaBulkUploadImporter
 
         // NPT-1076 round 2: must report the count of actually-imported rows, not the raw
         // DataTable.Rows.Count. Excel's "used range" can include trailing formatted-but-blank
-        // rows that get correctly skipped above (line 68) but inflated `numRows` to 172 in
-        // KE's 3-record test file, producing a misleading success banner.
+        // rows that the per-row `rowEmpty` guard above correctly skips, but `numRows` still
+        // counts them — KE's 3-record test file reported 172 row(s) because of this.
         result.RowsProcessed = processedRowCount;
         return result;
     }

--- a/Neptune.EFModels/Entities/OvtaBulkUploadImporter.cs
+++ b/Neptune.EFModels/Entities/OvtaBulkUploadImporter.cs
@@ -184,7 +184,11 @@ public static class OvtaBulkUploadImporter
         }
         await dbContext.SaveChangesAsync();
 
-        result.RowsProcessed = numRows;
+        // NPT-1076 round 2: must report the count of actually-imported rows, not the raw
+        // DataTable.Rows.Count. Excel's "used range" can include trailing formatted-but-blank
+        // rows that get correctly skipped above (line 68) but inflated `numRows` to 172 in
+        // KE's 3-record test file, producing a misleading success banner.
+        result.RowsProcessed = processedRowCount;
         return result;
     }
 

--- a/Neptune.Tests/OvtaBulkUploadImporterTests.cs
+++ b/Neptune.Tests/OvtaBulkUploadImporterTests.cs
@@ -388,6 +388,61 @@ namespace Neptune.Tests
         }
 
         [TestMethod]
+        public async Task RowsProcessed_ExcludesBlankRowsWithinUsedRange()
+        {
+            // KE round 2 (TC02): uploaded file with 3 records reported "172 row(s)" because the
+            // worksheet's used range stretched far past the actual data. The importer was using
+            // `numRows = dataTable.Rows.Count` (raw count) for the success banner instead of
+            // `processedRowCount` (rows that actually produced a persisted assessment). This
+            // test reproduces the inflated-used-range scenario by touching cells past the last
+            // data row, then asserts the result reports the data-row count, not the raw count.
+            var area = _dbContext.OnlandVisualTrashAssessmentAreas.AsNoTracking().FirstOrDefault();
+            if (area == null)
+            {
+                Assert.Inconclusive("No OVTA areas in dev DB.");
+                return;
+            }
+            var creator = GetAdminPerson();
+            var jurisdiction = _dbContext.StormwaterJurisdictions.Include(x => x.Organization).AsNoTracking()
+                .Single(x => x.StormwaterJurisdictionID == area.StormwaterJurisdictionID);
+            var validScore = OnlandVisualTrashAssessmentScore.All.First().OnlandVisualTrashAssessmentScoreDisplayName;
+
+            // Build the workbook by hand so we can touch blank cells past the data row,
+            // simulating the inflated "used range" Excel produces in real-world templates.
+            var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("OVTA Assessments");
+            for (var c = 0; c < BaseColumns.Length; c++)
+            {
+                ws.Cell(1, c + 1).Value = BaseColumns[c];
+            }
+            var dataRow = new[]
+            {
+                area.OnlandVisualTrashAssessmentAreaName, jurisdiction.Organization.OrganizationName, creator.Email,
+                "Finalized", "06/15/2024", validScore, "No",
+                "", "", "", "",
+            };
+            for (var c = 0; c < dataRow.Length; c++)
+            {
+                ws.Cell(2, c + 1).Value = dataRow[c];
+            }
+            // Touch a cell 10 rows past the data so ClosedXML's used range extends and produces
+            // ~10 blank-but-tracked rows in the resulting DataTable. The importer's per-row
+            // empty-row check skips them; the count returned must skip them too.
+            ws.Cell(12, 1).Value = "";
+            ws.Cell(12, 1).Style.Fill.BackgroundColor = XLColor.LightGray;
+
+            using var xlsx = new MemoryStream();
+            wb.SaveAs(xlsx);
+            xlsx.Position = 0;
+
+            var result = await OvtaBulkUploadImporter.BulkUploadAsync(_dbContext, xlsx, creator);
+
+            Assert.AreEqual(0, result.Errors.Count, string.Join("; ", result.Errors));
+            Assert.AreEqual(1, result.RowsProcessed,
+                "Success banner must reflect data rows actually imported, not the inflated worksheet used range.");
+        }
+
+        [TestMethod]
         public async Task PSIWhitespaceAndCasing_Accepted()
         {
             // Bug #1: mixed-case + leading/trailing whitespace around comma-separated PSI values

--- a/Neptune.Tests/OvtaBulkUploadImporterTests.cs
+++ b/Neptune.Tests/OvtaBulkUploadImporterTests.cs
@@ -409,7 +409,7 @@ namespace Neptune.Tests
 
             // Build the workbook by hand so we can touch blank cells past the data row,
             // simulating the inflated "used range" Excel produces in real-world templates.
-            var wb = new XLWorkbook();
+            using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet("OVTA Assessments");
             for (var c = 0; c < BaseColumns.Length; c++)
             {


### PR DESCRIPTION
## Summary

- KE round 2: uploaded a 3-record file (`TC02_OVTA_all_fields_populated.xlsx`) and got *"Successfully bulk uploaded OVTAs from 172 row(s)."*
- One-line fix in `OvtaBulkUploadImporter.cs:187` — return `processedRowCount` (the variable the loop already maintains, incremented only on rows that produce a persisted assessment) instead of `numRows` (`dataTable.Rows.Count`, which includes blank rows from Excel's inflated used range that the per-row empty-check already skips).
- New regression test that builds a workbook with 1 data row + a deliberately-touched blank cell 10 rows past the data, simulating the inflated-used-range scenario. Asserts `RowsProcessed == 1`.

## Test plan

- [ ] `dotnet build Neptune.sln` clean
- [ ] `dotnet test Neptune.Tests --filter "FullyQualifiedName~OvtaBulkUploadImporterTests"` — all 14 tests pass (13 prior + 1 new)
- [ ] Manual: re-upload `TC02_OVTA_all_fields_populated.xlsx` via SPA Data Hub → Upload OVTAs. Banner should now read *"Successfully bulk uploaded OVTAs from 3 row(s)."*
- [ ] KE flips red → green on NPT-1076.

## Notes for reviewers

- The existing happy-path test (`ValidRow_PersistsAssessmentAndRecalculatesAreaScores`) couldn't have caught this — it builds a tight 1-row workbook where `numRows == processedRowCount == 1`. The new test deliberately touches a cell past the data row to inflate ClosedXML's used range.
- The sibling `TrashScreenFieldVisitImporter` already does this correctly (`result.RowsProcessed++` inside its loop). OVTA's importer was the outlier.