### PR TITLE
NPT-1070: Fix TreatmentBMP CSV bulk-upload validation (name/type, lat-long, multiselect)

### DIFF
--- a/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
@@ -119,25 +119,33 @@ namespace Neptune.EFModels.Entities
                 treatmentBMPNamesInCsv.Add(treatmentBMPName);
             }
 
+            // A BMP name must map to a single type. Reject if any existing BMP — in any jurisdiction,
+            // including planning-module (project) BMPs — already uses this name with a different type.
+            // The jurisdiction-scoped update lookup below can't catch this (the existing BMP may be in
+            // another jurisdiction or be a project BMP), which is how a cross-type duplicate slipped through.
+            var conflictingTypeBMP = dbContext.TreatmentBMPs.Include(x => x.TreatmentBMPType).FirstOrDefault(x =>
+                x.TreatmentBMPName == treatmentBMPName &&
+                x.TreatmentBMPTypeID != treatmentBMPType.TreatmentBMPTypeID);
+            if (conflictingTypeBMP != null)
+            {
+                errorList.Add(
+                    $"BMP with name '{treatmentBMPName}' has a Type '{conflictingTypeBMP.TreatmentBMPType.TreatmentBMPTypeName}', which does not match the uploaded Type '{treatmentBMPType.TreatmentBMPTypeName}' for row: {rowNumber}");
+            }
+
+            // Match an existing inventory BMP (ProjectID == null) in this jurisdiction as the update target.
+            // Per the AK_TreatmentBMP_StormwaterJurisdictionID_TreatmentBMPName unique index, inventory names
+            // are unique per jurisdiction and project BMPs are never upload targets.
             var treatmentBMP = dbContext.TreatmentBMPs.Include(x => x.TreatmentBMPType).SingleOrDefault(x =>
                 x.TreatmentBMPName == treatmentBMPName &&
-                x.StormwaterJurisdictionID == stormwaterJurisdictionID.Value);
-            if (treatmentBMP != null)
-            {
-                // one last check; make sure the treatment bmp type of the existing treatment bmp matches the passed type
-                if (treatmentBMPType.TreatmentBMPTypeID != treatmentBMP.TreatmentBMPTypeID)
-                {
-                    errorList.Add(
-                        $"BMP with name '{treatmentBMPName}' has a Type '{treatmentBMP.TreatmentBMPType.TreatmentBMPTypeName}', which does not match the uploaded Type '{treatmentBMPType.TreatmentBMPTypeName}' for row: {rowNumber}");
-                }
-            }
-            else
+                x.StormwaterJurisdictionID == stormwaterJurisdictionID.Value &&
+                x.ProjectID == null);
+            if (treatmentBMP == null)
             {
                 treatmentBMP = new TreatmentBMP()
                 {
                     TreatmentBMPName = treatmentBMPName,
                     TreatmentBMPTypeID = treatmentBMPType.TreatmentBMPTypeID,
-                    StormwaterJurisdictionID = stormwaterJurisdictionID.Value, 
+                    StormwaterJurisdictionID = stormwaterJurisdictionID.Value,
                     InventoryIsVerified = false
                 };
             }
@@ -368,7 +376,14 @@ namespace Neptune.EFModels.Entities
                 {
                     return null;
                 }
