### PR TITLE
NPT-1078: Add ExternalAPI access audit log + per-token last-used timestamp

### DIFF
--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -18801,6 +18801,11 @@
             "format": "uuid",
             "nullable": true
           },
+          "LastWebServiceAccessDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
           "IsOCTAGrantReviewer": {
             "type": "boolean"
           },

--- a/Neptune.Database/Neptune.Database.sqlproj
+++ b/Neptune.Database/Neptune.Database.sqlproj
@@ -233,6 +233,7 @@
     <Build Include="dbo\Tables\dbo.WaterQualityManagementPlanVerifyType.sql" />
     <Build Include="dbo\Tables\dbo.WaterQualityManagementPlanVisitStatus.sql" />
     <Build Include="dbo\Tables\dbo.Watershed.sql" />
+    <Build Include="dbo\Tables\dbo.WebServiceAccessLog.sql" />
     <Build Include="dbo\User Defined Types\html.sql" />
   </ItemGroup>
   <ItemGroup>

--- a/Neptune.Database/dbo/Tables/dbo.Person.sql
+++ b/Neptune.Database/dbo/Tables/dbo.Person.sql
@@ -13,6 +13,7 @@ CREATE TABLE [dbo].[Person](
 	[ReceiveSupportEmails] [bit] NOT NULL,
 	[ReceiveRSBRevisionRequestEmails] [bit] NOT NULL,
 	[WebServiceAccessToken] [uniqueidentifier] NULL,
+	[LastWebServiceAccessDate] [datetime] NULL,
 	[IsOCTAGrantReviewer] [bit] NOT NULL,
     [GlobalID] VARCHAR(100) NULL,
     [ImpersonatedPersonID] [int] NULL CONSTRAINT [FK_Person_Person_ImpersonatedPersonID_PersonID] FOREIGN KEY REFERENCES [dbo].[Person]([PersonID])

--- a/Neptune.Database/dbo/Tables/dbo.WebServiceAccessLog.sql
+++ b/Neptune.Database/dbo/Tables/dbo.WebServiceAccessLog.sql
@@ -1,0 +1,22 @@
+-- NPT-1078: per-request audit trail for the Neptune.ExternalAPI surface so compliance
+-- can answer "who accessed what, when" and admins can identify stale tokens to prune.
+-- Written by WebServiceAccessLogMiddleware after each authenticated request resolves;
+-- denormalized timestamp also lives on Person.LastWebServiceAccessDate for fast
+-- "who's idle" queries without scanning this table.
+CREATE TABLE [dbo].[WebServiceAccessLog](
+    [WebServiceAccessLogID] [int] IDENTITY(1,1) NOT NULL CONSTRAINT [PK_WebServiceAccessLog_WebServiceAccessLogID] PRIMARY KEY,
+    [PersonID] [int] NOT NULL CONSTRAINT [FK_WebServiceAccessLog_Person_PersonID] FOREIGN KEY REFERENCES [dbo].[Person]([PersonID]),
+    [Endpoint] [varchar](200) NOT NULL,
+    [HttpMethod] [varchar](10) NOT NULL,
+    [RequestedDate] [datetime] NOT NULL CONSTRAINT [DF_WebServiceAccessLog_RequestedDate] DEFAULT GETUTCDATE(),
+    [ResponseStatusCode] [int] NOT NULL
+)
+GO
+
+-- Supports the most common "what did this person do" query (admin pruning, debugging).
+CREATE INDEX [IX_WebServiceAccessLog_PersonID_RequestedDate] ON [dbo].[WebServiceAccessLog] ([PersonID], [RequestedDate] DESC)
+GO
+
+-- Supports the "recent activity across all consumers" query (capacity, anomaly detection).
+CREATE INDEX [IX_WebServiceAccessLog_RequestedDate] ON [dbo].[WebServiceAccessLog] ([RequestedDate] DESC)
+GO

--- a/Neptune.EFModels/Entities/Generated/ExtensionMethods/WebServiceAccessLog.Binding.cs
+++ b/Neptune.EFModels/Entities/Generated/ExtensionMethods/WebServiceAccessLog.Binding.cs
@@ -1,0 +1,18 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[WebServiceAccessLog]
+namespace Neptune.EFModels.Entities
+{
+    public partial class WebServiceAccessLog : IHavePrimaryKey
+    {
+        public int PrimaryKey => WebServiceAccessLogID;
+
+
+        public static class FieldLengths
+        {
+            public const int Endpoint = 200;
+            public const int HttpMethod = 10;
+        }
+    }
+}

--- a/Neptune.EFModels/Entities/Generated/ExtensionMethods/WebServiceAccessLogPrimaryKey.cs
+++ b/Neptune.EFModels/Entities/Generated/ExtensionMethods/WebServiceAccessLogPrimaryKey.cs
@@ -1,0 +1,25 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: dbo.WebServiceAccessLog
+
+
+namespace Neptune.EFModels.Entities
+{
+    public class WebServiceAccessLogPrimaryKey : EntityPrimaryKey<WebServiceAccessLog>
+    {
+        public WebServiceAccessLogPrimaryKey() : base(){}
+        public WebServiceAccessLogPrimaryKey(int primaryKeyValue) : base(primaryKeyValue){}
+        public WebServiceAccessLogPrimaryKey(WebServiceAccessLog webServiceAccessLog) : base(webServiceAccessLog){}
+
+        public static implicit operator WebServiceAccessLogPrimaryKey(int primaryKeyValue)
+        {
+            return new WebServiceAccessLogPrimaryKey(primaryKeyValue);
+        }
+
+        public static implicit operator WebServiceAccessLogPrimaryKey(WebServiceAccessLog webServiceAccessLog)
+        {
+            return new WebServiceAccessLogPrimaryKey(webServiceAccessLog);
+        }
+    }
+}

--- a/Neptune.EFModels/Entities/Generated/NeptuneDbContext.cs
+++ b/Neptune.EFModels/Entities/Generated/NeptuneDbContext.cs
@@ -203,6 +203,8 @@ public partial class NeptuneDbContext : DbContext
 
     public virtual DbSet<Watershed> Watersheds { get; set; }
 
+    public virtual DbSet<WebServiceAccessLog> WebServiceAccessLogs { get; set; }
+
     public virtual DbSet<vFieldVisitDetailed> vFieldVisitDetaileds { get; set; }
 
     public virtual DbSet<vGeoServerLoadGeneratingUnit> vGeoServerLoadGeneratingUnits { get; set; }
@@ -1123,6 +1125,15 @@ public partial class NeptuneDbContext : DbContext
         modelBuilder.Entity<Watershed>(entity =>
         {
             entity.HasKey(e => e.WatershedID).HasName("PK_Watershed_WatershedID");
+        });
+
+        modelBuilder.Entity<WebServiceAccessLog>(entity =>
+        {
+            entity.HasKey(e => e.WebServiceAccessLogID).HasName("PK_WebServiceAccessLog_WebServiceAccessLogID");
+
+            entity.Property(e => e.RequestedDate).HasDefaultValueSql("(getutcdate())", "DF_WebServiceAccessLog_RequestedDate");
+
+            entity.HasOne(d => d.Person).WithMany(p => p.WebServiceAccessLogs).OnDelete(DeleteBehavior.ClientSetNull);
         });
 
         modelBuilder.Entity<vFieldVisitDetailed>(entity =>

--- a/Neptune.EFModels/Entities/Generated/Person.cs
+++ b/Neptune.EFModels/Entities/Generated/Person.cs
@@ -49,6 +49,9 @@ public partial class Person
 
     public Guid? WebServiceAccessToken { get; set; }
 
+    [Column(TypeName = "datetime")]
+    public DateTime? LastWebServiceAccessDate { get; set; }
+
     public bool IsOCTAGrantReviewer { get; set; }
 
     [StringLength(100)]
@@ -133,4 +136,7 @@ public partial class Person
 
     [InverseProperty("LastEditedByPerson")]
     public virtual ICollection<WaterQualityManagementPlanVerify> WaterQualityManagementPlanVerifies { get; set; } = new List<WaterQualityManagementPlanVerify>();
+
+    [InverseProperty("Person")]
+    public virtual ICollection<WebServiceAccessLog> WebServiceAccessLogs { get; set; } = new List<WebServiceAccessLog>();
 }

--- a/Neptune.EFModels/Entities/Generated/WebServiceAccessLog.cs
+++ b/Neptune.EFModels/Entities/Generated/WebServiceAccessLog.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Neptune.EFModels.Entities;
+
+[Table("WebServiceAccessLog")]
+[Index("PersonID", "RequestedDate", Name = "IX_WebServiceAccessLog_PersonID_RequestedDate", IsDescending = new[] { false, true })]
+[Index("RequestedDate", Name = "IX_WebServiceAccessLog_RequestedDate", AllDescending = true)]
+public partial class WebServiceAccessLog
+{
+    [Key]
+    public int WebServiceAccessLogID { get; set; }
+
+    public int PersonID { get; set; }
+
+    [StringLength(200)]
+    [Unicode(false)]
+    public string Endpoint { get; set; } = null!;
+
+    [StringLength(10)]
+    [Unicode(false)]
+    public string HttpMethod { get; set; } = null!;
+
+    [Column(TypeName = "datetime")]
+    public DateTime RequestedDate { get; set; }
+
+    public int ResponseStatusCode { get; set; }
+
+    [ForeignKey("PersonID")]
+    [InverseProperty("WebServiceAccessLogs")]
+    public virtual Person Person { get; set; } = null!;
+}

--- a/Neptune.EFModels/Entities/PersonExtensionMethods.cs
+++ b/Neptune.EFModels/Entities/PersonExtensionMethods.cs
@@ -65,6 +65,7 @@ public static class PersonExtensionMethods
             ReceiveSupportEmails = person.ReceiveSupportEmails,
             ReceiveRSBRevisionRequestEmails = person.ReceiveRSBRevisionRequestEmails,
             WebServiceAccessToken = person.WebServiceAccessToken,
+            LastWebServiceAccessDate = person.LastWebServiceAccessDate,
             IsOCTAGrantReviewer = person.IsOCTAGrantReviewer,
             HasAssignedStormwaterJurisdiction = person.StormwaterJurisdictionPeople.Any(),
             ImpersonatedPersonID = person.ImpersonatedPersonID,

--- a/Neptune.EFModels/Entities/WebServiceAccessLog.StaticHelpers.cs
+++ b/Neptune.EFModels/Entities/WebServiceAccessLog.StaticHelpers.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Neptune.EFModels.Entities;
+
+public static class WebServiceAccessLogs
+{
+    // Called from WebServiceAccessLogMiddleware (Neptune.ExternalAPI) after each
+    // authenticated request resolves. Inserts the audit row + denormalizes the
+    // timestamp onto Person.LastWebServiceAccessDate in one round trip so a single
+    // ExecuteUpdate keeps the "who's idle" query fast (no scan of the log table).
+    public static async Task CreateAsync(NeptuneDbContext dbContext, int personID, string endpoint, string httpMethod, int responseStatusCode)
+    {
+        var now = DateTime.UtcNow;
+
+        var log = new WebServiceAccessLog
+        {
+            PersonID = personID,
+            Endpoint = endpoint,
+            HttpMethod = httpMethod,
+            RequestedDate = now,
+            ResponseStatusCode = responseStatusCode,
+        };
+        dbContext.WebServiceAccessLogs.Add(log);
+        await dbContext.SaveChangesAsync();
+
+        await dbContext.People
+            .Where(x => x.PersonID == personID)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(x => x.LastWebServiceAccessDate, now));
+    }
+}

