### PR TITLE
NPT-1070: Reject unquoted multi-value CSV cells (TC38)

### DIFF
--- a/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
@@ -49,17 +49,20 @@ namespace Neptune.EFModels.Entities
                 "Allowable End Date of Installation (if applicable)", "Required Field Visits Per Year", "Required Post-Storm Field Visits Per Year","Notes"};
             var customAttributeTypes = treatmentBMPType.TreatmentBMPTypeCustomAttributeTypes.Select(x => x.CustomAttributeType).ToList();
 
-            var headerFieldCount = 0;
+            var recognizedColumnCount = 0;
             try
             {
                 var header = parser.ReadFields();
-                headerFieldCount = header.Length;
                 var customAttributeNames = customAttributeTypes.Select(x => x.CustomAttributeTypeName).ToList();
                 fieldsDict = ValidateHeader(header, requiredFields, optionalFields, customAttributeNames, out errorList, treatmentBMPType);
                 if (errorList.Any())
                 {
                     return null;
                 }
+                // Meaningful columns end at the last recognized header index. Using this rather than
+                // header.Length means a trailing blank header column (e.g. a header ending in a comma)
+                // can't absorb an unquoted comma spillover and silently swallow the invalid fragment.
+                recognizedColumnCount = fieldsDict.Any() ? fieldsDict.Values.Max() + 1 : header.Length;
             }
             catch
             {
@@ -75,16 +78,16 @@ namespace Neptune.EFModels.Entities
             {
                 var currentRow = parser.ReadFields();
 
-                // More fields than the header means an unquoted cell contained commas and was split into
-                // extra columns (e.g. a MultiSelect value typed as Gravel, InvalidMedia without quotes).
+                // Data beyond the recognized columns means an unquoted cell contained commas and was split
+                // into extra columns (e.g. a MultiSelect value typed as Gravel, InvalidMedia without quotes).
                 // A trailing comma yields a harmless empty extra field; only reject when an extra field
                 // carries real data, which would otherwise be silently dropped — hiding the invalid entry
                 // and letting the row commit. Tell the user to quote multi-value cells.
-                if (currentRow.Length > headerFieldCount &&
-                    currentRow.Skip(headerFieldCount).Any(x => !string.IsNullOrWhiteSpace(x)))
+                if (currentRow.Length > recognizedColumnCount &&
+                    currentRow.Skip(recognizedColumnCount).Any(x => !string.IsNullOrWhiteSpace(x)))
                 {
                     errorList.Add(
-                        $"Row {rowCount} has more columns ({currentRow.Length}) than the header ({headerFieldCount}). If a value contains commas (e.g. a multi-select entry like \"Gravel, Sand\"), wrap it in double quotes so it is not read as additional columns. Row: {rowCount}");
+                        $"Row {rowCount} has data in columns beyond the {recognizedColumnCount} recognized header columns. If a value contains commas (e.g. a multi-select entry like \"Gravel, Sand\"), wrap it in double quotes so it is not read as additional columns. Row: {rowCount}");
                     rowCount++;
                     continue;
                 }
@@ -541,7 +544,7 @@ namespace Neptune.EFModels.Entities
                         .ToList();
                     var invalidEntryDisplay = invalidEntries.Any() ? string.Join(", ", invalidEntries) : value;
                     return
-                        $"'{invalidEntryDisplay}' is not a valid {customAttributeTypeName} entry at row: {rowNumber}. Acceptable values are: {string.Join(", ", customAttributeTypeAcceptableValues)}";
+                        $"'{invalidEntryDisplay}' is not a valid {customAttributeTypeName} entry at row: {rowNumber}. Acceptable values are: {string.Join(", ", customAttributeTypeAcceptableValues ?? new List<string>())}";
                 default:
                     return
                         $"{customAttributeTypeName} entry at row: {rowNumber} experienced an unknown error. Please double check the sheet, and contact support with further questions.";
@@ -567,7 +570,8 @@ namespace Neptune.EFModels.Entities
                         .ToList();
 
                     return splitValues.Any() &&
-                           splitValues.All(x => customAttributeTypeAcceptableValues != null && customAttributeTypeAcceptableValues.Contains(x));
+                           customAttributeTypeAcceptableValues != null &&
+                           splitValues.All(customAttributeTypeAcceptableValues.Contains);
                 case CustomAttributeDataTypeEnum.String:
                     return true;
                 default:

--- a/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
@@ -49,9 +49,11 @@ namespace Neptune.EFModels.Entities
                 "Allowable End Date of Installation (if applicable)", "Required Field Visits Per Year", "Required Post-Storm Field Visits Per Year","Notes"};
             var customAttributeTypes = treatmentBMPType.TreatmentBMPTypeCustomAttributeTypes.Select(x => x.CustomAttributeType).ToList();
 
