### PR TITLE
NPT-1078: Update Auth0 redirectUri for SPA host swap (QA + prod cutover)

### DIFF
--- a/Neptune.Web/src/environments/environment.prod.ts
+++ b/Neptune.Web/src/environments/environment.prod.ts
@@ -9,7 +9,7 @@ export const environment = {
     auth0: {
         domain: "ocstormwatertools.us.auth0.com",
         clientId: "ifBEaIsDKHXBQoIyDVl1CB21avZh1xEx",
-        redirectUri: "https://web.ocstormwatertools.org/callback",
+        redirectUri: "https://www.ocstormwatertools.org/callback",
         audience: "OCSTApi",
     },
 };

--- a/Neptune.Web/src/environments/environment.qa.ts
+++ b/Neptune.Web/src/environments/environment.qa.ts
@@ -9,7 +9,7 @@ export const environment = {
     auth0: {
         domain: "ocstormwatertools.us.auth0.com",
         clientId: "ifBEaIsDKHXBQoIyDVl1CB21avZh1xEx",
-        redirectUri: "https://qa-web.ocstormwatertools.org/callback",
+        redirectUri: "https://qa.ocstormwatertools.org/callback",
         audience: "OCSTApi",
     },
 };


### PR DESCRIPTION
## Summary

After NPT-1078, the SPA host moved:
- **QA**: `qa-web.ocstormwatertools.org` → `qa.ocstormwatertools.org` (qa-web.* now serves the legacy MVC during the retirement window)
- **Prod (upcoming cutover)**: `web.ocstormwatertools.org` → `www.ocstormwatertools.org` (no parallel MVC in prod — full retirement at cutover)

The Auth0 `redirectUri` in both environment files was pointing at the old SPA host, which would cause Auth0 to redirect users to the now-MVC URL (QA) or a 404 (prod) after login.

## Test plan

- [ ] Merge → QA deploy
- [ ] Add `https://qa.ocstormwatertools.org/callback` to the Auth0 tenant's Allowed Callback URLs, Allowed Logout URLs, and Allowed Web Origins (and `https://www.ocstormwatertools.org/callback` ahead of prod cutover)
- [ ] Hit `https://qa.ocstormwatertools.org` in a browser, click Login → expect Auth0 redirect → callback to `qa.ocstormwatertools.org/callback` → SPA logged in

## Notes for reviewers

- The Auth0 tenant configuration is not in the repo — those allowlist edits have to happen in the Auth0 dashboard before this works end-to-end.
- Dev (`environment.ts`) is unchanged — local SSL cert is still tied to `neptune.localhost.sitkatech.com`.