### PR TITLE
NPT-1078: PowerBI follow-ups on ExternalAPI

### DIFF
--- a/Neptune.Database/Scripts/ReleaseScripts/035 - NPT-1078 Rename WebServices query param from x-api-key to token.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/035 - NPT-1078 Rename WebServices query param from x-api-key to token.sql
@@ -1,0 +1,24 @@
+DECLARE @MigrationName VARCHAR(200);
+SET @MigrationName = '035 - NPT-1078 Rename WebServices query param from x-api-key to token'
+IF NOT EXISTS(SELECT * FROM dbo.DatabaseMigration DM WHERE DM.ReleaseScriptFileName = @MigrationName)
+BEGIN
+
+    PRINT @MigrationName;
+
+    -- NPT-1078: per consumer feedback, the query string parameter name was renamed from
+    -- ?x-api-key= to ?token= so the public URL surface doesn't expose the internal header
+    -- naming convention. Update the Web Services tab help text accordingly. Only updates
+    -- the row if it still matches the prior 034-seeded copy verbatim — admin edits via
+    -- the in-page editor are preserved untouched.
+    DECLARE @OldContent NVARCHAR(MAX) = N'<p>Neptune exposes a set of read-only Web Services for external data consumers (most commonly PowerBI dashboards). The endpoints publish Treatment Facility, Water Quality Management Plan, Land Use, and Model Results data for downstream reporting.</p><p><strong>API Documentation.</strong> The full endpoint catalog, request/response schemas, and a built-in &quot;try it out&quot; client are available at the API documentation page linked below. The documentation is the canonical reference &mdash; per-endpoint URLs are not duplicated here.</p><p><strong>Access Tokens.</strong> Each user has a personal access token below. Send it in the <code>x-api-key</code> HTTP header on every request. Keep your token private; if it leaks, regenerate it from this page to invalidate the old one.</p><p><strong>PowerBI users.</strong> PowerBI&rsquo;s data source dialog doesn&rsquo;t make custom HTTP headers easy. As a convenience, the token may also be passed as a query string parameter &mdash; append <code>?x-api-key=YOUR-TOKEN</code> to the endpoint URL. Prefer the header path whenever your client supports it; URLs with embedded tokens are logged in server access logs and browser history.</p><p>NOTE: The legacy <code>/PowerBI/&hellip;</code> URLs hosted by the previous MVC application have been retired. All consumers must use the new API documented below.</p>';
+
+    DECLARE @NewContent NVARCHAR(MAX) = N'<p>Neptune exposes a set of read-only Web Services for external data consumers (most commonly PowerBI dashboards). The endpoints publish Treatment Facility, Water Quality Management Plan, Land Use, and Model Results data for downstream reporting.</p><p><strong>API Documentation.</strong> The full endpoint catalog, request/response schemas, and a built-in &quot;try it out&quot; client are available at the API documentation page linked below. The documentation is the canonical reference &mdash; per-endpoint URLs are not duplicated here.</p><p><strong>Access Tokens.</strong> Each user has a personal access token below. Send it in the <code>x-api-key</code> HTTP header on every request. Keep your token private; if it leaks, regenerate it from this page to invalidate the old one.</p><p><strong>PowerBI users.</strong> PowerBI&rsquo;s data source dialog doesn&rsquo;t make custom HTTP headers easy. As a convenience, the token may also be passed as a query string parameter &mdash; append <code>?token=YOUR-TOKEN</code> to the endpoint URL. Prefer the header path whenever your client supports it; URLs with embedded tokens are logged in server access logs and browser history.</p><p>NOTE: The legacy <code>/PowerBI/&hellip;</code> URLs hosted by the previous MVC application have been retired. All consumers must use the new API documented below.</p>';
+
+    UPDATE dbo.NeptunePage
+    SET NeptunePageContent = @NewContent
+    WHERE NeptunePageTypeID = 99
+      AND NeptunePageContent = @OldContent
+
+    INSERT INTO dbo.DatabaseMigration(MigrationAuthorName, ReleaseScriptFileName, MigrationReason)
+    SELECT 'Ray Lee', @MigrationName, 'NPT-1078: rename query string param from ?x-api-key= to ?token= per consumer feedback (cleaner public surface)'
+END

--- a/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -76,4 +76,6 @@ GO
 GO
 :r ".\034 - NPT-1078 Update WebServices rich text for PowerBI URL token option.sql"
 GO