-                locationErrorList.Add($"Treatment BMP Latitude {treatmentBMPLatitude} or Longitude {treatmentBMPLongitude} is null or empty space at row: {rowNumber}");
+                var missingLocationFields = new List<string>();
+                if (string.IsNullOrWhiteSpace(treatmentBMPLatitude)) missingLocationFields.Add("Latitude");
+                if (string.IsNullOrWhiteSpace(treatmentBMPLongitude)) missingLocationFields.Add("Longitude");
+                errorList.Add(
+                    $"{string.Join(" and ", missingLocationFields)} {(missingLocationFields.Count > 1 ? "are" : "is")} required for new Treatment BMPs at row: {rowNumber}");
+                // Return early — otherwise the blank value(s) also trip the decimal-parse/range checks below,
+                // producing two extra confusing "can not be converted to Decimal format" errors for the same row.
+                return null;
             }
             if (!decimal.TryParse(treatmentBMPLatitude, out var treatmentBMPLatitudeDecimal))
             {
@@ -495,8 +510,14 @@ namespace Neptune.EFModels.Entities
                         $"{customAttributeTypeName} field can not be converted to {customAttributeDataTypeDisplayName} at row: {rowNumber}";
                 case CustomAttributeDataTypeEnum.MultiSelect:
                 case CustomAttributeDataTypeEnum.PickFromList:
+                    // Identify the specific offending entry/entries rather than echoing the whole value, so a
+                    // mixed multi-select like "Gravel, InvalidMedia" reports only "InvalidMedia".
+                    var invalidEntries = value.Split(',').Select(x => x.Trim())
+                        .Where(x => customAttributeTypeAcceptableValues == null || !customAttributeTypeAcceptableValues.Contains(x))
+                        .ToList();
+                    var invalidEntryDisplay = invalidEntries.Any() ? string.Join(", ", invalidEntries) : value;
                     return
-                        $"{value} is not a valid {customAttributeTypeName} entry at row: {rowNumber}. Acceptable values are: {string.Join(", ", customAttributeTypeAcceptableValues)}";
+                        $"'{invalidEntryDisplay}' is not a valid {customAttributeTypeName} entry at row: {rowNumber}. Acceptable values are: {string.Join(", ", customAttributeTypeAcceptableValues)}";
                 default:
                     return
                         $"{customAttributeTypeName} entry at row: {rowNumber} experienced an unknown error. Please double check the sheet, and contact support with further questions.";

--- a/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
@@ -119,12 +119,17 @@ namespace Neptune.EFModels.Entities
                 treatmentBMPNamesInCsv.Add(treatmentBMPName);
             }
 
+            // Fetch every existing BMP sharing this name once, then derive both checks in memory
+            // (one query per row instead of two).
+            var existingBMPsWithName = dbContext.TreatmentBMPs.Include(x => x.TreatmentBMPType)
+                .Where(x => x.TreatmentBMPName == treatmentBMPName)
+                .ToList();
+
             // A BMP name must map to a single type. Reject if any existing BMP — in any jurisdiction,
             // including planning-module (project) BMPs — already uses this name with a different type.
             // The jurisdiction-scoped update lookup below can't catch this (the existing BMP may be in
             // another jurisdiction or be a project BMP), which is how a cross-type duplicate slipped through.
