### PR TITLE
NPT-1080: Render bullets on delineation GDB upload/download instructions

### DIFF
--- a/Neptune.Web/src/app/pages/delineation/gdb-download/gdb-download.component.scss
+++ b/Neptune.Web/src/app/pages/delineation/gdb-download/gdb-download.component.scss
@@ -10,8 +10,9 @@
 
 .instructions {
   ul {
+    list-style: disc;
     margin-top: $spacing-100;
-    padding-left: 1.25rem;
+    padding-left: 1.5rem;
   }
   li + li {
     margin-top: $spacing-100;

--- a/Neptune.Web/src/app/pages/delineation/gdb-upload/gdb-upload.component.scss
+++ b/Neptune.Web/src/app/pages/delineation/gdb-upload/gdb-upload.component.scss
@@ -10,8 +10,9 @@
 
 .instructions {
   ul {
+    list-style: disc;
     margin-top: $spacing-100;
-    padding-left: 1.25rem;
+    padding-left: 1.5rem;
   }
   li + li {
     margin-top: $spacing-100;


### PR DESCRIPTION
### Rework (KE 6/12/26)
> "Please re-format instruction content with bullet points (similar to other uploaders with hard coded instructions)" — on both the Delineation GDB **Download** and **Upload** pages.

(All 31 functional test cases TC01–TC31 passed; this is the only follow-up.)

### Root cause
Both pages already use `<ul><li>` instruction markup, but their `.instructions ul` SCSS omitted `list-style`. The global reset (`scss/base/_normalize.scss` → `list-style: none`) hid the markers, so the instructions rendered as an unstyled indented block. The reference "hard coded instructions" uploaders (`data-hub/land-use-block-upload`, `data-hub/ovta-area-upload`) override it with `list-style: disc; padding-left: 1.5rem;`.

### Change (CSS only)
Added `list-style: disc;` and bumped `padding-left` `1.25rem → 1.5rem` on `.instructions ul` in:
- `pages/delineation/gdb-download/gdb-download.component.scss`
- `pages/delineation/gdb-upload/gdb-upload.component.scss`

Now matches the Land Use Block / OVTA Area upload instruction styling.

### Notes
- No HTML/TS/backend/codegen/DB/test changes — purely presentational.