+            var headerFieldCount = 0;
             try
             {
                 var header = parser.ReadFields();
+                headerFieldCount = header.Length;
                 var customAttributeNames = customAttributeTypes.Select(x => x.CustomAttributeTypeName).ToList();
                 fieldsDict = ValidateHeader(header, requiredFields, optionalFields, customAttributeNames, out errorList, treatmentBMPType);
                 if (errorList.Any())
@@ -72,6 +74,20 @@ namespace Neptune.EFModels.Entities
             while (!parser.EndOfData)
             {
                 var currentRow = parser.ReadFields();
+
+                // More fields than the header means an unquoted cell contained commas and was split into
+                // extra columns (e.g. a MultiSelect value typed as Gravel, InvalidMedia without quotes).
+                // A trailing comma yields a harmless empty extra field; only reject when an extra field
+                // carries real data, which would otherwise be silently dropped — hiding the invalid entry
+                // and letting the row commit. Tell the user to quote multi-value cells.
+                if (currentRow.Length > headerFieldCount &&
+                    currentRow.Skip(headerFieldCount).Any(x => !string.IsNullOrWhiteSpace(x)))
+                {
+                    errorList.Add(
+                        $"Row {rowCount} has more columns ({currentRow.Length}) than the header ({headerFieldCount}). If a value contains commas (e.g. a multi-select entry like \"Gravel, Sand\"), wrap it in double quotes so it is not read as additional columns. Row: {rowCount}");
+                    rowCount++;
+                    continue;
+                }
 
                 var currentTreatmentBMP = ParseRequiredAndOptionalFieldAndCreateBMP(dbContext, currentRow, fieldsDict, rowCount, out var currentErrorList, treatmentBMPType, organizations, stormwaterJurisdictions, treatmentBMPNamesInCsv);
                 if (currentTreatmentBMP != null)
@@ -483,7 +499,9 @@ namespace Neptune.EFModels.Entities
 
                         if (customAttributeType.CustomAttributeDataType == CustomAttributeDataType.MultiSelect)
                         {
-                            var attributeValues = value.Split(new[] {','}).Select(x => x.Trim()).Select(x =>
+                            var attributeValues = value.Split(new[] {','}).Select(x => x.Trim())
+                                .Where(x => !string.IsNullOrEmpty(x))
+                                .Select(x =>
                                 new CustomAttributeValue { CustomAttribute = customAttribute, AttributeValue = x });
                             customAttributeValues.AddRange(attributeValues);
                         }
@@ -542,9 +560,14 @@ namespace Neptune.EFModels.Entities
                     return DateTime.TryParse(value, out _);
                 case CustomAttributeDataTypeEnum.PickFromList:
                 case CustomAttributeDataTypeEnum.MultiSelect:
-                    var splitValues = value.Split(',').Select(x => x.Trim());
+                    // Reject if ANY entry is invalid. Filter blank fragments (from leading/trailing/double
+                    // commas) so they neither trip a false rejection nor mask a genuine invalid entry.
+                    var splitValues = value.Split(',').Select(x => x.Trim())
+                        .Where(x => !string.IsNullOrEmpty(x))
+                        .ToList();
 
-                    return splitValues.All(customAttributeTypeAcceptableValues.Contains);
+                    return splitValues.Any() &&
+                           splitValues.All(x => customAttributeTypeAcceptableValues != null && customAttributeTypeAcceptableValues.Contains(x));
                 case CustomAttributeDataTypeEnum.String:
                     return true;
                 default:

--- a/Neptune.Tests/TestTreatmentCSVParser.cs
+++ b/Neptune.Tests/TestTreatmentCSVParser.cs
@@ -1300,5 +1300,116 @@ Frank,30,10,City of Orange,Sitka Technology Group,2008,ABCD,Perpetuity/Life of P
             TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out _);
             Assert.IsTrue(errorList.Any(x => x.Contains("Months of Operation")));
         }
+
+        // NPT-1070 TC38/TC39 — MultiSelect custom attribute validation. Data-driven so the suite does not
+        // hardcode a fragile type/option list: it discovers a real MultiSelect attribute from the DB.
+        private const string MultiSelectInvalidEntry = "ZZZ_InvalidEntry_NPT1070";
+
+        private (int TreatmentBMPTypeID, string AttributeName, List<string> ValidValues)? FindMultiSelectCustomAttribute()
+        {
+            var multiSelectDataTypeID = (int)CustomAttributeDataTypeEnum.MultiSelect;
+            var candidate = _dbContext.CustomAttributeTypes
+                .Include(x => x.TreatmentBMPTypeCustomAttributeTypes)
+                .AsNoTracking()
+                .Where(x => x.CustomAttributeDataTypeID == multiSelectDataTypeID
+                            && x.CustomAttributeTypeOptionsSchema != null
+                            && x.TreatmentBMPTypeCustomAttributeTypes.Any())
+                .ToList()
+                .Select(x => new
+                {
+                    Type = x,
+                    Options = System.Text.Json.JsonSerializer.Deserialize<List<string>>(x.CustomAttributeTypeOptionsSchema)
+                })
+                .FirstOrDefault(x => x.Options != null && x.Options.Count >= 2);
+
+            if (candidate == null)
+            {
+                return null;
+            }
+
+            return (candidate.Type.TreatmentBMPTypeCustomAttributeTypes.First().TreatmentBMPTypeID,
+                candidate.Type.CustomAttributeTypeName,
+                candidate.Options);
+        }
+
+        private static string BuildMultiSelectCsv(string bmpName, string attributeName, string valueCell)
+        {
+            return
+                $"BMP Name,Latitude,Longitude,Jurisdiction, Owner,Year Built or Installed,Asset ID in System of Record, Required Lifespan of Installation,Allowable End Date of Installation (if applicable), Required Field Visits Per Year, Required Post-Storm Field Visits Per Year,Notes,Trash Capture Status,Sizing Basis,{attributeName}\n" +
+                // Perpetuity lifespan with a blank end date is a valid combination, so the only errors a test
+                // sees come from the multi-select cell under test (not a spurious lifespan/end-date conflict).
+                $"{bmpName},30,10,City of Orange,Sitka Technology Group,2008,ABCD,Perpetuity/Life of Project,,5,6,Happy,Full,Not Provided,{valueCell}";
+        }
+
+        [TestMethod]
+        public void TestCustomAttributeMultiSelectMixedQuotedInvalidIsRejected()
+        {
+            var ms = FindMultiSelectCustomAttribute();
+            if (ms == null)
+            {
+                Assert.Inconclusive("No MultiSelect custom attribute type with options exists in the local database.");
+            }
+            var (treatmentBMPTypeID, attributeName, validValues) = ms.Value;
+            // Single quoted cell: the parser keeps "valid, invalid" as one field; validation must reject it.
+            var csv = BuildMultiSelectCsv("NPT1070 MultiSelect Mixed Quoted", attributeName, $"\"{validValues[0]}, {MultiSelectInvalidEntry}\"");
+            TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out _);
+            Assert.IsTrue(errorList.Any(x => x.Contains(attributeName) && x.Contains("is not a valid")),
+                "A quoted multi-select cell with a mix of valid and invalid entries should be rejected.");
+        }
+
+        [TestMethod]
+        public void TestCustomAttributeMultiSelectMixedUnquotedIsRejected()
+        {
+            var ms = FindMultiSelectCustomAttribute();
+            if (ms == null)
+            {
+                Assert.Inconclusive("No MultiSelect custom attribute type with options exists in the local database.");
+            }
+            var (treatmentBMPTypeID, attributeName, validValues) = ms.Value;
+            // Unquoted commas are split into extra columns by the CSV parser; the invalid entry must not be
+            // silently dropped and the row must not commit.
+            var csv = BuildMultiSelectCsv("NPT1070 MultiSelect Mixed Unquoted", attributeName, $"{validValues[0]}, {MultiSelectInvalidEntry}");
+            TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out var customAttributeValues);
+            Assert.IsTrue(errorList.Any(),
+                "An unquoted multi-select cell containing commas must not be silently accepted; the upload should be rejected.");
+            Assert.IsFalse(customAttributeValues.Any(v => v.AttributeValue == MultiSelectInvalidEntry),
+                "The invalid entry must never be stored.");
+            Assert.IsFalse(customAttributeValues.Any(v => v.AttributeValue == validValues[0]),
+                "The row must be rejected entirely, so the valid entry must not be partially stored either.");
+        }
+
+        [TestMethod]
+        public void TestCustomAttributeMultiSelectAllValidQuotedStoresSeparateRecords()
+        {
+            var ms = FindMultiSelectCustomAttribute();
+            if (ms == null)
+            {
+                Assert.Inconclusive("No MultiSelect custom attribute type with options exists in the local database.");
+            }
+            var (treatmentBMPTypeID, attributeName, validValues) = ms.Value;
+            var csv = BuildMultiSelectCsv("NPT1070 MultiSelect All Valid", attributeName, $"\"{validValues[0]}, {validValues[1]}\"");
+            TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out var customAttributeValues);
+            Assert.IsFalse(errorList.Any(x => x.Contains(attributeName)),
+                "An all-valid multi-select cell should not produce errors.");
+            var storedForAttribute = customAttributeValues
+                .Where(v => v.AttributeValue == validValues[0] || v.AttributeValue == validValues[1]).ToList();
+            Assert.AreEqual(2, storedForAttribute.Count,
+                "Each valid multi-select entry should be stored as a separate CustomAttributeValue.");
+        }
+
+        [TestMethod]
+        public void TestCustomAttributeMultiSelectInvalidAloneIsRejected()
+        {
+            var ms = FindMultiSelectCustomAttribute();
+            if (ms == null)
+            {
+                Assert.Inconclusive("No MultiSelect custom attribute type with options exists in the local database.");
+            }
+            var (treatmentBMPTypeID, attributeName, _) = ms.Value;
+            var csv = BuildMultiSelectCsv("NPT1070 MultiSelect Invalid Alone", attributeName, MultiSelectInvalidEntry);
+            TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out _);
+            Assert.IsTrue(errorList.Any(x => x.Contains(attributeName) && x.Contains("is not a valid")),
+                "A purely invalid multi-select entry should be rejected.");
+        }
     }
 }