-            var conflictingTypeBMP = dbContext.TreatmentBMPs.Include(x => x.TreatmentBMPType).FirstOrDefault(x =>
-                x.TreatmentBMPName == treatmentBMPName &&
+            var conflictingTypeBMP = existingBMPsWithName.FirstOrDefault(x =>
                 x.TreatmentBMPTypeID != treatmentBMPType.TreatmentBMPTypeID);
             if (conflictingTypeBMP != null)
             {
@@ -135,8 +140,7 @@ namespace Neptune.EFModels.Entities
             // Match an existing inventory BMP (ProjectID == null) in this jurisdiction as the update target.
             // Per the AK_TreatmentBMP_StormwaterJurisdictionID_TreatmentBMPName unique index, inventory names
             // are unique per jurisdiction and project BMPs are never upload targets.
-            var treatmentBMP = dbContext.TreatmentBMPs.Include(x => x.TreatmentBMPType).SingleOrDefault(x =>
-                x.TreatmentBMPName == treatmentBMPName &&
+            var treatmentBMP = existingBMPsWithName.SingleOrDefault(x =>
                 x.StormwaterJurisdictionID == stormwaterJurisdictionID.Value &&
                 x.ProjectID == null);
             if (treatmentBMP == null)
@@ -513,7 +517,9 @@ namespace Neptune.EFModels.Entities
                     // Identify the specific offending entry/entries rather than echoing the whole value, so a
                     // mixed multi-select like "Gravel, InvalidMedia" reports only "InvalidMedia".
                     var invalidEntries = value.Split(',').Select(x => x.Trim())
+                        .Where(x => !string.IsNullOrEmpty(x))
                         .Where(x => customAttributeTypeAcceptableValues == null || !customAttributeTypeAcceptableValues.Contains(x))
+                        .Distinct()
                         .ToList();
                     var invalidEntryDisplay = invalidEntries.Any() ? string.Join(", ", invalidEntries) : value;
                     return

--- a/Neptune.Tests/TestTreatmentCSVParser.cs
+++ b/Neptune.Tests/TestTreatmentCSVParser.cs
@@ -95,7 +95,7 @@ Test Cook Park,30,10,City of San Juan Capistrano,City of San Juan Capistrano,200
 Frank,,10,City of Orange,Sitka Technology Group,2008,ABCD,Perpetuity/Life of Project,11/12/2022,5,6,Happy,Full,Not Provided";
             const int treatmentBMPTypeID = 17;
             TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out _);
-            Assert.IsTrue(errorList.Any(x => x.Contains("Treatment BMP Latitude ")), "Expected an error message");
+            Assert.IsTrue(errorList.Any(x => x.Contains("Latitude is required for new Treatment BMPs")), "Expected an error message");
         }
 
         [TestMethod]
@@ -125,7 +125,7 @@ Frank,95,120,City of Orange,Sitka Technology Group,2008,ABCD,Perpetuity/Life of 
 Frank,30,,City of Orange,Sitka Technology Group,2008,ABCD,Perpetuity/Life of Project,11/12/2022,5,6,Happy,Full,Not Provided";
             const int treatmentBMPTypeID = 17;
             TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out _);
-            Assert.IsTrue(errorList.Any(x => x.Contains("Treatment BMP Latitude")), "Expected an error message");
+            Assert.IsTrue(errorList.Any(x => x.Contains("Longitude is required for new Treatment BMPs")), "Expected an error message");
         }
 
         [TestMethod]


### PR DESCRIPTION
Three tester-flagged validation issues in the TreatmentBMP CSV bulk-upload parser (`TreatmentBMPCsvParserHelper`). All 43 test cases otherwise pass.

### TC09 — name reused for a different type wasn't blocked
The collision check matched `name + jurisdiction` only, so an existing BMP in another jurisdiction or a project (planning-module) BMP slipped through and a duplicate-named BMP of a different type was created. Added a **name-based type-conflict guard across all jurisdictions (including project BMPs)** — if any existing BMP uses the uploaded name with a different type, it errors. Also scoped the insert/update lookup to `ProjectID == null` to match the DB AK (`AK_TreatmentBMP_StormwaterJurisdictionID_TreatmentBMPName ... WHERE ProjectID IS NULL`).

### TC02 / TC12 — blank lat/long produced noisy, vague errors
A new BMP with blank Latitude/Longitude emitted `"Treatment BMP Latitude  or Longitude  is null or empty space..."` (empty interpolation) **and** fell through to add two more `"can not be converted to Decimal format"` errors. Now emits one clear message naming the missing field(s) and returns early.

### TC38 — MultiSelect error didn't identify the invalid entry
Validation correctly rejected `"Gravel, InvalidMedia"`, but the error echoed the whole value. Now the MultiSelect/PickFromList error names the **specific invalid entry** (`'InvalidMedia'`).

### Tests
Updated the two lat/long-null assertions in `TestTreatmentCSVParser.cs` to the new wording. (These are live-DB integration tests run locally.)

### Notes
- Backend validation-message/logic only — **no codegen, frontend, or DB-schema changes**. The AK is unchanged.