### PR TITLE
NPT-1069: Show measurement unit display name on Benchmark & Threshold labels

### DIFF
--- a/Neptune.EFModels/Entities/TreatmentBMPAssessmentObservationType.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPAssessmentObservationType.cs
@@ -91,13 +91,20 @@ namespace Neptune.EFModels.Entities
 
         public string BenchmarkMeasurementUnitLabel()
         {
+            // NPT-1069: prefer the authoritative MeasurementUnitType lookup display name (e.g. "inches")
+            // so the SPA matches how the unit is presented elsewhere. Fall back to the schema's free-text
+            // label only when the OT has no resolvable MeasurementUnitTypeID (so it doesn't lose its suffix).
+            var unitType = BenchmarkMeasurementUnitType();
+            if (unitType != null)
+            {
+                return unitType.MeasurementUnitTypeDisplayName;
+            }
+
             var observationTypeCollectionMethod = ObservationTypeSpecification.ObservationTypeCollectionMethod;
             switch (observationTypeCollectionMethod.ToEnum)
             {
                 case ObservationTypeCollectionMethodEnum.DiscreteValue:
                     return GetDiscreteObservationTypeSchema().MeasurementUnitLabel;
-                case ObservationTypeCollectionMethodEnum.PassFail:
-                    return null;
                 case ObservationTypeCollectionMethodEnum.Percentage:
                     return GetPercentageSchema().MeasurementUnitLabel;
                 default:
@@ -123,18 +130,18 @@ namespace Neptune.EFModels.Entities
 
         public string ThresholdMeasurementUnitLabel()
         {
-            var observationThresholdType = ObservationTypeSpecification.ObservationThresholdType;
-            switch (observationThresholdType.ToEnum)
+            // NPT-1069: resolve the unit from the MeasurementUnitType lookup display name (matching
+            // BenchmarkMeasurementUnitLabel). Fall back to the benchmark label for SpecificValue when the
+            // lookup is null so a free-text-only OT keeps its suffix.
+            var unitType = ThresholdMeasurementUnitType();
+            if (unitType != null)
             {
-                case ObservationThresholdTypeEnum.SpecificValue:
-                    return BenchmarkMeasurementUnitLabel();
-                case ObservationThresholdTypeEnum.RelativeToBenchmark:
-                    return ThresholdMeasurementUnitForPercentFromBenchmark().MeasurementUnitTypeDisplayName;
-                case ObservationThresholdTypeEnum.None:
-                    return null;
-                default:
-                    return null;
+                return unitType.MeasurementUnitTypeDisplayName;
             }
+
+            return ObservationTypeSpecification.ObservationThresholdType.ToEnum == ObservationThresholdTypeEnum.SpecificValue
+                ? BenchmarkMeasurementUnitLabel()
+                : null;
         }
 
         public MeasurementUnitType ThresholdMeasurementUnitType()


### PR DESCRIPTION
### Rework (KE 6/12/26)
> "Mulch Thickness" showed **"Thickness"** in the B&T editor and BMP detail page; it should show the actual unit (**"inches"**) the way the unit is presented elsewhere.

### Root cause
An observation type carries two unit representations: a hand-entered free-text `MeasurementUnitLabel` in its schema JSON (which was `"Thickness"` for the Mulch Thickness OT), and the authoritative `MeasurementUnitType` lookup (resolved from the schema's `MeasurementUnitTypeID` → Inches → `"inches"`). The SPA surfaces rendered the free-text label via `BenchmarkMeasurementUnitLabel()`/`ThresholdMeasurementUnitLabel()`.

### Change
`Neptune.EFModels/Entities/TreatmentBMPAssessmentObservationType.cs` — both helpers now return `…MeasurementUnitType()?.MeasurementUnitTypeDisplayName`, falling back to the schema free-text label only when no `MeasurementUnitTypeID` resolves. Fixed once in the shared helpers, so all three consumers correct together:
- B&T editor modal + BMP detail B&T panel (`TreatmentBMPBenchmarkAndThresholds.cs`)
- BMP Type edit page (`TreatmentBMPTypes.StaticHelpers.cs`)

### Safety
- **Percentage** OTs → `"%"` (unchanged); **RelativeToBenchmark** thresholds → `"% increase from benchmark"` (unchanged); **PassFail** → null (unchanged). Only DiscreteValue OTs like Mulch Thickness change (`"Thickness"` → `"inches"`).
- `GetFormattedBenchmarkValue()`/`GetFormattedThresholdValue()` already use the lookup legend directly — untouched.

### Notes
- No DTO/route changes → **no codegen**; no frontend, DB, or test changes (the bound DTO fields already exist; `Neptune.Tests` references none of these methods).