--- a/Neptune.ExternalAPI/Middleware/WebServiceAccessLogMiddleware.cs
+++ b/Neptune.ExternalAPI/Middleware/WebServiceAccessLogMiddleware.cs
@@ -1,0 +1,52 @@
+using System.Security.Claims;
+using Microsoft.Extensions.Logging;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.ExternalAPI.Middleware;
+
+// NPT-1078: writes an audit row to dbo.WebServiceAccessLog after each authenticated
+// request resolves and denormalizes the timestamp onto Person.LastWebServiceAccessDate.
+// Drives compliance ("who accessed what, when") and token-pruning ("who hasn't used
+// theirs lately") use cases.
+//
+// Runs AFTER UseAuthentication/UseAuthorization so context.User reflects the resolved
+// identity, and AFTER the response pipeline finishes so we capture the actual status
+// code. Audit-write failures are logged-and-swallowed because we never want a logging
+// hiccup to fail a successful API call from a consumer's perspective.
+public class WebServiceAccessLogMiddleware(RequestDelegate next, ILogger<WebServiceAccessLogMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context, NeptuneDbContext dbContext)
+    {
+        await next(context);
+
+        // Skip anon traffic (healthz, /openapi, /docs). The auth handler returns Fail for
+        // protected endpoints when no key is provided, so an unauthenticated identity here
+        // also means "the request never reached an audited endpoint."
+        if (context.User?.Identity?.IsAuthenticated != true) return;
+
+        var personIDClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!int.TryParse(personIDClaim, out var personID)) return;
+
+        try
+        {
+            var endpoint = context.Request.Path.Value ?? string.Empty;
+            // Cap the endpoint string at the column's max length so a pathologically long
+            // URL doesn't fail the insert. The dbo.WebServiceAccessLog.Endpoint column is
+            // VARCHAR(200); truncate defensively here so the audit row still gets written.
+            if (endpoint.Length > 200) endpoint = endpoint[..200];
+
+            await WebServiceAccessLogs.CreateAsync(
+                dbContext,
+                personID,
+                endpoint,
+                context.Request.Method,
+                context.Response.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            // Log but don't rethrow — the consumer already has their response and we don't
+            // want a logging-side hiccup to turn a 200 into a 500.
+            logger.LogError(ex, "Failed to write WebServiceAccessLog row for PersonID {PersonID}", personID);
+        }
+    }
+}

