### PR TITLE
NPT-981: Show non-modeling delineations on management maps

### DIFF
--- a/Neptune.Web/src/app/pages/load-generating-units/load-generating-units.component.html
+++ b/Neptune.Web/src/app/pages/load-generating-units/load-generating-units.component.html
@@ -23,8 +23,8 @@
             <regional-subbasins-layer [mode]="OverlayMode.ReferenceOnly" [map]="map" [layerControl]="layerControl" [displayOnLoad]="false" [sortOrder]="10"></regional-subbasins-layer>
             <jurisdictions-layer [mode]="OverlayMode.ReferenceOnly" [map]="map" [layerControl]="layerControl" [displayOnLoad]="false" [sortOrder]="30"></jurisdictions-layer>
             <wqmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="40"></wqmps-layer>
-            <delineations-layer delineationStatus="Verified" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
-            <delineations-layer delineationStatus="Provisional" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="51"></delineations-layer>
+            <delineations-layer delineationStatus="Verified" [isAnalyzedInModelingModule]="true" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
+            <delineations-layer delineationStatus="Provisional" [isAnalyzedInModelingModule]="true" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="51"></delineations-layer>
         }
     </div>
 </hybrid-map-grid>

--- a/Neptune.Web/src/app/pages/planning-module/grant-programs/octa-m2-tier2-dashboard/octa-m2-tier2-dashboard.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/grant-programs/octa-m2-tier2-dashboard/octa-m2-tier2-dashboard.component.html
@@ -141,7 +141,7 @@
                 <stormwater-network-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="20"></stormwater-network-layer>
                 <jurisdictions-layer [mode]="OverlayMode.ReferenceOnly" [map]="map" [layerControl]="layerControl" [sortOrder]="30"></jurisdictions-layer>
                 <wqmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="40"></wqmps-layer>
-                <delineations-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
+                <delineations-layer [isAnalyzedInModelingModule]="true" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
                 <inventoried-bmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="60"></inventoried-bmps-layer>
                 }
             </neptune-map>

--- a/Neptune.Web/src/app/pages/planning-module/planning-map/planning-map.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/planning-map/planning-map.component.html
@@ -145,7 +145,7 @@
 
                 <wqmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="40"></wqmps-layer>
 
-                <delineations-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
+                <delineations-layer [isAnalyzedInModelingModule]="true" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
 
                 <inventoried-bmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="60"></inventoried-bmps-layer>
                 }

--- a/Neptune.Web/src/app/pages/planning-module/project-workflow/delineations/delineations.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/project-workflow/delineations/delineations.component.html
@@ -20,7 +20,7 @@
                     <stormwater-network-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="20"></stormwater-network-layer>
                     <jurisdictions-layer [mode]="OverlayMode.ReferenceOnly" [map]="map" [layerControl]="layerControl" [sortOrder]="30"></jurisdictions-layer>
                     <wqmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="40"></wqmps-layer>
-                    <delineations-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
+                    <delineations-layer [isAnalyzedInModelingModule]="true" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
                     <inventoried-bmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="60"></inventoried-bmps-layer>
                 }
             </neptune-map>

--- a/Neptune.Web/src/app/pages/planning-module/project-workflow/modeled-performance/modeled-performance.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/project-workflow/modeled-performance/modeled-performance.component.html
@@ -90,7 +90,7 @@
                                                 [layerControl]="layerControl"
                                                 [sortOrder]="30"></jurisdictions-layer>
                                             <wqmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="40"></wqmps-layer>
-                                            <delineations-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
+                                            <delineations-layer [isAnalyzedInModelingModule]="true" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
                                             <inventoried-bmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="60"></inventoried-bmps-layer>
                                         }
                                     </neptune-map>

--- a/Neptune.Web/src/app/pages/planning-module/project-workflow/treatment-bmps/treatment-bmps.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/project-workflow/treatment-bmps/treatment-bmps.component.html
@@ -36,7 +36,7 @@
                         <stormwater-network-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="20"></stormwater-network-layer>
                         <jurisdictions-layer [mode]="OverlayMode.ReferenceOnly" [map]="map" [layerControl]="layerControl" [sortOrder]="30"></jurisdictions-layer>
                         <wqmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="40"></wqmps-layer>
-                        <delineations-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
+                        <delineations-layer [isAnalyzedInModelingModule]="true" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
                         <inventoried-bmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="60"></inventoried-bmps-layer>
                     }
                 </neptune-map>

--- a/Neptune.Web/src/app/pages/planning-module/projects/project-map/project-map.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/projects/project-map/project-map.component.html
@@ -23,7 +23,7 @@
                             <stormwater-network-layer [displayOnLoad]="true" [map]="map" [layerControl]="layerControl" [sortOrder]="20"></stormwater-network-layer>
                             <jurisdictions-layer [mode]="OverlayMode.ReferenceOnly" [map]="map" [layerControl]="layerControl" [sortOrder]="30"></jurisdictions-layer>
                             <wqmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="40"></wqmps-layer>