### PR DESCRIPTION
## NPT-1070 — TC38 rework

Addresses the one remaining red item on the bulk-upload test card.

### Problem
An unquoted MultiSelect cell containing commas (e.g. `Gravel, InvalidMedia`) was split by the CSV parser into extra columns. The valid part filled the attribute column and validated, while the invalid part spilled into a trailing field that nothing reads — so it was **silently dropped and the row committed with no error**. (Quoted mixed values were already rejected by the existing `.All()` validation, which is why this only surfaced for unquoted cells.)

### Fix (`Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs`)
- **Structural guard** in `ParseBmpRowsFromCsv`: reject any row whose beyond-header fields carry **non-blank** data, with a clear message telling the user to quote multi-value cells. Trailing-comma empty fields are tolerated, so existing uploads are unaffected.
- **Hardening**: `ValidateCustomAttributeValueEntry` and the MultiSelect storage branch now filter blank fragments and null-guard the acceptable-values list, keeping the reject-if-any-invalid semantic.

### Tests (`Neptune.Tests/TestTreatmentCSVParser.cs`)
Added 4 data-driven MultiSelect regression tests (discover a real MultiSelect attribute from the DB; `Assert.Inconclusive` if none): quoted-mixed, unquoted-mixed, all-valid (TC39 parity), invalid-alone. The unquoted test was verified to **fail without the fix and pass with it**.

### Verification
- New MultiSelect tests pass; full `TreatmentBMPCsvParserHelperTest` class: 116 pass, 1 fail — that one (`TestBMPNameExistsAndMatchingJurisdictionAndType`) also fails on a clean baseline (pre-existing, local-DB-state dependent), unrelated to this change.
- Both `Neptune.EFModels` and `Neptune.Tests` build with 0 errors.
- No DB schema / DTO / API / Angular changes — no codegen needed.