--- a/Neptune.ExternalAPI/Program.cs
+++ b/Neptune.ExternalAPI/Program.cs
@@ -164,6 +164,7 @@ app.UseCors(policy =>
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseMiddleware<AccessDeniedMiddleware>();
+app.UseMiddleware<WebServiceAccessLogMiddleware>();
 app.UseMiddleware<LogHelper>();
 app.MapControllers();
 app.MapHealthChecks("/healthz");

--- a/Neptune.Models/DataTransferObjects/PersonDto.cs
+++ b/Neptune.Models/DataTransferObjects/PersonDto.cs
@@ -19,6 +19,7 @@ public class PersonDto
     public bool ReceiveSupportEmails { get; set; }
     public bool ReceiveRSBRevisionRequestEmails { get; set; }
     public Guid? WebServiceAccessToken { get; set; }
+    public DateTime? LastWebServiceAccessDate { get; set; }
     public bool IsOCTAGrantReviewer { get; set; }
     public bool HasAssignedStormwaterJurisdiction { get; set; }
     public int? ImpersonatedPersonID { get; set; }

--- a/Neptune.Web/src/app/pages/data-hub/tabs/web-services-tab/web-services-tab.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/tabs/web-services-tab/web-services-tab.component.html
@@ -13,6 +13,11 @@
             <div class="token-row">
                 <code [copyToClipboard]="true">{{ token }}</code>
             </div>
+            @if (lastWebServiceAccessDate(); as last) {
+                <p class="last-used">Last used: {{ last | date: 'MM/dd/yyyy h:mm a' : "+0000" }}</p>
+            } @else {
+                <p class="last-used">Last used: never</p>
+            }
             <button type="button" class="btn btn-secondary-outline" [disabled]="busy()" (click)="regenerateToken()">
                 Regenerate Token
             </button>

--- a/Neptune.Web/src/app/pages/data-hub/tabs/web-services-tab/web-services-tab.component.ts
+++ b/Neptune.Web/src/app/pages/data-hub/tabs/web-services-tab/web-services-tab.component.ts
@@ -1,3 +1,4 @@
+import { DatePipe } from "@angular/common";
 import { Component, computed, inject, signal, Signal } from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { map } from "rxjs";
@@ -16,7 +17,7 @@ import { DataHubQuickLinksComponent } from "../../components/data-hub-quick-link
 @Component({
     selector: "web-services-tab",
     standalone: true,
-    imports: [CustomRichTextComponent, CopyToClipboardDirective, DataHubQuickLinksComponent],
+    imports: [CustomRichTextComponent, CopyToClipboardDirective, DataHubQuickLinksComponent, DatePipe],
     templateUrl: "./web-services-tab.component.html",
     styleUrls: ["../../data-hub.component.scss", "./web-services-tab.component.scss"],
 })
@@ -33,6 +34,7 @@ export class WebServicesTabComponent {
 
     public webServiceToken: Signal<string | null> = computed(() => this.currentUser()?.WebServiceAccessToken ?? null);
     public personID: Signal<number | null> = computed(() => this.currentUser()?.PersonID ?? null);
+    public lastWebServiceAccessDate: Signal<string | null> = computed(() => this.currentUser()?.LastWebServiceAccessDate ?? null);
     public busy = signal(false);
 
     public generateToken(): void {

--- a/Neptune.Web/src/app/shared/generated/model/person-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/person-dto.ts
@@ -28,6 +28,7 @@ export class PersonDto {
     ReceiveSupportEmails?: boolean;
     ReceiveRSBRevisionRequestEmails?: boolean;
     WebServiceAccessToken?: string | null;
+    LastWebServiceAccessDate?: string | null;
     IsOCTAGrantReviewer?: boolean;
     HasAssignedStormwaterJurisdiction?: boolean;
     ImpersonatedPersonID?: number | null;
@@ -54,6 +55,7 @@ export interface PersonDtoForm {
     ReceiveSupportEmails?: FormControl<boolean>;
     ReceiveRSBRevisionRequestEmails?: FormControl<boolean>;
     WebServiceAccessToken?: FormControl<string>;
+    LastWebServiceAccessDate?: FormControl<string>;
     IsOCTAGrantReviewer?: FormControl<boolean>;
     HasAssignedStormwaterJurisdiction?: FormControl<boolean>;
     ImpersonatedPersonID?: FormControl<number>;
@@ -221,6 +223,16 @@ export class PersonDtoFormControls {
         }
     );
     public static WebServiceAccessToken = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static LastWebServiceAccessDate = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
         value,
         formControlOptions ?? 
         {


### PR DESCRIPTION
## Summary

Phase 1 of the audit/pruning capability for the new ExternalAPI surface. Covers the two compliance/ops drivers the team has:

1. **"Who accessed what, when"** — durable in-app audit trail. New `dbo.WebServiceAccessLog` table captures `PersonID + Endpoint + HttpMethod + RequestedDate + ResponseStatusCode` for every authenticated request. Indexed on `(PersonID, RequestedDate desc)` for per-person queries and `(RequestedDate desc)` for cross-consumer activity queries.
2. **"Who hasn't used their token lately"** — denormalized `Person.LastWebServiceAccessDate` column updated in the same write so the "idle token" query doesn't scan the log table.

Both writes happen in a new `WebServiceAccessLogMiddleware` (Neptune.ExternalAPI) that runs after `UseAuthentication`/`UseAuthorization` and after `_next(...)` so it captures the resolved identity and the actual response status code. Skips unauthenticated traffic (healthz / openapi / docs). Errors are logged-and-swallowed so a write hiccup never turns a 200 into a 500 for the consumer.

SPA Web Services tab on the Data Hub now shows "Last used: ..." (or "never") under the current user's token so they can self-confirm their token is being exercised.

**Datadog logging path is intentionally untouched** — Datadog is wired but the existing Serilog `MinimumLevel` is `Warning`, so we'd have to lower it to capture audit traffic and that gets expensive at our log-volume tier. The DB trail is also more compliance-defensible than third-party SaaS log retention.

**Phase 2** (admin-facing query UI, retention/purge Hangfire job, bulk "regenerate tokens idle >N days") is deferred to a future iteration. Admins can run SQL queries directly against `dbo.WebServiceAccessLog` for compliance investigations in the meantime.

### Note on generated files

Had to hand-write `Generated/WebServiceAccessLog.cs` (POCO) + `Generated/Person.cs` (`LastWebServiceAccessDate` prop + InverseProperty) + `Generated/NeptuneDbContext.cs` (DbSet + OnModelCreating) because the `Scaffold-DbContext` PowerShell cmdlet wasn't loaded in the shell I ran the scaffold from. The POCO Generator step (extension methods + primary key files) ran fine. A proper EF scaffold run will overwrite these by-hand additions to match.

## Test plan

- [ ] Hit any ExternalAPI endpoint with a valid `x-api-key` or `?token=` — `SELECT * FROM dbo.WebServiceAccessLog ORDER BY WebServiceAccessLogID DESC` shows the new row with correct PersonID / endpoint / method / status / RequestedDate
- [ ] `SELECT PersonID, LastWebServiceAccessDate FROM dbo.Person WHERE WebServiceAccessToken IS NOT NULL` — the caller's row reflects ~now
- [ ] Refresh the SPA Data Hub Web Services tab — "Last used: ..." line appears under the token (or "never" before the first call)
- [ ] Hit `/healthz` or `/docs` — no log row written
- [ ] Hit an endpoint with a bad token — 401, no log row (auth handler returns Fail before middleware runs)