-                            <delineations-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
+                            <delineations-layer [isAnalyzedInModelingModule]="true" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="50"></delineations-layer>
                             <inventoried-bmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="60"></inventoried-bmps-layer>
                         }
                     </neptune-map>

--- a/Neptune.Web/src/app/pages/trash-module/trash-home/trash-home.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/trash-home/trash-home.component.html
@@ -419,8 +419,7 @@
                                         [displayOnLoad]="false"
                                         [map]="map"
                                         [layerControl]="layerControl"
-                                        [sortOrder]="20"
-                                        [isAnalyzedInModelingModule]="false"></delineations-layer>
+                                        [sortOrder]="20"></delineations-layer>
                                 }
                                 @if (mapIsReady) {
                                     <wqmps-trash-capture-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="40"></wqmps-trash-capture-layer>

--- a/Neptune.Web/src/app/pages/trash-module/trash-land-use-block-index/trash-land-use-block-index.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/trash-land-use-block-index/trash-land-use-block-index.component.html
@@ -38,7 +38,7 @@
             } @if (mapIsReady) {
             <wqmps-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="20"></wqmps-layer>
             } @if (mapIsReady) {
-            <delineations-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="30" [isAnalyzedInModelingModule]="false"></delineations-layer>
+            <delineations-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="30"></delineations-layer>
             }
         </div>
         }

--- a/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
@@ -50,7 +50,7 @@
                 </wqmps-layer>
                 @if (mapIsReady) {
                     <parcel-layer [map]="map" [layerControl]="layerControl"></parcel-layer>
-                    <delineations-layer [map]="map" [layerControl]="layerControl" [isAnalyzedInModelingModule]="false"></delineations-layer>
+                    <delineations-layer [map]="map" [layerControl]="layerControl"></delineations-layer>
                     <jurisdictions-layer [map]="map" [layerControl]="layerControl" [mode]="OverlayMode.ReferenceOnly"></jurisdictions-layer>
                 }
             </hybrid-map-grid>

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/delineations-layer/delineations-layer.component.ts
@@ -26,7 +26,10 @@ export class DelineationsLayerComponent implements OnChanges {
     readonly WMS_STYLE = "delineation";
 
     @Input() delineationStatus: "Verified" | "Provisional" = "Verified";
-    @Input() isAnalyzedInModelingModule: boolean = true;
+    // Default false: a delineations layer shows ALL delineations (including trash/inlet BMP types whose
+    // TreatmentBMPType.IsAnalyzedInModelingModule = 0). Modeling/planning maps (LGU, planning module) opt
+    // in to the modeling-only view with [isAnalyzedInModelingModule]="true". Only affects the Verified layer.
+    @Input() isAnalyzedInModelingModule: boolean = false;
     @Input() map: L.Map;
     @Input() layerControl: any;
     @Input() sortOrder: number = 1;


### PR DESCRIPTION
## NPT-981 follow-up

### Problem
The Delineation Map (and other management maps) weren't rendering all delineations a user has access to. The `delineations-layer` defaulted `isAnalyzedInModelingModule` to `true`, appending `AND IsAnalyzedInModelingModule = 1` to the Verified layer's CQL filter. That hides verified delineations on the three BMP types where `TreatmentBMPType.IsAnalyzedInModelingModule = 0`:

- Catch Basin / Inlet (unscreened)
- In-stream Trash Capture
- Inlet and Pipe Screens

The BMP point marker still rendered, and clicking it fetched/drew the delineation via an unfiltered path (`/delineations/for-treatment-bmp/{id}`) — so the omission looked arbitrary (provisional showed; some verified didn't).

### Fix
- Flip the `isAnalyzedInModelingModule` default to **`false`** so a delineations layer shows **all** delineations unless a map opts in.
- Remove the now-redundant `="false"` overrides (delineation map, BMP detail, trash home, trash LUB index, WQMP).
- Add explicit `="true"` on the modeling/planning contexts that should keep the modeling-only view: **LGU map** and the **planning-module maps** (planning map, project map, OCTA M2 Tier 2 dashboard, project-workflow delineations/modeled-performance/treatment-bmps).

### Net effect
General/management maps now show every delineation (including trash/inlet BMP types); LGU + planning maps are unchanged.

Frontend-only; no codegen, no DB/API changes.

### Verification
`npm start` → Delineation Map: verified delineations on the three trash/inlet BMP types now render in the Verified layer without needing to click the marker. LGU/planning maps unchanged.