+:r ".\035 - NPT-1078 Rename WebServices query param from x-api-key to token.sql"
+GO
 

--- a/Neptune.ExternalAPI/Controllers/BlobFileDownloadHelper.cs
+++ b/Neptune.ExternalAPI/Controllers/BlobFileDownloadHelper.cs
@@ -1,10 +1,26 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
 using Neptune.Common.Services;
 
 namespace Neptune.ExternalAPI.Controllers;
 
 internal static class BlobFileDownloadHelper
 {
+    // All callers serve JSON blobs (LandUseStatistics.json, ModelResults.json,
+    // BaselineModelResults.json). The blobs were originally uploaded with
+    // Content-Type application/octet-stream by the Hangfire jobs, which PowerBI's
+    // data source dialog refuses to auto-detect as JSON. Force application/json on
+    // the response so consumers don't have to hand-configure parsers.
+    //
+    // Content-Disposition stays "attachment" — programmatic consumers (PowerBI, curl,
+    // fetch) ignore the header and just read the body, while browsers honor it and
+    // download the file instead of trying to render it inline. ModelResults.json is
+    // ~185MB, which is enough to OOM Chrome's JSON viewer if rendered in a tab.
+    //
+    // Uses the streaming download variant + FileStreamResult so ASP.NET pipes the blob
+    // straight to the response without buffering ~185MB in pod memory per request.
+    // ContentLength is set explicitly from the blob details so the response still has
+    // a definitive Content-Length header (lets clients show progress).
     public static async Task<IActionResult> DownloadIfExistsAsync(AzureBlobStorageService blobStorageService, string fileName, HttpResponse response)
     {
         if (!await blobStorageService.ExistsFromBlobStorage(fileName))
@@ -12,14 +28,15 @@ internal static class BlobFileDownloadHelper
             return new NotFoundResult();
         }
 
-        var contentDisposition = new System.Net.Mime.ContentDisposition
-        {
-            FileName = fileName,
-            Inline = false
-        };
-        response.Headers.Append("Content-Disposition", contentDisposition.ToString());
+        var contentDisposition = new ContentDispositionHeaderValue("attachment");
+        contentDisposition.SetHttpFileName(fileName);
+        response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
 
-        var blobDownloadResult = await blobStorageService.DownloadBlobFromBlobStorage(fileName);
-        return new FileContentResult(blobDownloadResult.Content.ToArray(), blobDownloadResult.Details.ContentType);
+        var blobStream = await blobStorageService.DownloadBlobFromBlobStorageAsStream(fileName);
+        return new FileStreamResult(blobStream.Content, "application/json")
+        {
+            FileDownloadName = fileName,
+            LastModified = blobStream.Details.LastModified,
+        };
     }
 }

--- a/Neptune.ExternalAPI/Controllers/BlobFileDownloadHelper.cs
+++ b/Neptune.ExternalAPI/Controllers/BlobFileDownloadHelper.cs
@@ -19,8 +19,9 @@ internal static class BlobFileDownloadHelper
     //
     // Uses the streaming download variant + FileStreamResult so ASP.NET pipes the blob
     // straight to the response without buffering ~185MB in pod memory per request.
