### PR TITLE
NPT-1078: Fix externalapi pod restart loop (map / + bump readiness timeout)

### DIFF
--- a/Neptune.ExternalAPI/Controllers/SystemInfoController.cs
+++ b/Neptune.ExternalAPI/Controllers/SystemInfoController.cs
@@ -5,23 +5,22 @@ using Neptune.ExternalAPI.Logging;
 namespace Neptune.ExternalAPI.Controllers;
 
 /// <summary>
-/// Anonymous service-info endpoints — health and version checks.
+/// Anonymous service-info endpoints — health and version checks. Also serves as the target
+/// for the kubelet startup/liveness probes via the root `/` route, mirroring Neptune.API's
+/// SystemInfoController. Hidden from Scalar so external consumers don't see noise.
 /// </summary>
 [AllowAnonymous]
 [ApiController]
 [ApiExplorerSettings(IgnoreApi = true)]
-[Route("system")]
 public class SystemInfoController : ControllerBase
 {
     /// <summary>
-    /// Service identity ping.
+    /// Service identity ping. Mapped at both <c>/</c> (kubelet startup/liveness probe target)
+    /// and <c>/system/info</c> (explicit name for humans hitting the API directly).
     /// </summary>
-    [HttpGet("info")]
+    [HttpGet("/")]
+    [HttpGet("system/info")]
     [LogIgnore]
-    [EndpointSummary("Service information")]
-    [EndpointDescription("Returns the service name and environment for sanity checks.")]
-    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
-    [Produces("application/json")]
     public IActionResult Info()
     {
         return Ok(new

--- a/charts/neptune/charts/neptune-externalapi/templates/deployment.yaml
+++ b/charts/neptune/charts/neptune-externalapi/templates/deployment.yaml
@@ -65,19 +65,11 @@ spec:
             periodSeconds: 4
             timeoutSeconds: 5
             failureThreshold: 3
-          # NPT-1078: explicit timeoutSeconds. The default is 1s, which is too short for the
-          # `AddDbContextCheck<NeptuneDbContext>` call — the first /healthz on a cold pod has
-          # to complete a TDS+TLS handshake against Azure SQL before the connection pool is
-          # warm, which can take 2+ seconds. Without this bump the probe cancels mid-handshake,
-          # the pool never establishes, and the pod is permanently NotReady.
           readinessProbe:
             httpGet:
               path: /healthz
               scheme: HTTP
               port: 8080
-            timeoutSeconds: 5
-            periodSeconds: 10
-            failureThreshold: 3
           lifecycle:
             preStop:
               exec:

--- a/charts/neptune/charts/neptune-externalapi/templates/deployment.yaml
+++ b/charts/neptune/charts/neptune-externalapi/templates/deployment.yaml
@@ -65,11 +65,19 @@ spec:
             periodSeconds: 4
             timeoutSeconds: 5
             failureThreshold: 3
+          # NPT-1078: explicit timeoutSeconds. The default is 1s, which is too short for the
+          # `AddDbContextCheck<NeptuneDbContext>` call — the first /healthz on a cold pod has
+          # to complete a TDS+TLS handshake against Azure SQL before the connection pool is
+          # warm, which can take 2+ seconds. Without this bump the probe cancels mid-handshake,
+          # the pool never establishes, and the pod is permanently NotReady.
           readinessProbe:
             httpGet:
               path: /healthz
               scheme: HTTP
               port: 8080
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
## Summary

QA deployment of the new `neptune-externalapi` pod has been crash-looping (9 restarts before this fix). `kubectl describe pod` showed the smoking gun:

```
Warning  Unhealthy  Startup probe failed: HTTP probe failed with statuscode: 404
Normal   Killing    Container externalapi failed startup probe, will be restarted
```

### Root cause

The helm deployment template was cloned from `neptune-api`, which has a kubelet startup probe at `GET /` expecting 2xx/3xx. Neptune.API's `SystemInfoController` is mapped to `[Route("/")]` so it returns 200. My ExternalAPI's `SystemInfoController` was only at `/system/info`, so `/` returned 404 → kubelet treated the probe as failed → after 30 failures (5 min) restarted the pod. Repeat 9×.

### Fix

`SystemInfoController`: drop the class-level `[Route("system")]` and put absolute routes on the action, so `Info()` serves both `/` (kubelet probe target, mirroring Neptune.API's pattern) and `/system/info` (the explicit human name). Still hidden from Scalar via `[ApiExplorerSettings(IgnoreApi = true)]`.

The helm deployment template is now byte-identical to `neptune-api/templates/deployment.yaml` (modulo naming).

### Diagnostic side-note (for the record)

Ran a raw `cat </dev/tcp/$DB_HOST/1433` from inside both `neptune-externalapi` and `neptune-api` pods to test SQL network reachability — both got "Connection reset by peer". That's actually **expected behavior** for Azure SQL: the server requires immediate TDS/TLS protocol negotiation and RSTs any TCP socket that doesn't speak the protocol within milliseconds. The raw `/dev/tcp` test is therefore unreliable for Azure SQL connectivity checks. Both pods could reach the SQL server at the network layer; the actual restart loop was driven entirely by the missing `/` route.

## Test plan

- [ ] Merge → QA deploy → confirm the new pod goes `Ready` within ~30 seconds and stays Ready
- [ ] `kubectl get pods -n h2o -l app.kubernetes.io/name=externalapi` shows `1/1` Ready, restart count stops climbing
- [ ] `GET https://qa-api.ocstormwatertools.org/healthz` returns 200 (once the variable-group typo is fixed too — see thread on PR #553)
- [ ] `GET https://qa-api.ocstormwatertools.org/docs` renders Scalar UI

## Notes for reviewers

- `[ApiExplorerSettings(IgnoreApi = true)]` is preserved so Scalar still doesn't show the system info endpoints in the public docs.
- `[LogIgnore]` keeps probe spam out of Serilog (otherwise we'd log a request every 10 seconds for the rest of the pod's life).
- Mirrors Neptune.API's `path: /` probe convention rather than retargeting probes elsewhere — keeps the templates aligned.