-    // ContentLength is set explicitly from the blob details so the response still has
-    // a definitive Content-Length header (lets clients show progress).
+    // Content-Length is set explicitly from the blob metadata — the Azure SDK response
+    // stream isn't reliably seekable, so FileStreamResult on its own may emit a
+    // chunked response without Content-Length, which breaks PowerBI's progress UI.
     public static async Task<IActionResult> DownloadIfExistsAsync(AzureBlobStorageService blobStorageService, string fileName, HttpResponse response)
     {
         if (!await blobStorageService.ExistsFromBlobStorage(fileName))
@@ -33,6 +34,7 @@ internal static class BlobFileDownloadHelper
         response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
 
         var blobStream = await blobStorageService.DownloadBlobFromBlobStorageAsStream(fileName);
+        response.ContentLength = blobStream.Details.ContentLength;
         return new FileStreamResult(blobStream.Content, "application/json")
         {
             FileDownloadName = fileName,

--- a/Neptune.ExternalAPI/Filters/WebServiceTokenAuthenticationHandler.cs
+++ b/Neptune.ExternalAPI/Filters/WebServiceTokenAuthenticationHandler.cs
@@ -16,20 +16,24 @@ public class WebServiceTokenAuthenticationHandler(
     public const string ApiKeyName = "x-api-key";
     public const string SchemeName = "ApiKeyScheme";
 
+    // Query string parameter name is deliberately different from the header name so the
+    // public URL surface ("?token=…") doesn't expose the internal header convention.
+    // PowerBI consumers paste a self-contained URL the same way the legacy MVC
+    // PowerBIController accepted the token as a route segment.
+    private const string TokenQueryParamName = "token";
+
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        // Header is the documented primary path. Query string is an undocumented PowerBI
-        // escape hatch — PowerBI's data source UI doesn't make custom headers easy, so
-        // users paste the token into a fully self-contained URL the same way the legacy
-        // MVC PowerBIController accepted it as a route segment. Tokens in URLs get logged
-        // in access logs / browser history / error reports; consumers should prefer the
-        // header path whenever they control the request headers.
+        // Header is the documented primary path. Query string is the PowerBI escape hatch
+        // — PowerBI's data source UI doesn't make custom HTTP headers easy. Tokens in URLs
+        // get logged in access logs / browser history / error reports; consumers should
+        // prefer the header path whenever they control the request headers.
         string? rawApiKey = null;
         if (Request.Headers.TryGetValue(ApiKeyName, out var headerValue))
         {
             rawApiKey = headerValue.ToString();
         }
-        else if (Request.Query.TryGetValue(ApiKeyName, out var queryValue))
+        else if (Request.Query.TryGetValue(TokenQueryParamName, out var queryValue))
         {
             rawApiKey = queryValue.ToString();
         }

--- a/Neptune.ExternalAPI/Logging/LogHelper.cs
+++ b/Neptune.ExternalAPI/Logging/LogHelper.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Serilog;
 using Serilog.Context;
 using Serilog.Events;
@@ -6,6 +7,22 @@ namespace Neptune.ExternalAPI.Logging;
 
 public class LogHelper(RequestDelegate next)
 {
+    // NPT-1078: Redact secret-shaped query params before they hit the log sink. The auth
+    // token is accepted via ?token= as a PowerBI escape hatch, and request logging that
+    // captures the raw QueryString would otherwise persist tokens to logs (and anything
+    // downstream — App Insights, log archives, etc.) for every authenticated request.
+    // Compile once and use a case-insensitive match so e.g. ?Token= and ?TOKEN= are also
+    // caught. The list mirrors common secret param names; expand if new ones are introduced.
+    private static readonly Regex SecretQueryParamPattern = new Regex(
+        @"(?<=\b(?:token|api[-_]?key|password|secret)=)[^&]*",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static string RedactSecrets(string queryString)
+    {
+        return SecretQueryParamPattern.Replace(queryString, "***");
+    }
+
+
     public async Task InvokeAsync(HttpContext httpContext)
     {
         EnrichLogContext(httpContext);
@@ -48,7 +65,7 @@ public class LogHelper(RequestDelegate next)
 
         if (request.QueryString.HasValue)
         {
-            LogContext.PushProperty("QueryString", request.QueryString.Value);
+            LogContext.PushProperty("QueryString", RedactSecrets(request.QueryString.Value));
         }
 
         LogContext.PushProperty("ContentType", httpContext.Response.ContentType);

--- a/Neptune.ExternalAPI/Program.cs
+++ b/Neptune.ExternalAPI/Program.cs
@@ -108,8 +108,20 @@ builder.Services.AddAuthentication(options =>
 // which (a) makes UseHttpsRedirection issue a needless 301 (PowerBI / curl users without
 // -L get stuck on it) and (b) makes the OpenAPI auto-detected server URL render as
 // "http://qa-api..." in Scalar, so the "try it out" client originates an http request
-// that has to follow the same 301. Clearing KnownNetworks/KnownProxies is required because
-// the ingress pod's IP varies and isn't on the default loopback trust list.
+// that has to follow the same 301.
+//
+// Clearing KnownNetworks/KnownProxies makes the middleware trust X-Forwarded-* from
+// any source IP. This is the standard ASP.NET-on-Kubernetes pattern (also what the
+// ASPNETCORE_FORWARDEDHEADERS_ENABLED env var does under the hood) and is defensible
+// here because:
+//   - The pod is only reachable through the AKS ingress; it isn't exposed directly to
+//     the internet, so external clients can't spoof these headers.
+//   - The pod CIDR varies per cluster, so hardcoding a known-network entry is brittle
+//     and would have to be re-tracked on every cluster recreation.
+//   - The only practical spoof vector is from another pod inside the cluster, which
+//     would already imply an existing compromise.
+// If the pod is ever exposed directly (bypassing the ingress) this trust list must be
+// tightened — e.g. via configuration-driven KnownNetworks for the ingress controller.
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;

--- a/Neptune.ExternalAPI/Program.cs
+++ b/Neptune.ExternalAPI/Program.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi;
@@ -102,6 +103,20 @@ builder.Services.AddAuthentication(options =>
 })
 .AddScheme<AuthenticationSchemeOptions, WebServiceTokenAuthenticationHandler>(WebServiceTokenAuthenticationHandler.SchemeName, _ => { });
 
+// AKS ingress terminates TLS and forwards the request to the pod over HTTP, setting
+// X-Forwarded-Proto: https. Without this, Request.Scheme stays "http" inside the pod,
+// which (a) makes UseHttpsRedirection issue a needless 301 (PowerBI / curl users without
+// -L get stuck on it) and (b) makes the OpenAPI auto-detected server URL render as
+// "http://qa-api..." in Scalar, so the "try it out" client originates an http request
+// that has to follow the same 301. Clearing KnownNetworks/KnownProxies is required because
+// the ingress pod's IP varies and isn't on the default loopback trust list.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
 builder.Services.AddHealthChecks().AddDbContextCheck<NeptuneDbContext>();
 builder.Services.AddProblemDetails();
 
@@ -122,6 +137,8 @@ else
     app.UseExceptionHandler();
 }
 
+// Must run before UseHttpsRedirection so the redirector sees the original scheme.
+app.UseForwardedHeaders();
 app.UseHttpsRedirection();
 app.UseResponseCompression();
 app.UseRouting();


### PR DESCRIPTION
## Summary

Four small, related fixes prompted by PowerBI consumer feedback on the new ExternalAPI surface:

- **Rename auth query param `?x-api-key=` → `?token=`** so the public URL surface doesn't expose the internal header naming convention. Header stays `x-api-key`. Migration 035 updates the seeded Web Services help text (only if it still matches the prior 034-seeded copy verbatim, so admin edits in the in-page editor are preserved).

- **Force `Content-Type: application/json`** on `/model-results/current`, `/model-results/baseline`, and `/land-use/statistics`. The blobs were uploaded as `application/octet-stream`, which PowerBI refuses to auto-detect as JSON; consumers were hand-configuring parsers. `Content-Disposition` stays `attachment` because `ModelResults.json` is ~185MB — enough to OOM Chrome's JSON viewer if rendered inline.

- **Stream the blob** to the response (`FileStreamResult` instead of `FileContentResult`) so the pod doesn't hold ~185MB in memory per concurrent request. The streaming variant was already in `AzureBlobStorageService`; one-line swap.

- **`UseForwardedHeaders`** (XForwardedFor + XForwardedProto) before `UseHttpsRedirection` so the AKS ingress's TLS-termination header is respected. Without it, `Request.Scheme` stays `"http"` inside the pod, which (a) makes `UseHttpsRedirection` issue a needless 301 (PowerBI / curl users without `-L` get stuck on it) and (b) makes the OpenAPI auto-detected server URL render `http://...` in Scalar so "try it out" originates an http request that has to follow the same 301.

## Test plan

- [ ] `curl -H "x-api-key: <token>" .../model-results/current` → 200, `Content-Type: application/json`
- [ ] `curl ".../model-results/current?token=<token>"` → 200, `Content-Type: application/json`
- [ ] `curl ".../model-results/current?x-api-key=<token>"` → 401 (old query param intentionally removed)
- [ ] Open the same URL in a browser → downloads `ModelResults.json` instead of trying to render inline
- [ ] Web Services tab on the SPA Data Hub now shows `?token=YOUR-TOKEN` instead of `?x-api-key=`
- [ ] On QA: `curl -v http://qa-api.ocstormwatertools.org/...` no longer issues a 301 when hit through the ingress (forwarded-proto is honored)
- [ ] On QA: Scalar docs page lists server URL as `https://qa-api...` (not `http://`)