### PR TITLE
UI/UX audit pilot: form, detail-page, and grid polish

### DIFF
--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -55,7 +55,7 @@ public class TreatmentBMPController(
         // filter above already excludes jurisdictions whose public BMP visibility is None; this adds
         // the per-BMP verified gate the SPA list endpoint was missing. Anonymous callers are an
         // Unassigned-role PersonDto sentinel (see UserContext), so this one check covers both. (NPT-1079)
-        var publicUser = CallingUser == null || CallingUser.RoleID == (int)RoleEnum.Unassigned;
+        var publicUser = CallingUser.RoleID == (int)RoleEnum.Unassigned;
 
         var entities = await DbContext.vTreatmentBMPDetaileds.AsNoTracking()
             .Where(x => stormwaterJurisdictionIDsPersonCanView.Contains(x.StormwaterJurisdictionID))

--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -50,8 +50,16 @@ public class TreatmentBMPController(
     {
         var stormwaterJurisdictionIDsPersonCanView = await StormwaterJurisdictionPeople.ListViewableStormwaterJurisdictionIDsByPersonIDForBMPsAsync(DbContext, CallingUser.PersonID);
 
+        // Public (anonymous) and unassigned users may only see verified BMPs, matching the legacy
+        // Find-a-BMP behavior (PersonModelExtensions.GetTreatmentBmpsPersonCanView). The jurisdiction
+        // filter above already excludes jurisdictions whose public BMP visibility is None; this adds
+        // the per-BMP verified gate the SPA list endpoint was missing. Anonymous callers are an
+        // Unassigned-role PersonDto sentinel (see UserContext), so this one check covers both. (NPT-1079)
+        var publicUser = CallingUser == null || CallingUser.RoleID == (int)RoleEnum.Unassigned;
+
         var entities = await DbContext.vTreatmentBMPDetaileds.AsNoTracking()
             .Where(x => stormwaterJurisdictionIDsPersonCanView.Contains(x.StormwaterJurisdictionID))
+            .Where(x => !publicUser || x.InventoryIsVerified)
             .ToListAsync();
 
         var treatmentBMPGridDtos = entities.Select(x => x.AsGridDto()).ToList();

--- a/Neptune.Database/dbo/Views/dbo.vTreatmentBMPDetailed.sql
+++ b/Neptune.Database/dbo/Views/dbo.vTreatmentBMPDetailed.sql
@@ -18,7 +18,7 @@ as
 
 select	tb.TreatmentBMPID as PrimaryKey,
 		tb.TreatmentBMPID, tb.TreatmentBMPName, tbt.TreatmentBMPTypeID, tbt.TreatmentBMPTypeName, sj.StormwaterJurisdictionID, o.OrganizationName
-		, tb.RequiredFieldVisitsPerYear, tb.RequiredPostStormFieldVisitsPerYear, tb.TreatmentBMPLifespanEndDate, tb.YearBuilt, tb.Notes
+		, tb.RequiredFieldVisitsPerYear, tb.RequiredPostStormFieldVisitsPerYear, tb.TreatmentBMPLifespanEndDate, tb.YearBuilt, tb.Notes, tb.InventoryIsVerified
 		, tb.OwnerOrganizationID, oo.OrganizationName as OwnerOrganizationName
 		, tblt.TreatmentBMPLifespanTypeID, tblt.TreatmentBMPLifespanTypeDisplayName
 		, tcst.TrashCaptureStatusTypeID, tcst.TrashCaptureStatusTypeDisplayName

--- a/Neptune.EFModels/Entities/Generated/vTreatmentBMPDetailed.cs
+++ b/Neptune.EFModels/Entities/Generated/vTreatmentBMPDetailed.cs
@@ -42,6 +42,8 @@ public partial class vTreatmentBMPDetailed
     [Unicode(false)]
     public string? Notes { get; set; }
 
+    public bool InventoryIsVerified { get; set; }
+
     public int OwnerOrganizationID { get; set; }
 
     [StringLength(200)]

--- a/Neptune.Web/src/app/pages/dashboard/tabs/bmp-records-tab/bmp-records-tab.component.ts
+++ b/Neptune.Web/src/app/pages/dashboard/tabs/bmp-records-tab/bmp-records-tab.component.ts
@@ -82,14 +82,14 @@ export class BmpRecordsTabComponent {
                 const actions: any[] = [
                     {
                         ActionName: "View",
-                        ActionIcon: "fa fa-eye",
+                        ActionIcon: "fas fa-file-alt",
                         ActionHandler: () => this.router.navigate(["/treatment-bmps", row.TreatmentBMPID]),
                     },
                 ];
                 if (row.CanDelete) {
                     actions.push({
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.delete(row),
                     });
                 }

--- a/Neptune.Web/src/app/pages/dashboard/tabs/delineations-tab/delineations-tab.component.ts
+++ b/Neptune.Web/src/app/pages/dashboard/tabs/delineations-tab/delineations-tab.component.ts
@@ -82,13 +82,13 @@ export class DelineationsTabComponent {
                 return [
                     {
                         ActionName: "View on Map",
-                        ActionIcon: "fas fa-map-location-dot",
+                        ActionIcon: "fas fa-map-marked-alt",
                         ActionHandler: () =>
                             this.router.navigate(["/delineation/delineation-map"], { queryParams: { treatmentBMPID: row.TreatmentBMPID } }),
                     },
                     {
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.delete(row),
                     },
                 ];

--- a/Neptune.Web/src/app/pages/dashboard/tabs/field-visits-tab/field-visits-tab.component.ts
+++ b/Neptune.Web/src/app/pages/dashboard/tabs/field-visits-tab/field-visits-tab.component.ts
@@ -90,12 +90,12 @@ export class FieldVisitsTabComponent {
                 return [
                     {
                         ActionName: inProgress ? "Continue" : "View",
-                        ActionIcon: inProgress ? "fa fa-pencil" : "fa fa-eye",
+                        ActionIcon: inProgress ? "fas fa-edit" : "fas fa-file-alt",
                         ActionHandler: () => this.router.navigate(target),
                     },
                     {
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.delete(row),
                     },
                 ];

--- a/Neptune.Web/src/app/pages/data-hub/components/data-hub-action-button/data-hub-action-button.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/components/data-hub-action-button/data-hub-action-button.component.html
@@ -1,13 +1,13 @@
 @if (disabled) {
-    <span class="btn btn-neptune is-disabled" [title]="disabledTooltip">
+    <span class="btn is-disabled" [class.btn-primary]="icon === 'upload'" [class.btn-primary-outline]="icon !== 'upload'" [title]="disabledTooltip">
         <i [class]="iconClass"></i> {{ label }}
     </span>
 } @else if (routerLink) {
-    <a class="btn btn-neptune" [routerLink]="routerLink">
+    <a class="btn" [class.btn-primary]="icon === 'upload'" [class.btn-primary-outline]="icon !== 'upload'" [routerLink]="routerLink">
         <i [class]="iconClass"></i> {{ label }}
     </a>
 } @else {
-    <button type="button" class="btn btn-neptune" (click)="onClick()">
+    <button type="button" class="btn" [class.btn-primary]="icon === 'upload'" [class.btn-primary-outline]="icon !== 'upload'" (click)="onClick()">
         <i [class]="iconClass"></i> {{ label }}
     </button>
 }

--- a/Neptune.Web/src/app/pages/data-hub/land-use-block-upload-approve/land-use-block-upload-approve.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/land-use-block-upload-approve/land-use-block-upload-approve.component.html
@@ -49,7 +49,7 @@
 
           <div class="actions">
             <button type="button" class="btn btn-primary" [disabled]="isWorking() || hasErrors()" (click)="approve()">Accept</button>
-            <button type="button" class="btn btn-secondary" [disabled]="isWorking()" (click)="cancel()">Cancel</button>
+            <button type="button" class="btn btn-primary-outline" [disabled]="isWorking()" (click)="cancel()">Cancel</button>
           </div>
         </div>
       </div>

--- a/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.html
@@ -1,7 +1,12 @@
-<page-header pageTitle="Upload Land Use Blocks">
-    <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'trash' }">&laquo; Back to Data Hub</a>
-    &nbsp;|&nbsp;
-    <a class="back-link" [routerLink]="['/data-hub/land-use-block-download']">Go to Download Land Use Blocks &raquo;</a>
+<page-header pageTitle="Upload Land Use Blocks" [templateAbove]="templateAbove" [templateRight]="templateRight">
+    <ng-template #templateAbove>
+        <div class="back">
+            <a [routerLink]="['/data-hub']" [queryParams]="{ tab: 'trash' }" class="back__link"><i class="fa fa-arrow-left"></i> Back to Data Hub</a>
+        </div>
+    </ng-template>
+    <ng-template #templateRight>
+        <a class="btn btn-primary-outline" [routerLink]="['/data-hub/land-use-block-download']"><i class="fa fa-download"></i> Download Land Use Blocks</a>
+    </ng-template>
 </page-header>
 
 <section class="content-section">
@@ -28,27 +33,29 @@
             <p>After you upload your file the new Land Use Blocks will be staged for review. Once approved, they replace any existing Land Use Blocks for your Jurisdiction. It may take up to twenty-four hours to see updated Trash Results on the home page.</p>
         </div>
         <div class="g-col-6">
-            @if (jurisdictionOptions$ | async; as opts) {
-                <form-field fieldLabel="Stormwater Jurisdiction" [type]="FormFieldType.Select" [formControl]="jurisdictionControl" [formInputOptions]="opts" placeholder="Select a jurisdiction"></form-field>
-            }
-            <form-field fieldLabel="Zipped File Geodatabase" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".zip" (change)="onFileChange($event)"></form-field>
+            <div class="grid-12">
+                @if (jurisdictionOptions$ | async; as opts) {
+                    <form-field fieldLabel="Stormwater Jurisdiction" [type]="FormFieldType.Select" [formControl]="jurisdictionControl" [formInputOptions]="opts" placeholder="Select a jurisdiction"></form-field>
+                }
+                <form-field fieldLabel="Zipped File Geodatabase" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".zip" (change)="onFileChange($event)"></form-field>
 
-            @if (errors().length > 0) {
-                <div class="alert alert-danger upload-errors">
-                    <strong>Upload could not be staged:</strong>
-                    <ul>
-                        @for (err of errors(); track $index) {
-                            <li>{{ err }}</li>
-                        }
-                    </ul>
-                </div>
-            }
+                @if (errors().length > 0) {
+                    <div class="alert alert-danger upload-errors">
+                        <strong>Upload could not be staged:</strong>
+                        <ul>
+                            @for (err of errors(); track $index) {
+                                <li>{{ err }}</li>
+                            }
+                        </ul>
+                    </div>
+                }
 
-            @if (successMessage()) {
-                <div class="alert alert-success">{{ successMessage() }}</div>
-            }
+                @if (successMessage()) {
+                    <div class="alert alert-success">{{ successMessage() }}</div>
+                }
+            </div>
 
-            <div class="actions">
+            <div class="page-footer">
                 <button type="button" class="btn btn-primary" [disabled]="isUploading() || fileControl.invalid || jurisdictionControl.invalid" (click)="submit()">
                     @if (isUploading()) { <i class="fa fa-spinner fa-spin"></i> Uploading... } @else { <i class="fa fa-upload"></i> Upload }
                 </button>

--- a/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.scss
+++ b/Neptune.Web/src/app/pages/data-hub/land-use-block-upload/land-use-block-upload.component.scss
@@ -1,9 +1,5 @@
 @use "/src/scss/abstracts" as *;
 
-.back-link {
-    font-size: $type-size-200;
-}
-
 .instructions {
     ul {
         list-style: disc;

--- a/Neptune.Web/src/app/pages/data-hub/ovta-area-approve/ovta-area-approve.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/ovta-area-approve/ovta-area-approve.component.html
@@ -32,7 +32,7 @@
                 <button type="button" class="btn btn-primary" [disabled]="isWorking() || (r.Errors && r.Errors.length > 0)" (click)="approve()">
                     @if (isWorking()) { <i class="fa fa-spinner fa-spin"></i> Working... } @else { <i class="fa fa-check"></i> Approve and commit }
                 </button>
-                <button type="button" class="btn btn-secondary" [disabled]="isWorking()" (click)="discard()">
+                <button type="button" class="btn btn-danger-outline" [disabled]="isWorking()" (click)="discard()">
                     <i class="fa fa-times"></i> Discard staged areas
                 </button>
             </div>

--- a/Neptune.Web/src/app/pages/data-hub/ovta-area-upload/ovta-area-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/ovta-area-upload/ovta-area-upload.component.html
@@ -1,7 +1,12 @@
-<page-header pageTitle="Upload OVTA Assessment Areas">
-    <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'trash' }">&laquo; Back to Data Hub</a>
-    &nbsp;|&nbsp;
-    <a class="back-link" [routerLink]="['/data-hub/ovta-area-download']">Go to Download OVTA Assessment Areas &raquo;</a>
+<page-header pageTitle="Upload OVTA Assessment Areas" [templateAbove]="templateAbove" [templateRight]="templateRight">
+    <ng-template #templateAbove>
+        <div class="back">
+            <a [routerLink]="['/data-hub']" [queryParams]="{ tab: 'trash' }" class="back__link"><i class="fa fa-arrow-left"></i> Back to Data Hub</a>
+        </div>
+    </ng-template>
+    <ng-template #templateRight>
+        <a class="btn btn-primary-outline" [routerLink]="['/data-hub/ovta-area-download']"><i class="fa fa-download"></i> Download OVTA Assessment Areas</a>
+    </ng-template>
 </page-header>
 
 <section class="content-section">
@@ -27,24 +32,26 @@
             </ul>
         </div>
         <div class="g-col-6">
-            @if (jurisdictionOptions$ | async; as opts) {
-                <form-field fieldLabel="Stormwater Jurisdiction" [type]="FormFieldType.Select" [formControl]="jurisdictionControl" [formInputOptions]="opts" placeholder="Select a jurisdiction"></form-field>
-            }
-            <form-field fieldLabel="Area Name Field" [type]="FormFieldType.Text" [formControl]="areaNameFieldControl" placeholder="OVTAAreaName"></form-field>
-            <form-field fieldLabel="Zipped File Geodatabase" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".zip" (change)="onFileChange($event)"></form-field>
+            <div class="grid-12">
+                @if (jurisdictionOptions$ | async; as opts) {
+                    <form-field fieldLabel="Stormwater Jurisdiction" [type]="FormFieldType.Select" [formControl]="jurisdictionControl" [formInputOptions]="opts" placeholder="Select a jurisdiction"></form-field>
+                }
+                <form-field fieldLabel="Area Name Field" [type]="FormFieldType.Text" [formControl]="areaNameFieldControl" placeholder="OVTAAreaName"></form-field>
+                <form-field fieldLabel="Zipped File Geodatabase" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".zip" (change)="onFileChange($event)"></form-field>
 
-            @if (errors().length > 0) {
-                <div class="alert alert-danger upload-errors">
-                    <strong>Upload could not be staged:</strong>
-                    <ul>
-                        @for (err of errors(); track $index) {
-                            <li>{{ err }}</li>
-                        }
-                    </ul>
-                </div>
-            }
+                @if (errors().length > 0) {
+                    <div class="alert alert-danger upload-errors">
+                        <strong>Upload could not be staged:</strong>
+                        <ul>
+                            @for (err of errors(); track $index) {
+                                <li>{{ err }}</li>
+                            }
+                        </ul>
+                    </div>
+                }
+            </div>
 
-            <div class="actions">
+            <div class="page-footer">
                 <button type="button" class="btn btn-primary" [disabled]="isUploading() || fileControl.invalid || jurisdictionControl.invalid || areaNameFieldControl.invalid" (click)="submit()">
                     @if (isUploading()) { <i class="fa fa-spinner fa-spin"></i> Uploading... } @else { <i class="fa fa-upload"></i> Upload }
                 </button>

--- a/Neptune.Web/src/app/pages/data-hub/ovta-upload/ovta-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/ovta-upload/ovta-upload.component.html
@@ -3,7 +3,7 @@
 </page-header>
 
 <ng-template #downloadTemplateButton>
-    <button type="button" class="btn btn-secondary" [disabled]="isDownloadingTemplate()" (click)="downloadTemplate()">
+    <button type="button" class="btn btn-primary-outline" [disabled]="isDownloadingTemplate()" (click)="downloadTemplate()">
         @if (isDownloadingTemplate()) { <i class="fa fa-spinner fa-spin"></i> Downloading... } @else { <i class="fa fa-download"></i> Download Template }
     </button>
 </ng-template>

--- a/Neptune.Web/src/app/pages/data-hub/ovta-upload/ovta-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/ovta-upload/ovta-upload.component.html
@@ -1,5 +1,9 @@
-<page-header pageTitle="Upload On-land Visual Trash Assessments" [templateRight]="downloadTemplateButton">
-    <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'trash' }">&laquo; Back to Data Hub</a>
+<page-header pageTitle="Upload On-land Visual Trash Assessments" [templateAbove]="templateAbove" [templateRight]="downloadTemplateButton">
+    <ng-template #templateAbove>
+        <div class="back">
+            <a [routerLink]="['/data-hub']" [queryParams]="{ tab: 'trash' }" class="back__link"><i class="fa fa-arrow-left"></i> Back to Data Hub</a>
+        </div>
+    </ng-template>
 </page-header>
 
 <ng-template #downloadTemplateButton>
@@ -16,24 +20,26 @@
             <custom-rich-text [customRichTextTypeID]="NeptunePageTypeEnum.UploadOVTAs"></custom-rich-text>
         </div>
         <div class="g-col-6">
-            <form-field fieldLabel="XLSX File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".xlsx" (change)="onFileChange($event)"></form-field>
+            <div class="grid-12">
+                <form-field fieldLabel="XLSX File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".xlsx" (change)="onFileChange($event)"></form-field>
 
-            @if (errors().length > 0) {
-                <div class="alert alert-danger upload-errors">
-                    <strong>Upload could not be completed:</strong>
-                    <ul>
-                        @for (err of errors(); track $index) {
-                            <li>{{ err }}</li>
-                        }
-                    </ul>
-                </div>
-            }
+                @if (errors().length > 0) {
+                    <div class="alert alert-danger upload-errors">
+                        <strong>Upload could not be completed:</strong>
+                        <ul>
+                            @for (err of errors(); track $index) {
+                                <li>{{ err }}</li>
+                            }
+                        </ul>
+                    </div>
+                }
 
-            @if (successMessage()) {
-                <div class="alert alert-success">{{ successMessage() }}</div>
-            }
+                @if (successMessage()) {
+                    <div class="alert alert-success">{{ successMessage() }}</div>
+                }
+            </div>
 
-            <div class="actions">
+            <div class="page-footer">
                 <button type="button" class="btn btn-primary" [disabled]="isUploading() || fileControl.invalid" (click)="submit()">
                     @if (isUploading()) { <i class="fa fa-spinner fa-spin"></i> Uploading... } @else { <i class="fa fa-upload"></i> Upload }
                 </button>

--- a/Neptune.Web/src/app/pages/data-hub/simplified-bmp-upload/simplified-bmp-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/simplified-bmp-upload/simplified-bmp-upload.component.html
@@ -3,7 +3,7 @@
 </page-header>
 
 <ng-template #downloadTemplateButton>
-    <button type="button" class="btn btn-secondary" [disabled]="isDownloadingTemplate()" (click)="downloadTemplate()">
+    <button type="button" class="btn btn-primary-outline" [disabled]="isDownloadingTemplate()" (click)="downloadTemplate()">
         @if (isDownloadingTemplate()) { <i class="fa fa-spinner fa-spin"></i> Downloading... } @else { <i class="fa fa-download"></i> Download Template }
     </button>
 </ng-template>

--- a/Neptune.Web/src/app/pages/data-hub/simplified-bmp-upload/simplified-bmp-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/simplified-bmp-upload/simplified-bmp-upload.component.html
@@ -1,5 +1,9 @@
-<page-header pageTitle="Upload Simplified BMPs" [templateRight]="downloadTemplateButton">
-    <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'wqmps' }">&laquo; Back to Data Hub</a>
+<page-header pageTitle="Upload Simplified BMPs" [templateAbove]="templateAbove" [templateRight]="downloadTemplateButton">
+    <ng-template #templateAbove>
+        <div class="back">
+            <a [routerLink]="['/data-hub']" [queryParams]="{ tab: 'wqmps' }" class="back__link"><i class="fa fa-arrow-left"></i> Back to Data Hub</a>
+        </div>
+    </ng-template>
 </page-header>
 
 <ng-template #downloadTemplateButton>
@@ -16,27 +20,29 @@
             <custom-rich-text [customRichTextTypeID]="NeptunePageTypeEnum.UploadSimplifiedBMPs"></custom-rich-text>
         </div>
         <div class="g-col-6">
-            @if (jurisdictionOptions$ | async; as opts) {
-                <form-field fieldLabel="Stormwater Jurisdiction" [type]="FormFieldType.Select" [formControl]="jurisdictionControl" [formInputOptions]="opts" placeholder="Select a jurisdiction"></form-field>
-            }
-            <form-field fieldLabel="XLSX File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".xlsx" (change)="onFileChange($event)"></form-field>
+            <div class="grid-12">
+                @if (jurisdictionOptions$ | async; as opts) {
+                    <form-field fieldLabel="Stormwater Jurisdiction" [type]="FormFieldType.Select" [formControl]="jurisdictionControl" [formInputOptions]="opts" placeholder="Select a jurisdiction"></form-field>
+                }
+                <form-field fieldLabel="XLSX File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".xlsx" (change)="onFileChange($event)"></form-field>
 
-            @if (errors().length > 0) {
-                <div class="alert alert-danger upload-errors">
-                    <strong>Upload could not be completed:</strong>
-                    <ul>
-                        @for (err of errors(); track $index) {
-                            <li>{{ err }}</li>
-                        }
-                    </ul>
-                </div>
-            }
+                @if (errors().length > 0) {
+                    <div class="alert alert-danger upload-errors">
+                        <strong>Upload could not be completed:</strong>
+                        <ul>
+                            @for (err of errors(); track $index) {
+                                <li>{{ err }}</li>
+                            }
+                        </ul>
+                    </div>
+                }
 
-            @if (successMessage()) {
-                <div class="alert alert-success">{{ successMessage() }}</div>
-            }
+                @if (successMessage()) {
+                    <div class="alert alert-success">{{ successMessage() }}</div>
+                }
+            </div>
 
-            <div class="actions">
+            <div class="page-footer">
                 <button type="button" class="btn btn-primary" [disabled]="isUploading() || fileControl.invalid || jurisdictionControl.invalid" (click)="submit()">
                     @if (isUploading()) { <i class="fa fa-spinner fa-spin"></i> Uploading... } @else { <i class="fa fa-upload"></i> Upload }
                 </button>

--- a/Neptune.Web/src/app/pages/data-hub/tabs/web-services-tab/web-services-tab.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/tabs/web-services-tab/web-services-tab.component.html
@@ -18,7 +18,7 @@
             } @else {
                 <p class="last-used">Last used: never</p>
             }
-            <button type="button" class="btn btn-secondary-outline" [disabled]="busy()" (click)="regenerateToken()">
+            <button type="button" class="btn btn-primary-outline" [disabled]="busy()" (click)="regenerateToken()">
                 Regenerate Token
             </button>
         } @else {

--- a/Neptune.Web/src/app/pages/data-hub/trash-screen-field-visit-upload/trash-screen-field-visit-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/trash-screen-field-visit-upload/trash-screen-field-visit-upload.component.html
@@ -1,5 +1,9 @@
-<page-header pageTitle="Upload Trash Screen Field Visits" [templateRight]="downloadTemplateButton">
-    <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'bmps' }">&laquo; Back to Data Hub</a>
+<page-header pageTitle="Upload Trash Screen Field Visits" [templateAbove]="templateAbove" [templateRight]="downloadTemplateButton">
+    <ng-template #templateAbove>
+        <div class="back">
+            <a [routerLink]="['/data-hub']" [queryParams]="{ tab: 'bmps' }" class="back__link"><i class="fa fa-arrow-left"></i> Back to Data Hub</a>
+        </div>
+    </ng-template>
 </page-header>
 
 <ng-template #downloadTemplateButton>
@@ -16,24 +20,26 @@
             <custom-rich-text [customRichTextTypeID]="NeptunePageTypeEnum.BulkUploadFieldVisits"></custom-rich-text>
         </div>
         <div class="g-col-6">
-            <form-field fieldLabel="XLSX File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".xlsx" (change)="onFileChange($event)"></form-field>
+            <div class="grid-12">
+                <form-field fieldLabel="XLSX File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".xlsx" (change)="onFileChange($event)"></form-field>
 
-            @if (errors().length > 0) {
-                <div class="alert alert-danger upload-errors">
-                    <strong>Upload could not be completed:</strong>
-                    <ul>
-                        @for (err of errors(); track $index) {
-                            <li>{{ err }}</li>
-                        }
-                    </ul>
-                </div>
-            }
+                @if (errors().length > 0) {
+                    <div class="alert alert-danger upload-errors">
+                        <strong>Upload could not be completed:</strong>
+                        <ul>
+                            @for (err of errors(); track $index) {
+                                <li>{{ err }}</li>
+                            }
+                        </ul>
+                    </div>
+                }
 
-            @if (successMessage()) {
-                <div class="alert alert-success">{{ successMessage() }}</div>
-            }
+                @if (successMessage()) {
+                    <div class="alert alert-success">{{ successMessage() }}</div>
+                }
+            </div>
 
-            <div class="actions">
+            <div class="page-footer">
                 <button type="button" class="btn btn-primary" [disabled]="isUploading() || fileControl.invalid" (click)="submit()">
                     @if (isUploading()) { <i class="fa fa-spinner fa-spin"></i> Uploading... } @else { <i class="fa fa-upload"></i> Upload }
                 </button>

--- a/Neptune.Web/src/app/pages/data-hub/trash-screen-field-visit-upload/trash-screen-field-visit-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/trash-screen-field-visit-upload/trash-screen-field-visit-upload.component.html
@@ -3,7 +3,7 @@
 </page-header>
 
 <ng-template #downloadTemplateButton>
-    <button type="button" class="btn btn-secondary" [disabled]="isDownloadingTemplate()" (click)="downloadTemplate()">
+    <button type="button" class="btn btn-primary-outline" [disabled]="isDownloadingTemplate()" (click)="downloadTemplate()">
         @if (isDownloadingTemplate()) { <i class="fa fa-spinner fa-spin"></i> Downloading... } @else { <i class="fa fa-download"></i> Download Template }
     </button>
 </ng-template>

--- a/Neptune.Web/src/app/pages/data-hub/treatment-bmp-upload/treatment-bmp-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/treatment-bmp-upload/treatment-bmp-upload.component.html
@@ -1,7 +1,12 @@
-<page-header pageTitle="Upload Treatment BMPs">
-    <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'bmps' }">&laquo; Back to Data Hub</a>
-    &nbsp;|&nbsp;
-    <a class="back-link" [routerLink]="['/data-hub/treatment-bmp-download']">Go to Download Treatment BMPs &raquo;</a>
+<page-header pageTitle="Upload Treatment BMPs" [templateAbove]="templateAbove" [templateRight]="templateRight">
+    <ng-template #templateAbove>
+        <div class="back">
+            <a [routerLink]="['/data-hub']" [queryParams]="{ tab: 'bmps' }" class="back__link"><i class="fa fa-arrow-left"></i> Back to Data Hub</a>
+        </div>
+    </ng-template>
+    <ng-template #templateRight>
+        <a class="btn btn-primary-outline" [routerLink]="['/data-hub/treatment-bmp-download']"><i class="fa fa-download"></i> Download Treatment BMPs</a>
+    </ng-template>
 </page-header>
 
 <section class="content-section">
@@ -12,27 +17,29 @@
             <custom-rich-text [customRichTextTypeID]="NeptunePageTypeEnum.UploadTreatmentBMPs"></custom-rich-text>
         </div>
         <div class="g-col-6">
-            @if (bmpTypeOptions$ | async; as opts) {
-                <form-field fieldLabel="Treatment BMP Type" [type]="FormFieldType.Select" [formControl]="bmpTypeControl" [formInputOptions]="opts" placeholder="Select a type"></form-field>
-            }
-            <form-field fieldLabel="CSV File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".csv" (change)="onFileChange($event)"></form-field>
+            <div class="grid-12">
+                @if (bmpTypeOptions$ | async; as opts) {
+                    <form-field fieldLabel="Treatment BMP Type" [type]="FormFieldType.Select" [formControl]="bmpTypeControl" [formInputOptions]="opts" placeholder="Select a type"></form-field>
+                }
+                <form-field fieldLabel="CSV File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".csv" (change)="onFileChange($event)"></form-field>
 
-            @if (errors().length > 0) {
-                <div class="alert alert-danger upload-errors">
-                    <strong>Upload could not be completed:</strong>
-                    <ul>
-                        @for (err of errors(); track $index) {
-                            <li>{{ err }}</li>
-                        }
-                    </ul>
-                </div>
-            }
+                @if (errors().length > 0) {
+                    <div class="alert alert-danger upload-errors">
+                        <strong>Upload could not be completed:</strong>
+                        <ul>
+                            @for (err of errors(); track $index) {
+                                <li>{{ err }}</li>
+                            }
+                        </ul>
+                    </div>
+                }
 
-            @if (successMessage()) {
-                <div class="alert alert-success">{{ successMessage() }}</div>
-            }
+                @if (successMessage()) {
+                    <div class="alert alert-success">{{ successMessage() }}</div>
+                }
+            </div>
 
-            <div class="actions">
+            <div class="page-footer">
                 <button type="button" class="btn btn-primary" [disabled]="isUploading() || fileControl.invalid || bmpTypeControl.invalid" (click)="submit()">
                     @if (isUploading()) { <i class="fa fa-spinner fa-spin"></i> Uploading... } @else { <i class="fa fa-upload"></i> Upload }
                 </button>

--- a/Neptune.Web/src/app/pages/data-hub/wqmp-locations-upload/wqmp-locations-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/wqmp-locations-upload/wqmp-locations-upload.component.html
@@ -3,7 +3,7 @@
 </page-header>
 
 <ng-template #downloadTemplateButton>
-    <button type="button" class="btn btn-secondary" [disabled]="isDownloadingTemplate()" (click)="downloadTemplate()">
+    <button type="button" class="btn btn-primary-outline" [disabled]="isDownloadingTemplate()" (click)="downloadTemplate()">
         @if (isDownloadingTemplate()) { <i class="fa fa-spinner fa-spin"></i> Downloading... } @else { <i class="fa fa-download"></i> Download Template }
     </button>
 </ng-template>

--- a/Neptune.Web/src/app/pages/data-hub/wqmp-locations-upload/wqmp-locations-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/wqmp-locations-upload/wqmp-locations-upload.component.html
@@ -1,5 +1,9 @@
-<page-header pageTitle="Upload WQMP Locations from APN List" [templateRight]="downloadTemplateButton">
-    <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'wqmps' }">&laquo; Back to Data Hub</a>
+<page-header pageTitle="Upload WQMP Locations from APN List" [templateAbove]="templateAbove" [templateRight]="downloadTemplateButton">
+    <ng-template #templateAbove>
+        <div class="back">
+            <a [routerLink]="['/data-hub']" [queryParams]="{ tab: 'wqmps' }" class="back__link"><i class="fa fa-arrow-left"></i> Back to Data Hub</a>
+        </div>
+    </ng-template>
 </page-header>
 
 <ng-template #downloadTemplateButton>
@@ -16,34 +20,36 @@
             <custom-rich-text [customRichTextTypeID]="NeptunePageTypeEnum.WQMPBoundaryFromAPNList"></custom-rich-text>
         </div>
         <div class="g-col-6">
-            @if (jurisdictionOptions$ | async; as opts) {
-                <form-field fieldLabel="Stormwater Jurisdiction" [type]="FormFieldType.Select" [formControl]="jurisdictionControl" [formInputOptions]="opts" placeholder="Select a jurisdiction"></form-field>
-            }
-            <form-field fieldLabel="CSV File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".csv" (change)="onFileChange($event)"></form-field>
+            <div class="grid-12">
+                @if (jurisdictionOptions$ | async; as opts) {
+                    <form-field fieldLabel="Stormwater Jurisdiction" [type]="FormFieldType.Select" [formControl]="jurisdictionControl" [formInputOptions]="opts" placeholder="Select a jurisdiction"></form-field>
+                }
+                <form-field fieldLabel="CSV File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".csv" (change)="onFileChange($event)"></form-field>
 
-            @if (errors().length > 0) {
-                <div class="alert alert-danger upload-errors">
-                    <strong>Upload could not be completed:</strong>
-                    <ul>
-                        @for (err of errors(); track $index) {
-                            <li>{{ err }}</li>
-                        }
-                    </ul>
-                </div>
-            }
+                @if (errors().length > 0) {
+                    <div class="alert alert-danger upload-errors">
+                        <strong>Upload could not be completed:</strong>
+                        <ul>
+                            @for (err of errors(); track $index) {
+                                <li>{{ err }}</li>
+                            }
+                        </ul>
+                    </div>
+                }
 
-            @if (successMessage()) {
-                <div class="alert alert-success">{{ successMessage() }}</div>
-            }
+                @if (successMessage()) {
+                    <div class="alert alert-success">{{ successMessage() }}</div>
+                }
 
-            @if (missingApns().length > 0) {
-                <div class="alert alert-warning">
-                    <strong>The following APNs were not found in the system:</strong>
-                    <p>{{ missingApns().join(", ") }}</p>
-                </div>
-            }
+                @if (missingApns().length > 0) {
+                    <div class="alert alert-warning">
+                        <strong>The following APNs were not found in the system:</strong>
+                        <p>{{ missingApns().join(", ") }}</p>
+                    </div>
+                }
+            </div>
 
-            <div class="actions">
+            <div class="page-footer">
                 <button type="button" class="btn btn-primary" [disabled]="isUploading() || fileControl.invalid || jurisdictionControl.invalid" (click)="submit()">
                     @if (isUploading()) { <i class="fa fa-spinner fa-spin"></i> Uploading... } @else { <i class="fa fa-upload"></i> Upload }
                 </button>

--- a/Neptune.Web/src/app/pages/data-hub/wqmp-upload/wqmp-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/wqmp-upload/wqmp-upload.component.html
@@ -1,5 +1,9 @@
-<page-header pageTitle="Upload Water Quality Management Plans" [templateRight]="downloadTemplateButton">
-    <a class="back-link" [routerLink]="['/data-hub']" [queryParams]="{ tab: 'wqmps' }">&laquo; Back to Data Hub</a>
+<page-header pageTitle="Upload Water Quality Management Plans" [templateAbove]="templateAbove" [templateRight]="downloadTemplateButton">
+    <ng-template #templateAbove>
+        <div class="back">
+            <a [routerLink]="['/data-hub']" [queryParams]="{ tab: 'wqmps' }" class="back__link"><i class="fa fa-arrow-left"></i> Back to Data Hub</a>
+        </div>
+    </ng-template>
 </page-header>
 
 <ng-template #downloadTemplateButton>
@@ -16,27 +20,29 @@
             <custom-rich-text [customRichTextTypeID]="NeptunePageTypeEnum.UploadWQMPs"></custom-rich-text>
         </div>
         <div class="g-col-6">
-            @if (jurisdictionOptions$ | async; as opts) {
-                <form-field fieldLabel="Stormwater Jurisdiction" [type]="FormFieldType.Select" [formControl]="jurisdictionControl" [formInputOptions]="opts" placeholder="Select a jurisdiction"></form-field>
-            }
-            <form-field fieldLabel="XLSX File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".xlsx" (change)="onFileChange($event)"></form-field>
+            <div class="grid-12">
+                @if (jurisdictionOptions$ | async; as opts) {
+                    <form-field fieldLabel="Stormwater Jurisdiction" [type]="FormFieldType.Select" [formControl]="jurisdictionControl" [formInputOptions]="opts" placeholder="Select a jurisdiction"></form-field>
+                }
+                <form-field fieldLabel="XLSX File" [type]="FormFieldType.File" [formControl]="fileControl" uploadFileAccepts=".xlsx" (change)="onFileChange($event)"></form-field>
 
-            @if (errors().length > 0) {
-                <div class="alert alert-danger upload-errors">
-                    <strong>Upload could not be completed:</strong>
-                    <ul>
-                        @for (err of errors(); track $index) {
-                            <li>{{ err }}</li>
-                        }
-                    </ul>
-                </div>
-            }
+                @if (errors().length > 0) {
+                    <div class="alert alert-danger upload-errors">
+                        <strong>Upload could not be completed:</strong>
+                        <ul>
+                            @for (err of errors(); track $index) {
+                                <li>{{ err }}</li>
+                            }
+                        </ul>
+                    </div>
+                }
 
-            @if (successMessage()) {
-                <div class="alert alert-success">{{ successMessage() }}</div>
-            }
+                @if (successMessage()) {
+                    <div class="alert alert-success">{{ successMessage() }}</div>
+                }
+            </div>
 
-            <div class="actions">
+            <div class="page-footer">
                 <button type="button" class="btn btn-primary" [disabled]="isUploading() || fileControl.invalid || jurisdictionControl.invalid" (click)="submit()">
                     @if (isUploading()) { <i class="fa fa-spinner fa-spin"></i> Uploading... } @else { <i class="fa fa-upload"></i> Upload }
                 </button>

--- a/Neptune.Web/src/app/pages/data-hub/wqmp-upload/wqmp-upload.component.html
+++ b/Neptune.Web/src/app/pages/data-hub/wqmp-upload/wqmp-upload.component.html
@@ -3,7 +3,7 @@
 </page-header>
 
 <ng-template #downloadTemplateButton>
-    <button type="button" class="btn btn-secondary" [disabled]="isDownloadingTemplate()" (click)="downloadTemplate()">
+    <button type="button" class="btn btn-primary-outline" [disabled]="isDownloadingTemplate()" (click)="downloadTemplate()">
         @if (isDownloadingTemplate()) { <i class="fa fa-spinner fa-spin"></i> Downloading... } @else { <i class="fa fa-download"></i> Download Template }
     </button>
 </ng-template>

--- a/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.html
+++ b/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.html
@@ -83,7 +83,7 @@
                                 <div class="inline-actions">
                                     <button type="button" class="btn btn-sm btn-primary" [disabled]="!selectedFlowType" (click)="beginDelineate()">Delineate</button>
                                     @if (choosingFlowType()) {
-                                        <button type="button" class="btn btn-sm btn-secondary" (click)="closeFlowTypeChooser()">Cancel</button>
+                                        <button type="button" class="btn btn-sm btn-primary-outline" (click)="closeFlowTypeChooser()">Cancel</button>
                                     }
                                 </div>
                             }
@@ -98,7 +98,7 @@
                             </p>
                             <div class="inline-actions">
                                 <button type="button" class="btn btn-sm btn-primary" [disabled]="saving$ | async" (click)="saveEdit()">Save</button>
-                                <button type="button" class="btn btn-sm btn-secondary" (click)="cancelEdit()">Cancel</button>
+                                <button type="button" class="btn btn-sm btn-primary-outline" (click)="cancelEdit()">Cancel</button>
                             </div>
                             @if (mode === "editingCentralized") {
                                 <!-- NPT-981 r3 (KE id-22): offer Request Revision during the trace, not only

--- a/Neptune.Web/src/app/pages/delineation/delineation-reconciliation-report/delineation-reconciliation-report.component.ts
+++ b/Neptune.Web/src/app/pages/delineation/delineation-reconciliation-report/delineation-reconciliation-report.component.ts
@@ -101,7 +101,7 @@ export class DelineationReconciliationReportComponent implements OnInit {
             this.utility.createActionsColumnDef((params: any) => [
                 {
                     ActionName: "View on Map",
-                    ActionIcon: "fas fa-map-location-dot",
+                    ActionIcon: "fas fa-map-marked-alt",
                     ActionHandler: () =>
                         this.router.navigate(["/delineation/delineation-map"], { queryParams: { treatmentBMPID: params.data.TreatmentBMPID } }),
                 },
@@ -139,7 +139,7 @@ export class DelineationReconciliationReportComponent implements OnInit {
             this.utility.createActionsColumnDef((params: any) => [
                 {
                     ActionName: "View on Map",
-                    ActionIcon: "fas fa-map-location-dot",
+                    ActionIcon: "fas fa-map-marked-alt",
                     ActionHandler: () =>
                         this.router.navigate(["/delineation/delineation-map"], { queryParams: { treatmentBMPID: params.data.TreatmentBMPID } }),
                 },

--- a/Neptune.Web/src/app/pages/delineation/gdb-approve/gdb-approve.component.html
+++ b/Neptune.Web/src/app/pages/delineation/gdb-approve/gdb-approve.component.html
@@ -39,7 +39,7 @@
 
         <div class="actions">
           <button type="button" class="btn btn-primary" [disabled]="isWorking() || hasErrors()" (click)="approve()">Accept</button>
-          <button type="button" class="btn btn-secondary" [disabled]="isWorking()" (click)="cancel()">Cancel</button>
+          <button type="button" class="btn btn-primary-outline" [disabled]="isWorking()" (click)="cancel()">Cancel</button>
         </div>
       </div>
     </div>

--- a/Neptune.Web/src/app/pages/delineation/revision-requests/revision-request-detail.component.html
+++ b/Neptune.Web/src/app/pages/delineation/revision-requests/revision-request-detail.component.html
@@ -81,7 +81,7 @@
               <form-field [formControl]="closeNotesControl" [type]="FormFieldType.Textarea" fieldLabel="Close Notes"></form-field>
               <div class="actions">
                 <button type="button" class="btn btn-primary" [disabled]="saving$ | async" (click)="submitClose()">Save</button>
-                <button type="button" class="btn btn-secondary" (click)="cancelClose()">Cancel</button>
+                <button type="button" class="btn btn-primary-outline" (click)="cancelClose()">Cancel</button>
               </div>
             </div>
           </div>

--- a/Neptune.Web/src/app/pages/delineation/revision-requests/revision-request-new.component.html
+++ b/Neptune.Web/src/app/pages/delineation/revision-requests/revision-request-new.component.html
@@ -59,7 +59,7 @@
 
       <div class="actions">
         <button type="button" class="btn btn-primary" [disabled]="saving$ | async" (click)="submit()">Submit</button>
-        <button type="button" class="btn btn-secondary" (click)="cancel()">Cancel</button>
+        <button type="button" class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
       </div>
     </div>
   </div>

--- a/Neptune.Web/src/app/pages/field-definition-edit/field-definition-edit.component.html
+++ b/Neptune.Web/src/app/pages/field-definition-edit/field-definition-edit.component.html
@@ -7,7 +7,7 @@
       <i></i>
       <div>
         <button type="button" class="btn btn-primary mt-1 mr-1 mb-1" (click)="saveDefinition()" [disabled]="isLoadingSubmit">Save</button>
-        <a [routerLink]="['/labels-and-definitions']" class="btn btn-secondary mt-1 mb-1">Cancel</a>
+        <a [routerLink]="['/labels-and-definitions']" class="btn btn-primary-outline mt-1 mb-1">Cancel</a>
       </div>
     </div>
   </div>

--- a/Neptune.Web/src/app/pages/field-records/field-records.component.ts
+++ b/Neptune.Web/src/app/pages/field-records/field-records.component.ts
@@ -132,6 +132,7 @@ export class FieldRecordsComponent implements OnInit {
                 const actions: { ActionName: string; ActionIcon?: string; ActionLink?: string; ActionHandler?: () => void }[] = [
                     {
                         ActionName: editable ? "Continue" : "View",
+                        ActionIcon: editable ? "fas fa-edit" : "fas fa-file-alt",
                         ActionLink: editable
                             ? `/field-visits/${visit.FieldVisitID}`
                             : `/field-visits/${visit.FieldVisitID}/view`,
@@ -140,7 +141,7 @@ export class FieldRecordsComponent implements OnInit {
                 if (this.canManage) {
                     actions.push({
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.deleteFieldVisit(params),
                     });
                 }
@@ -180,6 +181,7 @@ export class FieldRecordsComponent implements OnInit {
                 return [
                     {
                         ActionName: row.IsFieldVisitVerified ? "View Observations" : "Edit Observations",
+                        ActionIcon: row.IsFieldVisitVerified ? "fas fa-file-alt" : "fas fa-edit",
                         ActionHandler: () => this.router.navigate(["/field-visits", row.FieldVisitID, branch, "observations"]),
                     },
                 ];
@@ -207,6 +209,7 @@ export class FieldRecordsComponent implements OnInit {
                 return [
                     {
                         ActionName: row.IsFieldVisitVerified ? "View" : "Edit",
+                        ActionIcon: row.IsFieldVisitVerified ? "fas fa-file-alt" : "fas fa-edit",
                         ActionHandler: () => this.router.navigate(["/field-visits", row.FieldVisitID, "maintenance", "edit"]),
                     },
                 ];

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-step/assessment-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/assessment-step/assessment-step.component.html
@@ -30,7 +30,7 @@
     </ul>
 
     <div class="step-footer">
-        <button type="button" class="btn btn-secondary" (click)="wrapUpVisit(workflow)">
+        <button type="button" class="btn btn-primary-outline" (click)="wrapUpVisit(workflow)">
             Wrap Up Visit <i class="fa fa-flag-checkered ml-2"></i>
         </button>
         @if (!isPostMaintenance) {

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/change-date-and-type-modal/change-date-and-type-modal.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/change-date-and-type-modal/change-date-and-type-modal.component.html
@@ -22,6 +22,6 @@
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-primary" (click)="save()">Save</button>
-        <button type="button" class="btn btn-secondary" (click)="cancel()">Cancel</button>
+        <button type="button" class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
     </div>
 </div>

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-attributes-step/inventory-attributes-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-attributes-step/inventory-attributes-step.component.html
@@ -8,10 +8,10 @@
         (saveError)="onSaveError()"></treatment-bmp-custom-attributes-form>
 
     <div class="step-footer">
-        <button type="button" class="btn btn-secondary" [disabled]="isSaving || editor?.formGroup?.invalid" (click)="saveAndWrapUp()">
+        <button type="button" class="btn btn-primary-outline" [disabled]="isSaving || editor?.formGroup?.invalid" (click)="saveAndWrapUp()">
             Save &amp; Wrap Up Visit <i class="fa fa-flag-checkered ml-2"></i>
         </button>
-        <button type="button" class="btn btn-secondary" [disabled]="isSaving || editor?.formGroup?.invalid" (click)="save()">Save</button>
+        <button type="button" class="btn btn-primary-outline" [disabled]="isSaving || editor?.formGroup?.invalid" (click)="save()">Save</button>
         <button type="button" class="btn btn-primary" [disabled]="isSaving || editor?.formGroup?.invalid" (click)="saveAndContinue()">
             Save &amp; Continue <i class="fa fa-caret-right ml-2"></i>
         </button>

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-location-step/inventory-location-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-location-step/inventory-location-step.component.html
@@ -7,10 +7,10 @@
         (saveError)="onSaveError()"></treatment-bmp-location-editor>
 
     <div class="step-footer">
-        <button type="button" class="btn btn-secondary" [disabled]="isSaving || editor?.formGroup?.invalid" (click)="saveAndWrapUp()">
+        <button type="button" class="btn btn-primary-outline" [disabled]="isSaving || editor?.formGroup?.invalid" (click)="saveAndWrapUp()">
             Save &amp; Wrap Up Visit <i class="fa fa-flag-checkered ml-2"></i>
         </button>
-        <button type="button" class="btn btn-secondary" [disabled]="isSaving || editor?.formGroup?.invalid" (click)="save()">Save</button>
+        <button type="button" class="btn btn-primary-outline" [disabled]="isSaving || editor?.formGroup?.invalid" (click)="save()">Save</button>
         <button type="button" class="btn btn-primary" [disabled]="isSaving || editor?.formGroup?.invalid" (click)="saveAndContinue()">
             Save &amp; Continue <i class="fa fa-caret-right ml-2"></i>
         </button>

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-photos-step/inventory-photos-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-photos-step/inventory-photos-step.component.html
@@ -8,7 +8,7 @@
         (captionUpdated)="onPhotosChanged(workflow)"></treatment-bmp-images-editor>
 
     <div class="step-footer">
-        <button type="button" class="btn btn-secondary" (click)="wrapUpVisit(workflow)">
+        <button type="button" class="btn btn-primary-outline" (click)="wrapUpVisit(workflow)">
             Wrap Up Visit <i class="fa fa-flag-checkered ml-2"></i>
         </button>
         <button type="button" class="btn btn-primary" (click)="continueToAttributes(workflow)">

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-step/inventory-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/inventory-step/inventory-step.component.html
@@ -16,7 +16,7 @@
     }
 
     <div class="step-footer">
-        <button type="button" class="btn btn-secondary" (click)="wrapUpVisit(workflow)">
+        <button type="button" class="btn btn-primary-outline" (click)="wrapUpVisit(workflow)">
             Wrap Up Visit <i class="fa fa-flag-checkered ml-2"></i>
         </button>
         <button type="button" class="btn btn-primary" (click)="skipToAssessment(workflow)">

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-edit-step/maintenance-edit-step.component.html
@@ -123,10 +123,10 @@
 
         @if (!isReadOnly()) {
             <div class="step-footer">
-                <button type="button" class="btn btn-secondary" [disabled]="formGroup.invalid || isSaving()" (click)="save(workflow, 'wrap-up')">
+                <button type="button" class="btn btn-primary-outline" [disabled]="formGroup.invalid || isSaving()" (click)="save(workflow, 'wrap-up')">
                     Save &amp; Wrap Up Visit <i class="fa fa-flag-checkered ml-2"></i>
                 </button>
-                <button type="button" class="btn btn-secondary" [disabled]="formGroup.invalid || isSaving()" (click)="save(workflow, 'stay')">Save</button>
+                <button type="button" class="btn btn-primary-outline" [disabled]="formGroup.invalid || isSaving()" (click)="save(workflow, 'stay')">Save</button>
                 <button type="button" class="btn btn-primary" [disabled]="formGroup.invalid || isSaving()" (click)="save(workflow, 'continue')">
                     Save &amp; Continue <i class="fa fa-caret-right ml-2"></i>
                 </button>

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-step/maintenance-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/maintenance-step/maintenance-step.component.html
@@ -8,7 +8,7 @@
     </p>
 
     <div class="step-footer">
-        <button type="button" class="btn btn-secondary" (click)="wrapUpVisit(workflow)">
+        <button type="button" class="btn btn-primary-outline" (click)="wrapUpVisit(workflow)">
             Wrap Up Visit <i class="fa fa-flag-checkered ml-2"></i>
         </button>
         <button type="button" class="btn btn-primary" (click)="skipToPostMaintenanceAssessment(workflow)">

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/observations-step/observations-step.component.html
@@ -16,7 +16,7 @@
 
         @if (isPostMaintenance && assessmentDetail.ObservationTypes.length > 0 && !isReadOnly()) {
             <div class="copy-from-initial">
-                <button type="button" class="btn btn-secondary" (click)="copyFromInitial(workflow)">
+                <button type="button" class="btn btn-primary-outline" (click)="copyFromInitial(workflow)">
                     Copy data from Initial Assessment
                 </button>
             </div>
@@ -28,10 +28,10 @@
 
         @if (!isReadOnly()) {
             <div class="step-footer">
-                <button type="button" class="btn btn-secondary" (click)="save(workflow, 'wrap-up')">
+                <button type="button" class="btn btn-primary-outline" (click)="save(workflow, 'wrap-up')">
                     Save &amp; Wrap Up Visit <i class="fa fa-flag-checkered ml-2"></i>
                 </button>
-                <button type="button" class="btn btn-secondary" (click)="save(workflow, 'stay')">Save</button>
+                <button type="button" class="btn btn-primary-outline" (click)="save(workflow, 'stay')">Save</button>
                 <button type="button" class="btn btn-primary" (click)="save(workflow, 'continue')">
                     Save &amp; Continue <i class="fa fa-caret-right ml-2"></i>
                 </button>

--- a/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/visit-summary-step/visit-summary-step.component.html
+++ b/Neptune.Web/src/app/pages/field-visits/field-visit-workflow-outlet/visit-summary-step/visit-summary-step.component.html
@@ -82,8 +82,8 @@
     @if (canManage) {
         <div class="step-footer">
             @if (workflow.IsFieldVisitVerified) {
-                <button type="button" class="btn btn-secondary" (click)="markProvisional(workflow)">Mark Provisional</button>
-                <button type="button" class="btn btn-secondary" (click)="returnToEdit(workflow)">Return to Edit</button>
+                <button type="button" class="btn btn-primary-outline" (click)="markProvisional(workflow)">Mark Provisional</button>
+                <button type="button" class="btn btn-primary-outline" (click)="returnToEdit(workflow)">Return to Edit</button>
             } @else {
                 <button type="button" class="btn btn-primary" (click)="verify(workflow)">Verify Field Visit</button>
             }

--- a/Neptune.Web/src/app/pages/funding-sources/funding-source-modal/funding-source-modal.component.html
+++ b/Neptune.Web/src/app/pages/funding-sources/funding-source-modal/funding-source-modal.component.html
@@ -15,6 +15,6 @@
     </div>
     <div class="modal-footer">
         <button class="btn btn-primary" (click)="save()">Save</button>
-        <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
+        <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
     </div>
 </div>

--- a/Neptune.Web/src/app/pages/funding-sources/funding-sources.component.ts
+++ b/Neptune.Web/src/app/pages/funding-sources/funding-sources.component.ts
@@ -41,12 +41,12 @@ export class FundingSourcesComponent {
             this.utilityFunctions.createActionsColumnDef((params: any) => [
                 {
                     ActionName: "Edit",
-                    ActionIcon: "fa fa-edit",
+                    ActionIcon: "fas fa-edit",
                     ActionHandler: () => this.openEditModal(params.data),
                 },
                 {
                     ActionName: "Delete",
-                    ActionIcon: "fa fa-trash text-danger",
+                    ActionIcon: "fas fa-trash text-danger",
                     ActionHandler: () => this.deleteFundingSource(params.data),
                 },
             ]),

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-basics-modal/jurisdiction-basics-modal.component.html
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-basics-modal/jurisdiction-basics-modal.component.html
@@ -25,6 +25,6 @@
     </div>
     <div class="modal-footer">
         <button class="btn btn-primary" (click)="save()" [disabled]="formGroup.invalid || isSaving">Save</button>
-        <button class="btn btn-secondary" (click)="cancel()" [disabled]="isSaving">Cancel</button>
+        <button class="btn btn-primary-outline" (click)="cancel()" [disabled]="isSaving">Cancel</button>
     </div>
 </div>

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-detail.component.html
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-detail.component.html
@@ -9,14 +9,10 @@
 <app-alert-display></app-alert-display>
 <div class="grid-12">
     <div class="card">
-        <div class="card-header" style="display: flex; justify-content: space-between">
+        <div class="card-header">
             <span class="card-title">Basics</span>
             @if (canManage) {
-                <span class="card-actions">
-                    <a style="cursor: pointer" (click)="openBasicsModal()">
-                        <icon class="icon-button" icon="CirclePencil"></icon>
-                    </a>
-                </span>
+                <button type="button" class="btn btn-primary btn-sm" (click)="openBasicsModal()">Edit</button>
             }
         </div>
         <div class="card-body">
@@ -29,14 +25,10 @@
         </div>
     </div>
     <div class="card">
-        <div class="card-header" style="display: flex; justify-content: space-between">
+        <div class="card-header">
             <span class="card-title">Users Assigned to {{ jurisdiction.StormwaterJurisdictionName }}</span>
             @if (canManage) {
-                <span class="card-actions">
-                    <a style="cursor: pointer" (click)="openUsersModal()">
-                        <icon class="icon-button" icon="CirclePencil"></icon>
-                    </a>
-                </span>
+                <button type="button" class="btn btn-primary btn-sm" (click)="openUsersModal()">Edit</button>
             }
         </div>
         <div class="card-body">

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-detail.component.ts
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-detail.component.ts
@@ -12,7 +12,6 @@ import { AlertService } from "src/app/shared/services/alert.service";
 import { Alert } from "src/app/shared/models/alert";
 import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 import { NeptuneGridComponent } from "src/app/shared/components/neptune-grid/neptune-grid.component";
-import { IconComponent } from "src/app/shared/components/icon/icon.component";
 import { PersonDisplayDto, StormwaterJurisdictionGridDto, TreatmentBMPGridDto } from "src/app/shared/generated/model/models";
 import { StormwaterJurisdictionService } from "src/app/shared/generated/api/stormwater-jurisdiction.service";
 import { JurisdictionBasicsModalComponent, JurisdictionBasicsModalContext } from "./jurisdiction-basics-modal/jurisdiction-basics-modal.component";
@@ -23,7 +22,7 @@ import { JurisdictionUsersModalComponent, JurisdictionUsersModalContext } from "
     templateUrl: "./jurisdiction-detail.component.html",
     styleUrls: ["./jurisdiction-detail.component.scss"],
     standalone: true,
-    imports: [CommonModule, RouterLink, AsyncPipe, PageHeaderComponent, AlertDisplayComponent, NeptuneGridComponent, IconComponent],
+    imports: [CommonModule, RouterLink, AsyncPipe, PageHeaderComponent, AlertDisplayComponent, NeptuneGridComponent],
 })
 export class JurisdictionDetailComponent implements OnInit, OnChanges {
     private dialogService = inject(DialogService);

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.html
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.html
@@ -41,6 +41,6 @@
         <button type="button" class="btn btn-primary" [disabled]="isSaving()" (click)="save()">
             @if (isSaving()) { <i class="fa fa-spinner fa-spin"></i> Saving... } @else { Save }
         </button>
-        <button type="button" class="btn btn-secondary" [disabled]="isSaving()" (click)="cancel()">Cancel</button>
+        <button type="button" class="btn btn-primary-outline" [disabled]="isSaving()" (click)="cancel()">Cancel</button>
     </div>
 </div>

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-edit/custom-attribute-type-edit.component.html
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-edit/custom-attribute-type-edit.component.html
@@ -73,7 +73,7 @@
                                             </button>
                                         } @else {
                                             <span class="options-editor__text">{{ option }}</span>
-                                            <button type="button" class="btn btn-sm btn-secondary-outline" (click)="startEditOption($index)" [attr.aria-label]="'Edit option ' + option" title="Edit">
+                                            <button type="button" class="btn btn-sm btn-primary-outline" (click)="startEditOption($index)" [attr.aria-label]="'Edit option ' + option" title="Edit">
                                                 <i class="fa fa-pencil"></i>
                                             </button>
                                             <button type="button" class="btn-delete-row" (click)="removeOption($index)" [attr.aria-label]="'Delete option ' + option" title="Delete"></button>

--- a/Neptune.Web/src/app/pages/manage/custom-attribute-type-edit/custom-attribute-type-edit.component.html
+++ b/Neptune.Web/src/app/pages/manage/custom-attribute-type-edit/custom-attribute-type-edit.component.html
@@ -35,17 +35,17 @@
                             </form-field>
                             <form-field class="g-col-6" [formControl]="formGroup.controls.MeasurementUnitTypeID"
                                 fieldLabel="Measurement Unit" [type]="FormFieldType.Select"
-                                placeholder="Select Unit (optional)" [formInputOptions]="unitOptions">
+                                placeholder="Select Unit" [formInputOptions]="unitOptions">
                             </form-field>
                             <form-field class="g-col-6" [formControl]="formGroup.controls.IsRequired"
                                 fieldLabel="Is Required" [type]="FormFieldType.Select"
                                 [formInputOptions]="booleanOptions">
                             </form-field>
                             <form-field class="g-col-12" [formControl]="formGroup.controls.CustomAttributeTypeDescription"
-                                fieldLabel="Description" [type]="FormFieldType.Textarea" placeholder="Description (optional)">
+                                fieldLabel="Description" [type]="FormFieldType.Textarea" placeholder="Description">
                             </form-field>
                             <form-field class="g-col-12" [formControl]="formGroup.controls.CustomAttributeTypeDefaultValue"
-                                fieldLabel="Default Value" [type]="FormFieldType.Text" placeholder="Default value (optional)">
+                                fieldLabel="Default Value" [type]="FormFieldType.Text" placeholder="Default value">
                             </form-field>
                         </div>
                     </div>
@@ -68,7 +68,7 @@
                                             <button type="button" class="btn btn-sm btn-primary" (click)="saveOptionEdit($index)" title="Save">
                                                 <i class="fa fa-check"></i>
                                             </button>
-                                            <button type="button" class="btn btn-sm btn-secondary-outline" (click)="cancelOptionEdit()" title="Cancel">
+                                            <button type="button" class="btn btn-sm btn-primary-outline" (click)="cancelOptionEdit()" title="Cancel">
                                                 <i class="fa fa-times"></i>
                                             </button>
                                         } @else {
@@ -98,7 +98,7 @@
 
         <div class="page-footer">
             <button type="button" class="btn btn-primary" (click)="save()" [disabled]="isSaving() || formGroup.invalid">Save</button>
-            <button type="button" class="btn btn-secondary-outline" (click)="cancel()" [disabled]="isSaving()">Cancel</button>
+            <button type="button" class="btn btn-primary-outline" (click)="cancel()" [disabled]="isSaving()">Cancel</button>
         </div>
     </div>
 } @else {

--- a/Neptune.Web/src/app/pages/manage/custom-attributes.component.ts
+++ b/Neptune.Web/src/app/pages/manage/custom-attributes.component.ts
@@ -83,6 +83,7 @@ export class CustomAttributesComponent implements OnInit {
                 const actions: any[] = [
                     {
                         ActionName: "View",
+                        ActionIcon: "fas fa-file-alt",
                         ActionHandler: () => this.router.navigate(["/manage/custom-attributes", id]),
                     },
                     {
@@ -94,7 +95,7 @@ export class CustomAttributesComponent implements OnInit {
                 if (!isModeling) {
                     actions.push({
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.confirmDelete(row),
                     });
                 }

--- a/Neptune.Web/src/app/pages/manage/observation-type-edit/observation-type-edit.component.html
+++ b/Neptune.Web/src/app/pages/manage/observation-type-edit/observation-type-edit.component.html
@@ -91,7 +91,7 @@
 
         <div class="page-footer">
             <button type="button" class="btn btn-primary" (click)="save()" [disabled]="isSaving() || formGroup.invalid || !derivedSpecID() || (activeSchemaGroup() && activeSchemaGroup()!.invalid)">Save</button>
-            <button type="button" class="btn btn-secondary-outline" (click)="cancel()" [disabled]="isSaving()">Cancel</button>
+            <button type="button" class="btn btn-primary-outline" (click)="cancel()" [disabled]="isSaving()">Cancel</button>
         </div>
     </div>
 } @else {

--- a/Neptune.Web/src/app/pages/manage/observation-types-manage.component.ts
+++ b/Neptune.Web/src/app/pages/manage/observation-types-manage.component.ts
@@ -69,6 +69,7 @@ export class ObservationTypesManageComponent implements OnInit {
                 return [
                     {
                         ActionName: "View",
+                        ActionIcon: "fas fa-file-alt",
                         ActionHandler: () => this.router.navigate(["/program-info/observation-types", id]),
                     },
                     {
@@ -78,7 +79,7 @@ export class ObservationTypesManageComponent implements OnInit {
                     },
                     {
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.confirmDelete(row),
                     },
                 ];

--- a/Neptune.Web/src/app/pages/manage/treatment-bmp-type-edit/treatment-bmp-type-edit.component.html
+++ b/Neptune.Web/src/app/pages/manage/treatment-bmp-type-edit/treatment-bmp-type-edit.component.html
@@ -212,7 +212,7 @@
         <!-- Actions -->
         <div class="page-footer">
             <button class="btn btn-primary" (click)="save()" [disabled]="isSaving">Save</button>
-            <button class="btn btn-secondary-outline" (click)="cancel()">Cancel</button>
+            <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
             @if (!isCreate) {
                 <button class="btn btn-danger-outline" (click)="deleteBMPType()" style="margin-left: auto">
                     Delete

--- a/Neptune.Web/src/app/pages/manage/treatment-bmp-types-manage.component.ts
+++ b/Neptune.Web/src/app/pages/manage/treatment-bmp-types-manage.component.ts
@@ -70,6 +70,7 @@ export class TreatmentBmpTypesManageComponent implements OnInit {
                 return [
                     {
                         ActionName: "View",
+                        ActionIcon: "fas fa-file-alt",
                         ActionHandler: () => this.router.navigate(["/program-info/treatment-bmp-types", id]),
                     },
                     {
@@ -79,7 +80,7 @@ export class TreatmentBmpTypesManageComponent implements OnInit {
                     },
                     {
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.confirmDelete(row),
                     },
                 ];

--- a/Neptune.Web/src/app/pages/organizations/organization-modal/organization-modal.component.html
+++ b/Neptune.Web/src/app/pages/organizations/organization-modal/organization-modal.component.html
@@ -35,6 +35,6 @@
     </div>
     <div class="modal-footer">
         <button class="btn btn-primary" (click)="save()" [disabled]="formGroup.invalid">Save</button>
-        <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
+        <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
     </div>
 </div>

--- a/Neptune.Web/src/app/pages/organizations/organizations.component.ts
+++ b/Neptune.Web/src/app/pages/organizations/organizations.component.ts
@@ -42,12 +42,12 @@ export class OrganizationsComponent {
             this.utilityFunctions.createActionsColumnDef((params: any) => [
                 {
                     ActionName: "Edit",
-                    ActionIcon: "fa fa-edit",
+                    ActionIcon: "fas fa-edit",
                     ActionHandler: () => this.openEditModal(params.data),
                 },
                 {
                     ActionName: "Delete",
-                    ActionIcon: "fa fa-trash text-danger",
+                    ActionIcon: "fas fa-trash text-danger",
                     ActionHandler: () => this.deleteOrganization(params.data),
                 },
             ]),

--- a/Neptune.Web/src/app/pages/planning-module/grant-programs/octa-m2-tier2-dashboard/octa-m2-tier2-dashboard.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/grant-programs/octa-m2-tier2-dashboard/octa-m2-tier2-dashboard.component.html
@@ -158,7 +158,7 @@
                     <a
                         href="javascript:void(0);"
                         [dropdownToggle]="downloadMenuToggle"
-                        class="btn btn-sm btn-secondary-outline dropdown-toggle"
+                        class="btn btn-sm btn-primary-outline dropdown-toggle"
                         role="button"
                         data-toggle="dropdown"
                         aria-haspopup="true"

--- a/Neptune.Web/src/app/pages/planning-module/project-workflow/delineations/delineations.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/project-workflow/delineations/delineations.component.html
@@ -132,6 +132,6 @@
 </workflow-body>
 
 <div class="page-footer">
-    <button class="btn btn-primary mr-2" (click)="save()" [disabled]="(isLoadingSubmit$ | async) ?? false">Save</button>
-    <button class="btn btn-primary-outline ml-auto" (click)="save(true)" [disabled]="(isLoadingSubmit$ | async) ?? false">Save & Continue</button>
+    <button class="btn btn-primary-outline mr-2" (click)="save()" [disabled]="(isLoadingSubmit$ | async) ?? false">Save</button>
+    <button class="btn btn-primary ml-auto" (click)="save(true)" [disabled]="(isLoadingSubmit$ | async) ?? false">Save & Continue</button>
 </div>

--- a/Neptune.Web/src/app/pages/planning-module/project-workflow/project-attachments/project-attachments.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/project-workflow/project-attachments/project-attachments.component.html
@@ -132,7 +132,7 @@
                         }
                         Save
                     </button>
-                    <button type="button" class="btn btn-secondary" (click)="closeEditAttachmentModal()">Cancel</button>
+                    <button type="button" class="btn btn-primary-outline" (click)="closeEditAttachmentModal()">Cancel</button>
                 </div>
             </form>
         </div>

--- a/Neptune.Web/src/app/pages/planning-module/project-workflow/project-attachments/project-attachments.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/project-workflow/project-attachments/project-attachments.component.html
@@ -70,7 +70,7 @@
                                 }
                                 Save
                             </button>
-                            <button type="reset" class="btn btn-secondary" [disabled]="isLoadingSubmit" (click)="resetAttachmentForm(addAttachmentForm)">
+                            <button type="reset" class="btn btn-primary-outline" [disabled]="isLoadingSubmit" (click)="resetAttachmentForm(addAttachmentForm)">
                                 @if (isLoadingSubmit) {
                                     <span class="fa fa-spinner loading-spinner"></span>
                                 }

--- a/Neptune.Web/src/app/pages/planning-module/project-workflow/project-basics/project-basics.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/project-workflow/project-basics/project-basics.component.html
@@ -56,6 +56,6 @@
 }
 
 <div class="page-footer">
-  <button class="btn btn-primary mr-2" (click)="save()" [disabled]="formGroup.invalid || isLoadingSubmit">Save</button>
-  <button class="btn btn-primary-outline ml-auto" (click)="save(true)" [disabled]="formGroup.invalid || isLoadingSubmit">Save & Continue</button>
+  <button class="btn btn-primary-outline mr-2" (click)="save()" [disabled]="formGroup.invalid || isLoadingSubmit">Save</button>
+  <button class="btn btn-primary ml-auto" (click)="save(true)" [disabled]="formGroup.invalid || isLoadingSubmit">Save & Continue</button>
 </div>

--- a/Neptune.Web/src/app/pages/planning-module/project-workflow/treatment-bmps/treatment-bmps.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/project-workflow/treatment-bmps/treatment-bmps.component.html
@@ -227,7 +227,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" (click)="changeTreatmentBMPType(selectedTreatmentBMPType)">Update</button>
-                <button type="button" class="btn btn-secondary" (click)="closeEditTreatmentBMPTypeModal()">Cancel</button>
+                <button type="button" class="btn btn-primary-outline" (click)="closeEditTreatmentBMPTypeModal()">Cancel</button>
             </div>
         </div>
     </ng-template>

--- a/Neptune.Web/src/app/pages/planning-module/project-workflow/treatment-bmps/treatment-bmps.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/project-workflow/treatment-bmps/treatment-bmps.component.html
@@ -59,7 +59,7 @@
                             @if (selectedTreatmentBMP.TreatmentBMPID > 0) {
                                 <div>
                                     {{ getTypeNameByTypeID(selectedTreatmentBMP.TreatmentBMPTypeID) }}
-                                    <button class="btn btn-sm btn-secondary l-2" (click)="openEditTreatmentBMPTypeModal()">Change Type</button>
+                                    <button class="btn btn-sm btn-primary-outline l-2" (click)="openEditTreatmentBMPTypeModal()">Change Type</button>
                                 </div>
                             } @else {
                                 <select name="type" [(ngModel)]="selectedTreatmentBMP.TreatmentBMPTypeID" (change)="updateModelingAttributesForSelectedTreatmentBMP()" required>
@@ -234,6 +234,6 @@
 </workflow-body>
 
 <div class="page-footer">
-    <button class="btn btn-primary mr-2" (click)="save()" [disabled]="(isLoadingSubmit$ | async) ?? false">Save</button>
-    <button class="btn btn-primary-outline ml-auto" (click)="save(true)" [disabled]="(isLoadingSubmit$ | async) ?? false">Save & Continue</button>
+    <button class="btn btn-primary-outline mr-2" (click)="save()" [disabled]="(isLoadingSubmit$ | async) ?? false">Save</button>
+    <button class="btn btn-primary ml-auto" (click)="save(true)" [disabled]="(isLoadingSubmit$ | async) ?? false">Save & Continue</button>
 </div>

--- a/Neptune.Web/src/app/pages/planning-module/projects/attachments-display/attachments-display.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/projects/attachments-display/attachments-display.component.html
@@ -4,19 +4,17 @@
     <div class="g-col-6">
         <div class="card">
             <div class="card-header">
-                <div class="grid-12">
-                    <div class="g-col-10 card-header-name">
-                        {{ attachment.DisplayName }}
-                    </div>
-                    @if (!readOnly) {
-                    <div class="g-col-2">
-                        <button type="button" class="btn-delete-row ml-3" aria-label="Delete attachment" title="Delete" (click)="emitDeleteAttachmentTriggered(attachment.ProjectDocumentID)"></button>
-                        <span class="ml-3" style="cursor: pointer" (click)="emitEditAttachmentTriggered(attachment)">
-                            <i class="fa fa-edit"></i>
-                        </span>
-                    </div>
-                    }
-                </div>
+                <span class="card-title card-header-name">{{ attachment.DisplayName }}</span>
+                @if (!readOnly) {
+                <span class="attachment-actions">
+                    <button type="button" class="btn btn-sm btn-primary-outline btn-icon" title="Edit attachment" aria-label="Edit attachment" (click)="emitEditAttachmentTriggered(attachment)">
+                        <i class="fa fa-pencil"></i>
+                    </button>
+                    <button type="button" class="btn btn-sm btn-danger-outline btn-icon" title="Delete attachment" aria-label="Delete attachment" (click)="emitDeleteAttachmentTriggered(attachment.ProjectDocumentID)">
+                        <i class="fa fa-trash"></i>
+                    </button>
+                </span>
+                }
             </div>
             <div class="card-body">
                 <div class="grid-12">

--- a/Neptune.Web/src/app/pages/planning-module/projects/attachments-display/attachments-display.component.scss
+++ b/Neptune.Web/src/app/pages/planning-module/projects/attachments-display/attachments-display.component.scss
@@ -1,0 +1,9 @@
+@use "/src/scss/abstracts" as *;
+
+// Edit/Delete actions: grouped on one line, matching the WQMP detail document icon buttons
+// (edit = btn-primary-outline, delete = btn-danger-outline, icon-only square).
+.attachment-actions {
+    display: inline-flex;
+    gap: $spacing-200;
+    flex-shrink: 0;
+}

--- a/Neptune.Web/src/app/pages/planning-module/projects/project-list/project-list.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/projects/project-list/project-list.component.html
@@ -8,6 +8,7 @@
                 [rowData]="projects$ | async"
                 [columnDefs]="projectColumnDefs"
                 rowSelection="single"
+                [sizeColumnsToFitGrid]="true"
                 (gridReady)="onGridReady($event)"
                 [pagination]="true"
                 downloadFileName="projects">

--- a/Neptune.Web/src/app/pages/planning-module/projects/project-list/project-list.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/projects/project-list/project-list.component.html
@@ -1,5 +1,8 @@
 <div>
-    <page-header pageTitle="Projects" [customRichTextTypeID]="richTextTypeID"></page-header>
+    <page-header pageTitle="Projects" [customRichTextTypeID]="richTextTypeID" [templateRight]="headerActions"></page-header>
+    <ng-template #headerActions>
+        <a class="btn btn-orange" [routerLink]="['/planning/projects/new']"><i class="fa fa-plus"></i> Add New Project</a>
+    </ng-template>
 
     <div class="page-body">
         <div class="all-users">
@@ -13,7 +16,6 @@
                 [pagination]="true"
                 downloadFileName="projects">
                 <div customGridActionsRight class="custom-grid-actions">
-                    <a class="btn btn-sm btn-orange" [routerLink]="['/planning/projects/new']"> <i class="fa fa-plus"></i> &nbsp; Add New Project </a>
                     <a
                         href="javascript:void(0);"
                         [dropdownToggle]="downloadMenuToggle"

--- a/Neptune.Web/src/app/pages/planning-module/projects/project-list/project-list.component.ts
+++ b/Neptune.Web/src/app/pages/planning-module/projects/project-list/project-list.component.ts
@@ -98,9 +98,9 @@ export class ProjectListComponent implements OnInit {
             this.utilityFunctionsService.createLinkColumnDef("Organization", "Organization.OrganizationName", "Organization.OrganizationID", {
                 InRouterLink: "/organizations/",
             }),
-            this.utilityFunctionsService.createBasicColumnDef("Jurisdiction", "StormwaterJurisdiction.Organization.OrganizationName"),
+            this.utilityFunctionsService.createBasicColumnDef("Jurisdiction", "StormwaterJurisdiction.StormwaterJurisdictionName"),
             this.utilityFunctionsService.createDateColumnDef("Date Created", "DateCreated", "M/d/yyyy", { Width: 120 }),
-            this.utilityFunctionsService.createBasicColumnDef("Project Description", "ProjectDescription"),
+            this.utilityFunctionsService.createBasicColumnDef("Project Description", "ProjectDescription", { MaxWidth: 400 }),
             {
                 headerName: "Shared with OCTA M2 Tier 2 Grant Program",
                 valueGetter: (params) => (params.data.ShareOCTAM2Tier2Scores ? "Yes" : "No"),

--- a/Neptune.Web/src/app/pages/planning-module/projects/project-list/project-list.component.ts
+++ b/Neptune.Web/src/app/pages/planning-module/projects/project-list/project-list.component.ts
@@ -79,14 +79,14 @@ export class ProjectListComponent implements OnInit {
         this.projectColumnDefs = [
             this.utilityFunctionsService.createActionsColumnDef((params: any) => {
                 return [
-                    { ActionName: "View", ActionHandler: () => this.router.navigate(["planning", "projects", params.data.ProjectID]) },
+                    { ActionName: "View", ActionIcon: "fas fa-file-alt", ActionHandler: () => this.router.navigate(["planning", "projects", params.data.ProjectID]) },
                     {
                         ActionName: "Edit",
                         ActionIcon: "fas fa-edit",
                         ActionHandler: () =>
                             this.router.navigateByUrl(`/planning/projects/edit/${params.data.ProjectID + (params.data.ShareOCTAM2Tier2Scores ? "/review-and-share" : "")}`),
                     },
-                    { ActionName: "Delete", ActionIcon: "fa fa-trash text-danger", ActionHandler: () => this.deleteModal(params) },
+                    { ActionName: "Delete", ActionIcon: "fas fa-trash text-danger", ActionHandler: () => this.deleteModal(params) },
                 ];
             }),
             this.utilityFunctionsService.createLinkColumnDef("Project ID", "ProjectID", "ProjectID", {

--- a/Neptune.Web/src/app/pages/program-info/observation-type-detail/observation-type-detail.component.html
+++ b/Neptune.Web/src/app/pages/program-info/observation-type-detail/observation-type-detail.component.html
@@ -10,7 +10,7 @@
         </ng-template>
         <ng-template #templateRight>
             @if (isAdmin) {
-                <button type="button" class="btn btn-secondary-outline" title="Preview what the Observation Type will look like in a Treatment BMP Assessment form" (click)="openPreview(vm)">
+                <button type="button" class="btn btn-primary-outline" title="Preview what the Observation Type will look like in a Treatment BMP Assessment form" (click)="openPreview(vm)">
                     <i class="fa fa-eye"></i> Preview
                 </button>
                 <button type="button" class="btn btn-primary-outline ml-2" (click)="openEdit()">

--- a/Neptune.Web/src/app/pages/program-info/treatment-bmp-type-detail/treatment-bmp-type-detail.component.ts
+++ b/Neptune.Web/src/app/pages/program-info/treatment-bmp-type-detail/treatment-bmp-type-detail.component.ts
@@ -164,18 +164,19 @@ export class TreatmentBmpTypeDetailComponent implements OnInit {
             const actions: { ActionName: string; ActionIcon?: string; ActionHandler: () => void }[] = [
                 {
                     ActionName: "View",
+                    ActionIcon: "fas fa-file-alt",
                     ActionHandler: () => this.router.navigate(["/treatment-bmps", params.data.TreatmentBMPID]),
                 },
             ];
             if (canEdit) {
                 actions.push({
                     ActionName: "Edit",
-                    ActionIcon: "fa fa-pencil",
+                    ActionIcon: "fas fa-edit",
                     ActionHandler: () => this.router.navigate(["/treatment-bmps", params.data.TreatmentBMPID, "edit-basic-info"]),
                 });
                 actions.push({
                     ActionName: "Delete",
-                    ActionIcon: "fa fa-trash text-danger",
+                    ActionIcon: "fas fa-trash text-danger",
                     ActionHandler: () => this.deleteBMP(params),
                 });
             }

--- a/Neptune.Web/src/app/pages/support/request-support/request-support.component.html
+++ b/Neptune.Web/src/app/pages/support/request-support/request-support.component.html
@@ -79,7 +79,7 @@
             <button type="button" class="btn btn-primary" [disabled]="isSubmitting() || formGroup.invalid" (click)="submit()">
                 @if (isSubmitting()) { <i class="fa fa-spinner fa-spin"></i> Sending... } @else { Submit Request }
             </button>
-            <a class="btn btn-secondary" [routerLink]="['/']">Cancel</a>
+            <a class="btn btn-primary-outline" [routerLink]="['/']">Cancel</a>
         </div>
     }
 </section>

--- a/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-initiate-ovta/trash-initiate-ovta.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovta-workflow/trash-initiate-ovta/trash-initiate-ovta.component.html
@@ -45,5 +45,5 @@
     </form>
 </workflow-body>
 <div class="page-footer">
-    <button class="btn btn-primary-outline ml-auto" (click)="save(true)" [disabled]="formGroup.invalid || isLoadingSubmit">Save & Continue</button>
+    <button class="btn btn-primary ml-auto" (click)="save(true)" [disabled]="formGroup.invalid || isLoadingSubmit">Save & Continue</button>
 </div>

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.html
@@ -48,7 +48,7 @@
               </dd>
               <dt class="g-col-4"><field-definition fieldDefinitionType="BaselineScore"></field-definition></dt>
               <dd class="g-col-8">
-                {{ onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentBaselineScoreName ?? "Not enough completed asssessments" }} @if (onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentBaselineScoreTrashGenerationRate) { ({{onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentBaselineScoreTrashGenerationRate}} gal/ac/yr)}
+                {{ onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentBaselineScoreName ?? "Not enough completed assessments" }} @if (onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentBaselineScoreTrashGenerationRate) { ({{onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentBaselineScoreTrashGenerationRate}} gal/ac/yr)}
               </dd>
               <dt class="g-col-4"><field-definition fieldDefinitionType="ProgressScore"></field-definition></dt>
               <dd class="g-col-8">

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
@@ -81,7 +81,7 @@ export class TrashOvtaAreaDetailComponent {
         this.ovtaColumnDefs = [
             this.utilityFunctionsService.createActionsColumnDef((params: any) => {
                 const actions = [
-                    { ActionName: "View", ActionHandler: () => this.router.navigate(["trash", "onland-visual-trash-assessments", params.data.OnlandVisualTrashAssessmentID]) },
+                    { ActionName: "View", ActionIcon: "fas fa-file-alt", ActionHandler: () => this.router.navigate(["trash", "onland-visual-trash-assessments", params.data.OnlandVisualTrashAssessmentID]) },
                     {
                         ActionName: params.data.OnlandVisualTrashAssessmentStatusID == OnlandVisualTrashAssessmentStatusEnum.Complete ? "Return to Edit" : "Edit",
                         ActionIcon: "fas fa-edit",

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-index/trash-ovta-area-index.component.ts
@@ -61,18 +61,24 @@ export class TrashOvtaAreaIndexComponent {
         this.ovtaAreaColumnDefs = [
             this.utilityFunctionsService.createActionsColumnDef((params: any) => {
                 const totalAssessments = (params.data.NumberOfAssessmentsInProgress ?? 0) + (params.data.NumberOfAssessmentsCompleted ?? 0);
+                // Action menus standardize on always showing an icon, using the canonical icon-per-verb mapping.
+                // NOTE: the app loads FontAwesome 4.7 (scss) + 5.2 (cdn) — use FA5 glyph names (e.g. fa-file-alt,
+                // not the FA6 fa-file-lines). View => fa-file-alt, add/new => fa-plus, Delete => fa-trash text-danger.
                 return [
                     {
                         ActionName: "View",
+                        ActionIcon: "fas fa-file-alt",
                         ActionHandler: () => this.router.navigate(["trash", "onland-visual-trash-assessment-areas", params.data.OnlandVisualTrashAssessmentAreaID]),
                     },
                     {
                         ActionName: "Add New OVTA",
+                        ActionIcon: "fas fa-plus",
                         ActionHandler: () =>
                             this.addNewOVTA(params.data.OnlandVisualTrashAssessmentAreaID, params.data.OnlandVisualTrashAssessmentAreaName, params.data.StormwaterJurisdictionID),
                     },
                     {
                         ActionName: "Delete",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () =>
                             this.deleteOVTAArea(params.data.OnlandVisualTrashAssessmentAreaID, params.data.OnlandVisualTrashAssessmentAreaName, totalAssessments),
                     },

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-index/trash-ovta-index.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-index/trash-ovta-index.component.ts
@@ -48,7 +48,7 @@ export class TrashOvtaIndexComponent {
         this.ovtaColumnDefs = [
             this.utilityFunctionsService.createActionsColumnDef((params: any) => {
                 return [
-                    { ActionName: "View", ActionHandler: () => this.router.navigate(["trash", "onland-visual-trash-assessments", params.data.OnlandVisualTrashAssessmentID]) },
+                    { ActionName: "View", ActionIcon: "fas fa-file-alt", ActionHandler: () => this.router.navigate(["trash", "onland-visual-trash-assessments", params.data.OnlandVisualTrashAssessmentID]) },
                     {
                         ActionName: params.data.OnlandVisualTrashAssessmentStatusID == OnlandVisualTrashAssessmentStatusEnum.Complete ? "Return to Edit" : "Edit",
                         ActionIcon: "fas fa-edit",
@@ -59,6 +59,7 @@ export class TrashOvtaIndexComponent {
                     },
                     {
                         ActionName: "Delete",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () =>
                             this.deleteOVTA(
                                 params.data.OnlandVisualTrashAssessmentID,

--- a/Neptune.Web/src/app/pages/treatment-bmps/create-treatment-bmp/create-treatment-bmp.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/create-treatment-bmp/create-treatment-bmp.component.html
@@ -152,5 +152,5 @@
 
 <div class="page-footer">
     <button class="btn btn-primary mr-2" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
-    <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
+    <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
 </div>

--- a/Neptune.Web/src/app/pages/treatment-bmps/create-treatment-bmp/create-treatment-bmp.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/create-treatment-bmp/create-treatment-bmp.component.html
@@ -8,149 +8,148 @@
 
 <app-alert-display></app-alert-display>
 
-<form [formGroup]="formGroup" class="grid-12">
-    <form-field class="g-col-6" size="md" [formControl]="formGroup.controls.TreatmentBMPName" fieldLabel="BMP Name" [type]="FormFieldType.Text" placeholder="Name"></form-field>
+<form [formGroup]="formGroup">
+    <h4 class="module-title">Details</h4>
+    <div class="grid-12">
+        <form-field class="g-col-6" size="md" [formControl]="formGroup.controls.TreatmentBMPName" fieldLabel="BMP Name" [type]="FormFieldType.Text" placeholder="Name"></form-field>
 
-    <form-field
-        class="g-col-6"
-        size="md"
-        [formControl]="formGroup.controls.TreatmentBMPTypeID"
-        fieldLabel="BMP Type"
-        [type]="FormFieldType.Select"
-        [formInputOptions]="treatmentBMPTypeSelectOptions$ | async"
-        placeholder="Select BMP Type">
-    </form-field>
-
-    <form-field
-        class="g-col-6"
-        size="md"
-        [formControl]="formGroup.controls.StormwaterJurisdictionID"
-        fieldLabel="Stormwater Jurisdiction"
-        [type]="FormFieldType.Select"
-        [formInputOptions]="stormwaterJurisdictionSelectOptions$ | async"
-        placeholder="Select Jurisdiction">
-    </form-field>
-
-    <form-field
-        class="g-col-6"
-        size="md"
-        [formControl]="formGroup.controls.OwnerOrganizationID"
-        fieldLabel="Owner Organization"
-        [type]="FormFieldType.Select"
-        [formInputOptions]="organizationSelectOptions$ | async"
-        placeholder="Same as the Jurisdiction's Organization">
-    </form-field>
-
-    <form-field class="g-col-6" size="md" [formControl]="formGroup.controls.YearBuilt" fieldLabel="Year Built" [type]="FormFieldType.Number" placeholder="Year built"> </form-field>
-
-    <form-field class="g-col-6" size="md" [formControl]="formGroup.controls.SystemOfRecordID" fieldLabel="System Of Record ID" [type]="FormFieldType.Text" placeholder="System of Record ID">
-    </form-field>
-
-    <form-field
-        class="g-col-6"
-        size="md"
-        [formControl]="formGroup.controls.WaterQualityManagementPlanID"
-        fieldLabel="Water Quality Management Plan"
-        [type]="FormFieldType.Select"
-        [formInputOptions]="wqmpSelectOptions$ | async"
-        placeholder="Select WQMP">
-    </form-field>
-
-    <form-field
-        class="g-col-6"
-        size="md"
-        [formControl]="formGroup.controls.TreatmentBMPLifespanTypeID"
-        fieldLabel="Lifespan Type"
-        [type]="FormFieldType.Select"
-        [formInputOptions]="lifeSpanTypeSelectOptions"
-        placeholder="Select Lifespan Type">
-    </form-field>
-
-    @if (showLifeSpanEndDateField$ | async) {
-        <div class="g-col-6"><!-- Empty for spacing--></div>
         <form-field
             class="g-col-6"
             size="md"
-            [formControl]="formGroup.controls.TreatmentBMPLifespanEndDate"
-            fieldLabel="Lifespan End Date"
-            [type]="FormFieldType.Date"
-            placeholder="End Date">
+            [formControl]="formGroup.controls.TreatmentBMPTypeID"
+            fieldLabel="BMP Type"
+            [type]="FormFieldType.Select"
+            [formInputOptions]="treatmentBMPTypeSelectOptions$ | async"
+            placeholder="Select BMP Type">
         </form-field>
-    }
 
-    <form-field
-        class="g-col-6"
-        size="md"
-        [formControl]="formGroup.controls.SizingBasisTypeID"
-        fieldLabel="Sizing Basis"
-        [type]="FormFieldType.Select"
-        [formInputOptions]="sizingBasisTypeSelectOptions"
-        placeholder="Select Sizing Basis">
-    </form-field>
-
-    <form-field
-        class="g-col-6"
-        size="md"
-        [formControl]="formGroup.controls.TrashCaptureStatusTypeID"
-        fieldLabel="Trash Capture Status"
-        [type]="FormFieldType.Select"
-        [formInputOptions]="trashCaptureStatusTypeSelectOptions"
-        placeholder="Select Trash Capture Status">
-    </form-field>
-
-    @if (showTrashCaptureEffectivenessField$ | async) {
-        <div class="g-col-6"><!-- Empty for spacing--></div>
         <form-field
             class="g-col-6"
             size="md"
-            [formControl]="formGroup.controls.TrashCaptureEffectiveness"
-            fieldLabel="Trash Capture Effectiveness (%)"
+            [formControl]="formGroup.controls.StormwaterJurisdictionID"
+            fieldLabel="Stormwater Jurisdiction"
+            [type]="FormFieldType.Select"
+            [formInputOptions]="stormwaterJurisdictionSelectOptions$ | async"
+            placeholder="Select Jurisdiction">
+        </form-field>
+
+        <form-field
+            class="g-col-6"
+            size="md"
+            [formControl]="formGroup.controls.OwnerOrganizationID"
+            fieldLabel="Owner Organization"
+            [type]="FormFieldType.Select"
+            [formInputOptions]="organizationSelectOptions$ | async"
+            placeholder="Same as the Jurisdiction's Organization">
+        </form-field>
+
+        <form-field class="g-col-6" size="md" [formControl]="formGroup.controls.YearBuilt" fieldLabel="Year Built" [type]="FormFieldType.Number" placeholder="Year built"> </form-field>
+
+        <form-field class="g-col-6" size="md" [formControl]="formGroup.controls.SystemOfRecordID" fieldLabel="System Of Record ID" [type]="FormFieldType.Text" placeholder="System of Record ID">
+        </form-field>
+
+        <form-field
+            class="g-col-6"
+            size="md"
+            [formControl]="formGroup.controls.WaterQualityManagementPlanID"
+            fieldLabel="Water Quality Management Plan"
+            [type]="FormFieldType.Select"
+            [formInputOptions]="wqmpSelectOptions$ | async"
+            placeholder="Select WQMP">
+        </form-field>
+
+        <form-field
+            class="g-col-6"
+            size="md"
+            [formControl]="formGroup.controls.TreatmentBMPLifespanTypeID"
+            fieldLabel="Lifespan Type"
+            [type]="FormFieldType.Select"
+            [formInputOptions]="lifeSpanTypeSelectOptions"
+            placeholder="Select Lifespan Type">
+        </form-field>
+
+        @if (showLifeSpanEndDateField$ | async) {
+            <form-field
+                class="g-col-6"
+                size="md"
+                [formControl]="formGroup.controls.TreatmentBMPLifespanEndDate"
+                fieldLabel="Lifespan End Date"
+                [type]="FormFieldType.Date"
+                placeholder="End Date">
+            </form-field>
+        }
+
+        <form-field
+            class="g-col-6"
+            size="md"
+            [formControl]="formGroup.controls.SizingBasisTypeID"
+            fieldLabel="Sizing Basis"
+            [type]="FormFieldType.Select"
+            [formInputOptions]="sizingBasisTypeSelectOptions"
+            placeholder="Select Sizing Basis">
+        </form-field>
+
+        <form-field
+            class="g-col-6"
+            size="md"
+            [formControl]="formGroup.controls.TrashCaptureStatusTypeID"
+            fieldLabel="Trash Capture Status"
+            [type]="FormFieldType.Select"
+            [formInputOptions]="trashCaptureStatusTypeSelectOptions"
+            placeholder="Select Trash Capture Status">
+        </form-field>
+
+        @if (showTrashCaptureEffectivenessField$ | async) {
+            <form-field
+                class="g-col-6"
+                size="md"
+                [formControl]="formGroup.controls.TrashCaptureEffectiveness"
+                fieldLabel="Trash Capture Effectiveness (%)"
+                [type]="FormFieldType.Number"
+                units="%"
+                placeholder="Effectiveness (1-99)">
+            </form-field>
+        }
+
+        <form-field
+            class="g-col-6"
+            size="md"
+            [formControl]="formGroup.controls.RequiredFieldVisitsPerYear"
+            fieldLabel="Required Field Visits Per Year"
             [type]="FormFieldType.Number"
-            units="%"
-            placeholder="Effectiveness (1-99)">
+            placeholder="Required visits per year">
         </form-field>
-    }
 
-    <form-field
-        class="g-col-6"
-        size="md"
-        [formControl]="formGroup.controls.RequiredFieldVisitsPerYear"
-        fieldLabel="Required Field Visits Per Year"
-        [type]="FormFieldType.Number"
-        placeholder="Required visits per year">
-    </form-field>
+        <form-field
+            class="g-col-6"
+            size="md"
+            [formControl]="formGroup.controls.RequiredPostStormFieldVisitsPerYear"
+            fieldLabel="Required Post-Storm Field Visits Per Year"
+            [type]="FormFieldType.Number"
+            placeholder="Required post-storm visits per year">
+        </form-field>
 
-    <form-field
-        class="g-col-6"
-        size="md"
-        [formControl]="formGroup.controls.RequiredPostStormFieldVisitsPerYear"
-        fieldLabel="Required Post-Storm Field Visits Per Year"
-        [type]="FormFieldType.Number"
-        placeholder="Required post-storm visits per year">
-    </form-field>
-
-    <div class="g-col-12 mt-3">
-        <h3 class="section-title sm blue">Location</h3>
-        <lat-lon-picker [latControl]="formGroup.controls.Latitude" [lonControl]="formGroup.controls.Longitude" [instructionsTemplate]="latLonInstructions">
-            <ng-template #latLonInstructions>
-                <div class="lat-lon-instructions">
-                    To set the location of the Treatment BMP:
-                    <ul>
-                        <li>Place the BMP at your current location (using GPS if available) <strong>OR</strong></li>
-                        <li>Click on the location of the BMP on the map <strong>OR</strong></li>
-                        <li>Directly type in the latitude and longitude</li>
-                    </ul>
-
-                    <p class="mt-1">For centralized BMPs, any existing delineation will automatically be re-calculated based on the new saved location.</p>
-                </div>
-            </ng-template>
-        </lat-lon-picker>
+        <form-field class="g-col-12" size="md" [formControl]="formGroup.controls.Notes" fieldLabel="Notes" [type]="FormFieldType.Textarea" placeholder="Notes"></form-field>
     </div>
 
-    <form-field class="g-col-12" size="md" [formControl]="formGroup.controls.Notes" fieldLabel="Notes" [type]="FormFieldType.Textarea" placeholder="Notes"></form-field>
+    <h4 class="module-title mt-4">Location</h4>
+    <lat-lon-picker [latControl]="formGroup.controls.Latitude" [lonControl]="formGroup.controls.Longitude" [instructionsTemplate]="latLonInstructions">
+        <ng-template #latLonInstructions>
+            <div class="lat-lon-instructions">
+                To set the location of the Treatment BMP:
+                <ul>
+                    <li>Place the BMP at your current location (using GPS if available) <strong>OR</strong></li>
+                    <li>Click on the location of the BMP on the map <strong>OR</strong></li>
+                    <li>Directly type in the latitude and longitude</li>
+                </ul>
+
+                <p class="mt-1">For centralized BMPs, any existing delineation will automatically be re-calculated based on the new saved location.</p>
+            </div>
+        </ng-template>
+    </lat-lon-picker>
 </form>
 
 <div class="page-footer">
-    <button class="btn btn-primary mr-2" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
+    <button class="btn btn-primary" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
     <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
 </div>

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/begin-field-visit-modal/begin-field-visit-modal.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/begin-field-visit-modal/begin-field-visit-modal.component.html
@@ -47,6 +47,6 @@
             }
             {{ hasInProgressVisit && formGroup.controls.ContinueExistingInProgress.value === true ? "Continue Visit" : "Begin Visit" }}
         </button>
-        <button type="button" class="btn btn-secondary" [disabled]="isSaving" (click)="cancel()">Cancel</button>
+        <button type="button" class="btn btn-primary-outline" [disabled]="isSaving" (click)="cancel()">Cancel</button>
     </div>
 </div>

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-benchmark-threshold-modal/treatment-bmp-benchmark-threshold-modal.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-benchmark-threshold-modal/treatment-bmp-benchmark-threshold-modal.component.html
@@ -34,5 +34,5 @@
 </div>
 <div class="modal-footer">
     <button class="btn btn-primary" (click)="save()" [disabled]="isSaving">Save</button>
-    <button class="btn btn-secondary" (click)="cancel()" [disabled]="isSaving">Cancel</button>
+    <button class="btn btn-primary-outline" (click)="cancel()" [disabled]="isSaving">Cancel</button>
 </div>

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.html
@@ -420,7 +420,7 @@
             <div class="card-header">
                 <span class="card-title">Field Visits</span>
                 @if (currentPersonCanManage) {
-                    <button class="btn btn-primary-outline btn-sm" (click)="openBeginFieldVisitModal()"><i class="fa fa-plus"></i> Begin Field Visit</button>
+                    <button class="btn btn-primary btn-sm" (click)="openBeginFieldVisitModal()"><i class="fa fa-plus"></i> Begin Field Visit</button>
                 }
             </div>
             <div class="card-body">
@@ -440,7 +440,7 @@
             <div class="card-header">
                 <span class="card-title">Funding Events</span>
                 @if (currentPersonCanManage) {
-                    <button class="btn btn-primary-outline btn-sm" (click)="openAddFundingEventModal()"><i class="fa fa-plus"></i> Add Funding Event</button>
+                    <button class="btn btn-primary btn-sm" (click)="openAddFundingEventModal()"><i class="fa fa-plus"></i> Add Funding Event</button>
                 }
             </div>
             <div class="card-body">
@@ -543,7 +543,7 @@
                 <div class="card-header">
                     <span class="card-title">Documents</span>
                     @if (currentPersonCanManage) {
-                        <button class="btn btn-primary-outline btn-sm" (click)="openDocumentUploadModal()"><i class="fa fa-plus"></i> Upload Document</button>
+                        <button class="btn btn-primary btn-sm" (click)="openDocumentUploadModal()"><i class="fa fa-plus"></i> Upload Document</button>
                     }
                 </div>
                 <div class="card-body">

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
@@ -225,6 +225,7 @@ export class TreatmentBmpDetailComponent implements OnInit, OnChanges {
                 const actions: { ActionName: string; ActionIcon?: string; ActionLink?: string; ActionHandler?: () => void }[] = [
                     {
                         ActionName: editable ? "Continue" : "View",
+                        ActionIcon: editable ? "fas fa-edit" : "fas fa-file-alt",
                         ActionLink: editable
                             ? `/field-visits/${visit.FieldVisitID}`
                             : `/field-visits/${visit.FieldVisitID}/view`,
@@ -233,7 +234,7 @@ export class TreatmentBmpDetailComponent implements OnInit, OnChanges {
                 if (this.currentPersonCanManage) {
                     actions.push({
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.deleteFieldVisit(params),
                     });
                 }

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
@@ -6,6 +6,8 @@ import { ConfirmService } from "src/app/shared/services/confirm/confirm.service"
 import { Component, OnInit, OnChanges, SimpleChanges, ViewChild, TemplateRef, Input } from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
 import { DatePipe, AsyncPipe, CommonModule } from "@angular/common";
+import { HttpErrorResponse } from "@angular/common/http";
+import { escapeHtml } from "src/app/shared/helpers/html-escape";
 import { BehaviorSubject, Observable } from "rxjs";
 import { shareReplay, switchMap, tap } from "rxjs/operators";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
@@ -624,9 +626,17 @@ export class TreatmentBmpDetailComponent implements OnInit, OnChanges {
     uploadDocument(fileResource: IFileResourceUpload): void {
         this.treatmentBMPDocumentByTreatmentBMPService
             .createTreatmentBMPDocumentByTreatmentBMP(this.treatmentBMPID, fileResource.File, fileResource.DocumentDescription)
-            .subscribe((result) => {
-                this.alertService.pushAlert(new Alert("Successfully uploaded document.", AlertContext.Success));
-                this.refreshTreatmentBMPDocumentsTrigger$.next();
+            .subscribe({
+                next: () => {
+                    this.alertService.pushAlert(new Alert("Successfully uploaded document.", AlertContext.Success));
+                    this.refreshTreatmentBMPDocumentsTrigger$.next();
+                },
+                // Surface server-side validation failures (e.g. unsupported file type / oversized
+                // file) instead of swallowing the 400 and leaving the user with no feedback.
+                error: (err: HttpErrorResponse) => {
+                    const raw = err?.error?.detail ?? err?.error?.title ?? err?.error ?? "There was an error uploading the document.";
+                    this.alertService.pushAlert(new Alert(escapeHtml(typeof raw === "string" ? raw : "There was an error uploading the document."), AlertContext.Danger));
+                },
             });
     }
 

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-update-basic-info/treatment-bmp-update-basic-info.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-update-basic-info/treatment-bmp-update-basic-info.component.html
@@ -134,11 +134,11 @@
             placeholder="Required post-storm visits per year">
         </form-field>
 
-        <form-field size="md" [formControl]="formGroup.controls.Notes" fieldLabel="Notes" [type]="FormFieldType.Textarea" placeholder="Notes"> </form-field>
+        <form-field class="g-col-12" size="md" [formControl]="formGroup.controls.Notes" fieldLabel="Notes" [type]="FormFieldType.Textarea" placeholder="Notes"> </form-field>
     </form>
 
     <div class="page-footer">
-        <button class="btn btn-primary mr-2" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
+        <button class="btn btn-primary" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
         <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
     </div>
 }

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-update-basic-info/treatment-bmp-update-basic-info.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-update-basic-info/treatment-bmp-update-basic-info.component.html
@@ -139,6 +139,6 @@
 
     <div class="page-footer">
         <button class="btn btn-primary mr-2" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
-        <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
+        <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
     </div>
 }

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-update-basic-info/treatment-bmp-update-basic-info.component.scss
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-update-basic-info/treatment-bmp-update-basic-info.component.scss
@@ -1,7 +1,19 @@
 @use "/src/scss/abstracts" as *;
 
+// Read-only values (BMP Type, Jurisdiction) rendered to line up with the
+// md form-field inputs beside them: same height, padding and body-size text,
+// styled as a disabled field so the rows align instead of floating large.
 .form-control-readonly {
-    height: 3rem;
-    line-height: 3rem;
-    font-size: clamp(0.87rem, 0.74rem + 0.62vw, 1.13rem);
+    display: flex;
+    align-items: center;
+    height: 2.5rem;
+    padding: 0.375rem 0.625rem;
+    font-size: $type-size-300;
+    color: $gray-700;
+    background-color: $gray-100;
+    border: 1px solid rgba(black, 0.1);
+    border-radius: 0.25rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
@@ -115,15 +115,14 @@ export class TreatmentBmpsComponent {
             this.utilityFunctionsService.createBasicColumnDef("Trash Capture Status", "TrashCaptureStatusTypeDisplayName", { UseCustomDropdownFilter: true }),
             this.utilityFunctionsService.createBasicColumnDef("Trash Capture Effectiveness (%)", "TrashCaptureEffectiveness"),
             this.utilityFunctionsService.createBasicColumnDef("Delineation Type", "DelineationTypeDisplayName", { UseCustomDropdownFilter: true }),
-            // NPT-1061: Notes was previously mid-grid and dominated visible width on rows with
-            // long entries. Moved to the far right + capped at 300px with wrap so long notes flow
-            // vertically instead of pushing every other column off-screen.
+            // NPT-1061: Notes was previously mid-grid and dominated visible width on rows with long
+            // entries. Moved to the far right + capped at 300px. Kept on a single line (truncated
+            // with an ellipsis) rather than wrapping with autoHeight — wrapping grew rows unbounded
+            // and made tall, uneven rows. The grid's default tooltipValueGetter shows the full note
+            // on hover, so nothing is lost.
             {
                 ...this.utilityFunctionsService.createBasicColumnDef("Notes", "Notes"),
                 maxWidth: 300,
-                wrapText: true,
-                autoHeight: true,
-                cellStyle: { whiteSpace: "normal", lineHeight: "1.3" },
             },
         ];
         this.treatmentBmps$ = this.treatmentBMPService

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
@@ -69,17 +69,19 @@ export class TreatmentBmpsComponent {
                 const actions: { ActionName: string; ActionIcon?: string; ActionHandler: () => void }[] = [
                     {
                         ActionName: "View",
+                        ActionIcon: "fas fa-file-alt",
                         ActionHandler: () => this.router.navigate(["/treatment-bmps", params.data.TreatmentBMPID]),
                     },
                 ];
                 if (canEdit) {
                     actions.push({
                         ActionName: "Start Field Visit",
+                        ActionIcon: "fas fa-clipboard-check",
                         ActionHandler: () => this.openBeginFieldVisitModal(params.data.TreatmentBMPID),
                     });
                     actions.push({
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.deleteModal(params),
                     });
                 }

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
@@ -63,7 +63,8 @@ export class TreatmentBmpsComponent {
 
     ngOnInit(): void {
         const canEdit = this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission();
-        this.columnDefs = [
+        const isAnonymousOrUnassigned = this.authenticationService.isCurrentUserAnonymousOrUnassigned();
+        const columnDefs: ColDef[] = [
             this.utilityFunctionsService.createActionsColumnDef((params: any) => {
                 const actions: { ActionName: string; ActionIcon?: string; ActionHandler: () => void }[] = [
                     {
@@ -125,6 +126,12 @@ export class TreatmentBmpsComponent {
                 maxWidth: 300,
             },
         ];
+        // NPT-1079: public (anonymous) + unassigned users see only the fields the legacy "Find a
+        // BMP" map exposed — Name and Type. Hide the actions column and all operational columns
+        // (assessments, maintenance, lifespan, sizing, trash, notes, jurisdiction, owner).
+        const publicHeaders = new Set(["Name", "Type"]);
+        this.columnDefs = isAnonymousOrUnassigned ? columnDefs.filter((c) => publicHeaders.has(c.headerName as string)) : columnDefs;
+
         this.treatmentBmps$ = this.treatmentBMPService
             .listTreatmentBMP()
             .pipe(

--- a/Neptune.Web/src/app/pages/users/user-detail/edit-jurisdictions-modal/edit-jurisdictions-modal.component.html
+++ b/Neptune.Web/src/app/pages/users/user-detail/edit-jurisdictions-modal/edit-jurisdictions-modal.component.html
@@ -24,6 +24,6 @@
         <button type="button" class="btn btn-primary" [disabled]="isSaving()" (click)="save()">
             @if (isSaving()) { <i class="fa fa-spinner fa-spin"></i> Saving... } @else { Save }
         </button>
-        <button type="button" class="btn btn-secondary" [disabled]="isSaving()" (click)="cancel()">Cancel</button>
+        <button type="button" class="btn btn-primary-outline" [disabled]="isSaving()" (click)="cancel()">Cancel</button>
     </div>
 </div>

--- a/Neptune.Web/src/app/pages/users/user-detail/edit-roles-modal/edit-roles-modal.component.html
+++ b/Neptune.Web/src/app/pages/users/user-detail/edit-roles-modal/edit-roles-modal.component.html
@@ -1,6 +1,6 @@
 <div class="modal">
     <div class="modal-header">
-        <h3>Edit Roles for {{ ref.data.detail.FirstName }} {{ ref.data.detail.LastName }}</h3>
+        <h3>Edit Roles for {{ ((ref.data.detail.FirstName || '') + ' ' + (ref.data.detail.LastName || '')).trim() || ref.data.detail.Email || 'this user' }}</h3>
     </div>
     <div class="modal-body">
         @if (errorMessage(); as msg) {
@@ -57,6 +57,6 @@
         <button type="button" class="btn btn-primary" [disabled]="formGroup.invalid || isSaving()" (click)="save()">
             @if (isSaving()) { <i class="fa fa-spinner fa-spin"></i> Saving... } @else { Save }
         </button>
-        <button type="button" class="btn btn-secondary" [disabled]="isSaving()" (click)="cancel()">Cancel</button>
+        <button type="button" class="btn btn-primary-outline" [disabled]="isSaving()" (click)="cancel()">Cancel</button>
     </div>
 </div>

--- a/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.html
+++ b/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.html
@@ -1,5 +1,5 @@
 @if (detail$ | async; as detail) {
-    <page-header [pageTitle]="detail.FirstName + ' ' + detail.LastName" [templateAbove]="templateAbove" [templateRight]="headerActions">
+    <page-header [pageTitle]="((detail.FirstName || '') + ' ' + (detail.LastName || '')).trim() || detail.Email || 'Unknown User'" [templateAbove]="templateAbove" [templateRight]="headerActions">
         <ng-template #templateAbove>
             <!-- NPT-999 r3 (KE 5/20/26): the back-link only renders for Admin / SitkaAdmin
                  viewers since the /users list itself is now guarded to those roles. Jurisdiction
@@ -45,10 +45,10 @@
                 <div class="card-body">
                     <dl class="grid-12 key-value-list">
                         <dt class="g-col-5">First Name</dt>
-                        <dd class="g-col-7">{{ detail.FirstName }}</dd>
+                        <dd class="g-col-7">{{ detail.FirstName || "—" }}</dd>
 
                         <dt class="g-col-5">Last Name</dt>
-                        <dd class="g-col-7">{{ detail.LastName }}</dd>
+                        <dd class="g-col-7">{{ detail.LastName || "—" }}</dd>
 
                         <dt class="g-col-5">Email</dt>
                         <dd class="g-col-7">{{ detail.Email }}</dd>

--- a/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.html
+++ b/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.html
@@ -13,7 +13,7 @@
         </ng-template>
         <ng-template #headerActions>
             @if (canImpersonate(detail)) {
-                <button type="button" class="btn btn-secondary" style="margin-right: 0.5rem" (click)="impersonate(detail)">
+                <button type="button" class="btn btn-primary-outline" style="margin-right: 0.5rem" (click)="impersonate(detail)">
                     <i class="fa fa-user-secret"></i> Impersonate
                 </button>
             }

--- a/Neptune.Web/src/app/pages/users/users.component.ts
+++ b/Neptune.Web/src/app/pages/users/users.component.ts
@@ -46,7 +46,7 @@ export class UsersComponent implements OnInit {
                 ...this.utilityFunctions.createActionsColumnDef((params: any) => [
                     {
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.deleteUser(params.data),
                     },
                 ]),

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-boundary/edit-boundary.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-boundary/edit-boundary.component.html
@@ -57,7 +57,7 @@
                 }
                 Save
             </button>
-            <button class="btn btn-secondary-outline" (click)="cancel()" [disabled]="isLoadingSubmit">Cancel</button>
+            <button class="btn btn-primary-outline" (click)="cancel()" [disabled]="isLoadingSubmit">Cancel</button>
         </div>
     </div>
 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-parcels/edit-parcels.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-parcels/edit-parcels.component.html
@@ -71,6 +71,6 @@
 
     <div class="page-footer">
         <button class="btn btn-primary" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
-        <button class="btn btn-secondary-outline" (click)="cancel()">Cancel</button>
+        <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
     </div>
 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-quick-bmps/edit-quick-bmps.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-quick-bmps/edit-quick-bmps.component.html
@@ -26,20 +26,15 @@
         enter the percentage of this WQMP site treated by each Simplified Structural BMP. The total should not exceed 100%.
     </p>
 
-    <hr />
-
-    <p>
-        Should all BMPs override Dry Weather Flow?&nbsp;&nbsp;
-        <button type="button" class="btn btn-sm btn-primary" (click)="setAllDryWeatherOverridesToYes()">Set all to 'Yes'</button>
-    </p>
-
     @if (quickBMPRows.length) {
+        <p class="mb-3">
+            Should all BMPs override Dry Weather Flow?&nbsp;&nbsp;
+            <button type="button" class="btn btn-sm btn-primary" (click)="setAllDryWeatherOverridesToYes()">Set all to 'Yes'</button>
+        </p>
+
         @for (row of quickBMPRows.controls; track $index) {
-            <div class="quick-bmp-entry" [formGroup]="row">
+            <div class="quick-bmp-entry" [class.first]="$first" [formGroup]="row">
                 <div class="quick-bmp-entry-body">
-                    <div class="quick-bmp-delete-col">
-                        <button type="button" class="btn-delete-row delete-icon" aria-label="Remove row" title="Remove row" (click)="removeRow($index)"></button>
-                    </div>
                     <div class="quick-bmp-fields">
                         <div class="field-group field-name">
                             <form-field
@@ -108,6 +103,9 @@
                             fieldLabel="Notes"
                             placeholder=""></form-field>
                     </div>
+                    <div class="quick-bmp-delete-col">
+                        <button type="button" class="btn-delete-row delete-icon" aria-label="Remove row" title="Remove row" (click)="removeRow($index)"></button>
+                    </div>
                 </div>
             </div>
         }
@@ -120,15 +118,13 @@
         <p class="system-text">There are no Simplified Structural BMPs associated with this WQMP. Use the Add button to enter one or more.</p>
     }
 
-    <div class="actions-row mt-3">
-        <button class="btn btn-primary" (click)="addRow()">
-            <i class="fa fa-plus"></i> Add
+    <div class="add-row mt-3">
+        <button class="btn btn-primary-outline" (click)="addRow()">
+            <i class="fa fa-plus"></i> Add Simplified BMP
         </button>
     </div>
 
-    <hr />
-
-    <div class="actions-row mt-3">
+    <div class="page-footer">
         <button class="btn btn-primary" (click)="save()">Save</button>
         <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
     </div>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-quick-bmps/edit-quick-bmps.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-quick-bmps/edit-quick-bmps.component.scss
@@ -1,8 +1,12 @@
 @use "/src/scss/abstracts" as *;
 
 .quick-bmp-entry {
-    border-bottom: 2px solid #ddd;
+    border-bottom: 2px solid $gray-200;
     padding: 1rem 0;
+
+    &.first {
+        border-top: 2px solid $gray-200;
+    }
 
     .quick-bmp-entry-body {
         display: flex;
@@ -11,17 +15,19 @@
     }
 
     .quick-bmp-delete-col {
-        flex: 0 0 20px;
+        flex: 0 0 1.25rem;
         padding-top: 0.25rem;
     }
 
     .delete-icon {
         cursor: pointer;
-        color: #6c757d;
+        color: $gray-600;
         font-size: 1rem;
 
+        // On hover btn-delete-row fills with the danger color, so the icon
+        // goes white to stay legible against the red fill.
         &:hover {
-            color: $danger;
+            color: $white;
         }
     }
 
@@ -34,7 +40,7 @@
     }
 
     .quick-bmp-notes {
-        width: 250px;
+        width: 22rem;
         flex-shrink: 0;
         display: flex;
         flex-direction: column;
@@ -44,7 +50,7 @@
             flex: 1;
 
             ::ng-deep textarea {
-                min-height: 160px;
+                min-height: 10rem;
                 resize: vertical;
             }
         }
@@ -88,9 +94,9 @@
     }
 }
 
-.actions-row {
+.add-row {
     display: flex;
-    justify-content: flex-end;
+    justify-content: flex-start;
     gap: 0.5rem;
 }
 

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/steps/supporting-documentation-step.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/verification-wizard/steps/supporting-documentation-step.component.html
@@ -36,6 +36,6 @@
     </div>
 
     <div class="page-footer">
-        <button class="btn btn-primary-outline" (click)="continueToReview()" [disabled]="isBusy()">Save and Continue</button>
+        <button class="btn btn-primary" (click)="continueToReview()" [disabled]="isBusy()">Save and Continue</button>
     </div>
 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
@@ -50,12 +50,12 @@
                     }
                 </div>
                 <div class="card-body">
-                    <dl class="grid-12 key-value-list">
-                        <dt class="g-col-5"><field-definition fieldDefinitionType="WaterQualityManagementPlan" fieldDefinitionLabelOverride="Name"></field-definition></dt>
-                        <dd class="g-col-7">{{ wqmp.WaterQualityManagementPlanName }}</dd>
+                    <dl class="kv">
+                        <dt><field-definition fieldDefinitionType="WaterQualityManagementPlan" fieldDefinitionLabelOverride="Name"></field-definition></dt>
+                        <dd>{{ wqmp.WaterQualityManagementPlanName }}</dd>
 
-                        <dt class="g-col-5"><field-definition fieldDefinitionType="Jurisdiction"></field-definition></dt>
-                        <dd class="g-col-7">
+                        <dt><field-definition fieldDefinitionType="Jurisdiction"></field-definition></dt>
+                        <dd>
                             @if (!isAnonymousOrUnassigned) {
                                 <a [routerLink]="['/jurisdictions', wqmp.StormwaterJurisdictionID]">{{ wqmp.StormwaterJurisdictionOrganizationName }}</a>
                             } @else {
@@ -63,50 +63,50 @@
                             }
                         </dd>
 
-                        <dt class="g-col-5">Priority</dt>
-                        <dd class="g-col-7">{{ wqmp.WaterQualityManagementPlanPriorityDisplayName ?? "" }}</dd>
+                        <dt>Priority</dt>
+                        <dd>{{ wqmp.WaterQualityManagementPlanPriorityDisplayName ?? "" }}</dd>
 
-                        <dt class="g-col-5">Status</dt>
-                        <dd class="g-col-7">{{ wqmp.WaterQualityManagementPlanStatusDisplayName ?? "" }}</dd>
+                        <dt>Status</dt>
+                        <dd>{{ wqmp.WaterQualityManagementPlanStatusDisplayName ?? "" }}</dd>
 
-                        <dt class="g-col-5">Development Type</dt>
-                        <dd class="g-col-7">{{ wqmp.WaterQualityManagementPlanDevelopmentTypeDisplayName ?? "" }}</dd>
+                        <dt>Development Type</dt>
+                        <dd>{{ wqmp.WaterQualityManagementPlanDevelopmentTypeDisplayName ?? "" }}</dd>
 
-                        <dt class="g-col-5">Land Use</dt>
-                        <dd class="g-col-7">{{ wqmp.WaterQualityManagementPlanLandUseDisplayName ?? "" }}</dd>
+                        <dt>Land Use</dt>
+                        <dd>{{ wqmp.WaterQualityManagementPlanLandUseDisplayName ?? "" }}</dd>
 
-                        <dt class="g-col-5">Permit Term</dt>
-                        <dd class="g-col-7">{{ wqmp.WaterQualityManagementPlanPermitTermDisplayName ?? "" }}</dd>
+                        <dt>Permit Term</dt>
+                        <dd>{{ wqmp.WaterQualityManagementPlanPermitTermDisplayName ?? "" }}</dd>
 
-                        <dt class="g-col-5">Approval Date</dt>
-                        <dd class="g-col-7">{{ wqmp.ApprovalDate ? (wqmp.ApprovalDate | date: "MM/dd/yyyy" : "+0000") : "" }}</dd>
+                        <dt>Approval Date</dt>
+                        <dd>{{ wqmp.ApprovalDate ? (wqmp.ApprovalDate | date: "MM/dd/yyyy" : "+0000") : "" }}</dd>
 
-                        <dt class="g-col-5">Date of Construction</dt>
-                        <dd class="g-col-7">{{ wqmp.DateOfConstruction ? (wqmp.DateOfConstruction | date: "MM/dd/yyyy" : "+0000") : "" }}</dd>
+                        <dt>Date of Construction</dt>
+                        <dd>{{ wqmp.DateOfConstruction ? (wqmp.DateOfConstruction | date: "MM/dd/yyyy" : "+0000") : "" }}</dd>
 
-                        <dt class="g-col-5"><field-definition fieldDefinitionType="HydromodificationApplies"></field-definition></dt>
-                        <dd class="g-col-7">{{ wqmp.HydromodificationAppliesTypeDisplayName ?? "" }}</dd>
+                        <dt><field-definition fieldDefinitionType="HydromodificationApplies"></field-definition></dt>
+                        <dd>{{ wqmp.HydromodificationAppliesTypeDisplayName ?? "" }}</dd>
 
-                        <dt class="g-col-5">Hydrologic Subarea</dt>
-                        <dd class="g-col-7">{{ wqmp.HydrologicSubareaName ?? "" }}</dd>
+                        <dt>Hydrologic Subarea</dt>
+                        <dd>{{ wqmp.HydrologicSubareaName ?? "" }}</dd>
 
-                        <dt class="g-col-5">Record Number</dt>
-                        <dd class="g-col-7">{{ wqmp.RecordNumber ?? "" }}</dd>
+                        <dt>Record Number</dt>
+                        <dd>{{ wqmp.RecordNumber ?? "" }}</dd>
 
-                        <dt class="g-col-5">Recorded WQMP Area (Acres)</dt>
-                        <dd class="g-col-7">{{ wqmp.RecordedWQMPAreaInAcres ?? "" }}</dd>
+                        <dt>Recorded WQMP Area (Acres)</dt>
+                        <dd>{{ wqmp.RecordedWQMPAreaInAcres ?? "" }}</dd>
 
-                        <dt class="g-col-5"><field-definition fieldDefinitionType="TrashCaptureStatus"></field-definition></dt>
-                        <dd class="g-col-7">{{ wqmp.TrashCaptureStatusTypeDisplayName }}</dd>
+                        <dt><field-definition fieldDefinitionType="TrashCaptureStatus"></field-definition></dt>
+                        <dd>{{ wqmp.TrashCaptureStatusTypeDisplayName }}</dd>
 
                         @if (wqmp.TrashCaptureStatusTypeID === TrashCaptureStatusTypeEnum.Partial) {
-                            <dt class="g-col-5">Trash Capture Effectiveness</dt>
-                            <dd class="g-col-7">{{ wqmp.TrashCaptureEffectiveness }}%</dd>
+                            <dt>Trash Capture Effectiveness</dt>
+                            <dd>{{ wqmp.TrashCaptureEffectiveness }}%</dd>
                         }
 
                         @if (!isAnonymousOrUnassigned) {
-                            <dt class="g-col-5">Maintenance Contact</dt>
-                            <dd class="g-col-7">
+                            <dt>Maintenance Contact</dt>
+                            <dd>
                                 @if (wqmp.MaintenanceContactName) {
                                     <div><strong>{{ wqmp.MaintenanceContactName }}</strong></div>
                                 }
@@ -188,15 +188,15 @@
             <div class="card">
                 <div class="card-header">
                     <span class="card-title">Locations</span>
-                </div>
-                <div class="card-body">
                     @if (currentPersonCanEdit) {
-                        <div class="mb-3" style="display: flex; justify-content: flex-end; gap: 0.5rem">
-                            <a class="btn btn-primary-outline" [routerLink]="['/water-quality-management-plans', waterQualityManagementPlanID, 'edit-parcels']">Edit Parcels</a>
-                            <a class="btn btn-primary-outline" [class.disabled]="!wqmp.WaterQualityManagementPlanBoundaryBBox"
+                        <div class="flex">
+                            <a class="btn btn-primary-outline btn-sm" [routerLink]="['/water-quality-management-plans', waterQualityManagementPlanID, 'edit-parcels']">Edit Parcels</a>
+                            <a class="btn btn-primary-outline btn-sm" [class.disabled]="!wqmp.WaterQualityManagementPlanBoundaryBBox"
                                 [routerLink]="wqmp.WaterQualityManagementPlanBoundaryBBox ? ['/water-quality-management-plans', waterQualityManagementPlanID, 'edit-boundary'] : null">Refine Area</a>
                         </div>
                     }
+                </div>
+                <div class="card-body">
                     <neptune-map [mapHeight]="'500px'" [showLegend]="false" [boundingBox]="boundingBox" (onMapLoad)="handleMapReady($event)">
                         @if (mapIsReady) {
                             <wqmps-layer
@@ -206,12 +206,12 @@
                                 [layerControl]="layerControl"></wqmps-layer>
                         }
                     </neptune-map>
-                    <dl class="grid-12 mt-3 key-value-list">
-                        <dt class="g-col-5">Calculated Acreage of Assigned Boundary</dt>
-                        <dd class="g-col-7">{{ wqmp.CalculatedWQMPAcreage ?? "" }}</dd>
+                    <dl class="kv mt-3">
+                        <dt>Calculated Acreage of Assigned Boundary</dt>
+                        <dd>{{ wqmp.CalculatedWQMPAcreage ?? "" }}</dd>
 
-                        <dt class="g-col-5">WQMP Boundary Notes</dt>
-                        <dd class="g-col-7">{{ wqmp.WaterQualityManagementPlanBoundaryNotes ?? "" }}</dd>
+                        <dt>WQMP Boundary Notes</dt>
+                        <dd>{{ wqmp.WaterQualityManagementPlanBoundaryNotes ?? "" }}</dd>
                     </dl>
                 </div>
             </div>
@@ -264,7 +264,7 @@
             <div class="card-body">
                 <!-- Modeling Approach -->
                 <div class="modeling-approach-heading">
-                    <h4 class="mb-2">Modeling Approach</h4>
+                    <h4 class="module-title mb-2">Modeling Approach</h4>
                     <div class="modeling-approach-header-actions">
                         <a [routerLink]="['/wqmp-modeling-options']">Learn about WQMP Modeling Options</a>
                         @if (currentPersonCanEdit) {
@@ -290,7 +290,7 @@
                 }
 
                 <!-- Inventoried Structural BMPs -->
-                <h4 class="mt-4 mb-2 flex-between">Inventoried Structural BMPs
+                <h4 class="module-title mt-4 mb-2 flex-between">Inventoried Structural BMPs
                     @if (currentPersonCanEdit) {
                         <button type="button" class="btn btn-primary btn-sm" (click)="openEditTreatmentBMPsModal(wqmp)">
                             Edit
@@ -314,7 +314,7 @@
                 }
 
                 <!-- Simplified Structural BMPs (Quick BMPs) -->
-                <h4 class="mt-4 mb-2 flex-between">Simplified Structural BMPs
+                <h4 class="module-title mt-4 mb-2 flex-between">Simplified Structural BMPs
                     @if (currentPersonCanEdit) {
                         <button type="button" class="btn btn-primary btn-sm" (click)="navigateToEditQuickBMPs()">
                             Edit
@@ -343,7 +343,7 @@
                 }
 
                 <!-- Source Control BMPs -->
-                <h4 class="mt-4 mb-2 flex-between">Source Control BMPs
+                <h4 class="module-title mt-4 mb-2 flex-between">Source Control BMPs
                     @if (currentPersonCanEdit) {
                         <button type="button" class="btn btn-primary btn-sm" (click)="navigateToEditSourceControlBMPs()">
                             Edit
@@ -403,43 +403,50 @@
                 </div>
                 <div class="card-body">
                     @if (documents$ | async; as documents) {
+                        @if (documents.length) {
+                        <div class="document-groups">
                         @for (docGroup of documentsByType; track docGroup.typeDisplayName) {
-                            <h4>{{ docGroup.typeDisplayName }}</h4>
                             @if (docGroup.documents.length) {
+                            <div class="document-group">
+                            <div class="module-title document-group-title">{{ docGroup.typeDisplayName }}</div>
+                                <div class="document-entries">
                                 @for (doc of docGroup.documents; track doc.WaterQualityManagementPlanDocumentID) {
                                     <div class="document-entry">
                                         <div class="document-entry-header">
-                                            @if (doc.FileResource?.FileResourceGUID) {
-                                                <a [href]="fileResourceUrl(doc.FileResource.FileResourceGUID)" target="_blank">
-                                                    {{ doc.DisplayName }} <i class="fa fa-download"></i>
-                                                </a>
-                                            } @else {
-                                                <span>{{ doc.DisplayName }}</span>
-                                            }
-                                            @if (currentPersonCanManage) {
-                                                <span class="document-entry-actions">
-                                                    <button class="btn btn-link btn-sm" (click)="openDocumentEditModal(doc)" title="Edit document">
-                                                        <i class="fa fa-pencil"></i> Edit
+                                            <span class="document-name">{{ doc.DisplayName }}</span>
+                                            <span class="document-entry-actions">
+                                                @if (doc.FileResource?.FileResourceGUID) {
+                                                    <a class="btn btn-sm btn-primary-outline doc-action" [href]="fileResourceUrl(doc.FileResource.FileResourceGUID)" target="_blank" title="Download document" aria-label="Download document">
+                                                        <i class="fa fa-download"></i>
+                                                    </a>
+                                                }
+                                                @if (currentPersonCanManage) {
+                                                    <button type="button" class="btn btn-sm btn-primary-outline doc-action" (click)="openDocumentEditModal(doc)" title="Edit document" aria-label="Edit document">
+                                                        <i class="fa fa-pencil"></i>
                                                     </button>
-                                                    <button class="btn btn-link btn-sm text-danger" (click)="confirmDocumentDelete(doc)" title="Delete document">
-                                                        <i class="fa fa-trash"></i> Delete
+                                                    <button type="button" class="btn btn-sm btn-danger-outline doc-action" (click)="confirmDocumentDelete(doc)" title="Delete document" aria-label="Delete document">
+                                                        <i class="fa fa-trash"></i>
                                                     </button>
-                                                </span>
-                                            }
+                                                }
+                                            </span>
                                         </div>
-                                        <dl class="dl-horizontal document-details">
+                                        <dl class="kv document-details">
                                             <dt>Uploaded On</dt>
                                             <dd>{{ doc.UploadDate | date: "MM/dd/yyyy" }}</dd>
                                             <dt>File Type</dt>
                                             <dd>{{ doc.FileResource?.FileResourceMimeType?.FileResourceMimeTypeDisplayName }}</dd>
                                             <dt>Description</dt>
-                                            <dd>{{ doc.Description }}</dd>
+                                            <dd>{{ doc.Description || "—" }}</dd>
                                         </dl>
                                     </div>
                                 }
-                            } @else {
-                                <p class="system-text">No documents provided</p>
+                                </div>
+                            </div>
                             }
+                        }
+                        </div>
+                        } @else {
+                            <p class="system-text">No documents provided</p>
                         }
                     } @else {
                         <div [loadingSpinner]="{ isLoading: true, loadingHeight: 100 }"></div>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
@@ -190,8 +190,8 @@
                     <span class="card-title">Locations</span>
                     @if (currentPersonCanEdit) {
                         <div class="flex">
-                            <a class="btn btn-primary-outline btn-sm" [routerLink]="['/water-quality-management-plans', waterQualityManagementPlanID, 'edit-parcels']">Edit Parcels</a>
-                            <a class="btn btn-primary-outline btn-sm" [class.disabled]="!wqmp.WaterQualityManagementPlanBoundaryBBox"
+                            <a class="btn btn-primary btn-sm" [routerLink]="['/water-quality-management-plans', waterQualityManagementPlanID, 'edit-parcels']">Edit Parcels</a>
+                            <a class="btn btn-primary btn-sm" [class.disabled]="!wqmp.WaterQualityManagementPlanBoundaryBBox"
                                 [routerLink]="wqmp.WaterQualityManagementPlanBoundaryBBox ? ['/water-quality-management-plans', waterQualityManagementPlanID, 'edit-boundary'] : null">Refine Area</a>
                         </div>
                     }
@@ -396,7 +396,7 @@
                 <div class="card-header">
                     <span class="card-title">Documents</span>
                     @if (currentPersonCanManage) {
-                        <button class="btn btn-primary-outline btn-sm" (click)="openDocumentUploadModal()">
+                        <button class="btn btn-primary btn-sm" (click)="openDocumentUploadModal()">
                             <i class="fa fa-plus"></i> Upload Document
                         </button>
                     }
@@ -460,7 +460,7 @@
             <div class="card-header">
                 <span class="card-title">WQMP O&amp;M Verification</span>
                 @if (currentPersonCanEdit) {
-                    <a class="btn btn-primary-outline btn-sm"
+                    <a class="btn btn-primary btn-sm"
                        [routerLink]="['/water-quality-management-plans', waterQualityManagementPlanID, 'verifications', 'new']">
                         <i class="fa fa-plus"></i> Begin O&amp;M Verification
                     </a>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
@@ -416,15 +416,15 @@
                                             <span class="document-name">{{ doc.DisplayName }}</span>
                                             <span class="document-entry-actions">
                                                 @if (doc.FileResource?.FileResourceGUID) {
-                                                    <a class="btn btn-sm btn-primary-outline doc-action" [href]="fileResourceUrl(doc.FileResource.FileResourceGUID)" target="_blank" title="Download document" aria-label="Download document">
+                                                    <a class="btn btn-sm btn-primary-outline btn-icon" [href]="fileResourceUrl(doc.FileResource.FileResourceGUID)" target="_blank" title="Download document" aria-label="Download document">
                                                         <i class="fa fa-download"></i>
                                                     </a>
                                                 }
                                                 @if (currentPersonCanManage) {
-                                                    <button type="button" class="btn btn-sm btn-primary-outline doc-action" (click)="openDocumentEditModal(doc)" title="Edit document" aria-label="Edit document">
+                                                    <button type="button" class="btn btn-sm btn-primary-outline btn-icon" (click)="openDocumentEditModal(doc)" title="Edit document" aria-label="Edit document">
                                                         <i class="fa fa-pencil"></i>
                                                     </button>
-                                                    <button type="button" class="btn btn-sm btn-danger-outline doc-action" (click)="confirmDocumentDelete(doc)" title="Delete document" aria-label="Delete document">
+                                                    <button type="button" class="btn btn-sm btn-danger-outline btn-icon" (click)="confirmDocumentDelete(doc)" title="Delete document" aria-label="Delete document">
                                                         <i class="fa fa-trash"></i>
                                                     </button>
                                                 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.scss
@@ -11,11 +11,6 @@
 
 }
 
-.card-body h4 {
-    color: $primary;
-    font-size: $type-size-400;
-}
-
 // NPT-1068: Modeling Approach heading row. Lift the Edit button + "Learn about WQMP Modeling
 // Options" link OUT of the h4 so they don't inherit its large teal heading styling.
 .modeling-approach-heading {
@@ -101,39 +96,82 @@
 }
 
 .document-entry {
-    margin-bottom: 1rem;
+    border: 1px solid $gray-200;
+    border-radius: $border-radius-200;
+    padding: $spacing-400;
 }
 
 .document-entry-header {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    gap: 1rem;
+    justify-content: space-between;
+    gap: $spacing-300;
+}
+
+// Document title: larger and bolder than the field labels below it, so the two read
+// as distinct levels — but the same text color (inherits body), per request.
+.document-name {
+    font-size: $type-size-300;
+    font-weight: 700;
 }
 
 .document-entry-actions {
     display: inline-flex;
-    gap: 0.25rem;
+    gap: $spacing-100;
     white-space: nowrap;
+    flex-shrink: 0;
+}
+
+// Icon-only sizing for the grouped action buttons (download / edit / delete); color and
+// hover come from the btn-primary-outline / btn-danger-outline classes applied alongside.
+// NOTE: the app has several competing icon-button styles (btn-edit-inline, btn-delete-row,
+// and undefined btn-icon/icon-button) — a candidate to consolidate into one shared class.
+.doc-action {
+    width: 2rem;
+    height: 2rem;
+    min-width: 0;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    .fa {
+        margin: 0;
+        font-size: 0.875rem;
+    }
 }
 
 ::ng-deep .ag-row-pinned-bottom {
     font-weight: bold;
 }
 
+// NPT UX pilot: document rows use the shared compact .kv key/value grid
+// (auto / 1fr, left-aligned labels) instead of a floated dl-horizontal, so labels
+// and values align in clean columns and the value reads as body copy, not a heading.
+// Responsive grid of distinct document-type tiles: fills available width with as
+// many columns as fit (auto-fill / minmax), collapsing to a single column on
+// narrow screens. Each tile is a bordered panel so categories stay visually distinct.
+// Document-type sections stack vertically (full width) so each document has room to
+// spread horizontally and titles don't wrap.
+.document-groups {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-500;
+}
+
+// Within a full-width section, documents flow into as many columns as fit.
+.document-entries {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(28rem, 1fr));
+    gap: $spacing-400 $spacing-500;
+}
+
+.document-group-title {
+    margin-bottom: $spacing-200;
+}
+
 .document-details {
-    margin-top: 0.25rem;
-    margin-left: 1rem;
-
-    dt {
-        float: left;
-        width: 120px;
-        font-weight: normal;
-        clear: left;
-    }
-
-    dd {
-        margin-left: 130px;
-    }
+    margin-top: $spacing-100;
+    margin-left: $spacing-300;
 }
 

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.scss
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.scss
@@ -117,29 +117,12 @@
 
 .document-entry-actions {
     display: inline-flex;
-    gap: $spacing-100;
+    gap: $spacing-200;
     white-space: nowrap;
     flex-shrink: 0;
 }
 
-// Icon-only sizing for the grouped action buttons (download / edit / delete); color and
-// hover come from the btn-primary-outline / btn-danger-outline classes applied alongside.
-// NOTE: the app has several competing icon-button styles (btn-edit-inline, btn-delete-row,
-// and undefined btn-icon/icon-button) — a candidate to consolidate into one shared class.
-.doc-action {
-    width: 2rem;
-    height: 2rem;
-    min-width: 0;
-    padding: 0;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-
-    .fa {
-        margin: 0;
-        font-size: 0.875rem;
-    }
-}
+// Icon-only action buttons use the shared .btn-icon class (see _btn.scss).
 
 ::ng-deep .ag-row-pinned-bottom {
     font-weight: bold;

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
@@ -394,6 +394,7 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
                 const actions: any[] = [
                     {
                         ActionName: "View",
+                        ActionIcon: "fas fa-file-alt",
                         ActionHandler: () => this.router.navigate(["/water-quality-management-plans", wqmpID, "verifications", verifyID, "view"]),
                     },
                 ];
@@ -405,7 +406,7 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
                     });
                     actions.push({
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.confirmDeleteVerification(verifyID, params.data.VerificationDate),
                     });
                 }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-document-modal/wqmp-document-modal.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-document-modal/wqmp-document-modal.component.html
@@ -7,7 +7,7 @@
     <form [formGroup]="formGroup">
         <form-field
             size="md"
-            [fieldLabel]="mode === 'add' ? 'File' : 'Replace File (optional)'"
+            [fieldLabel]="mode === 'add' ? 'File' : 'Replace File'"
             [type]="FormFieldType.File"
             [formControl]="fileControl"
             [uploadFileAccepts]="uploadFileAccepts"
@@ -52,5 +52,5 @@
 </div>
 <div class="modal-footer">
     <button class="btn btn-primary" (click)="save()" [disabled]="isSaving()">{{ mode === "add" ? "Upload" : "Save" }}</button>
-    <button class="btn btn-secondary-outline" (click)="cancel()" [disabled]="isSaving()">Cancel</button>
+    <button class="btn btn-primary-outline" (click)="cancel()" [disabled]="isSaving()">Cancel</button>
 </div>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component.html
@@ -52,7 +52,7 @@
                 <form-field [type]="fieldType" [formControl]="editControl" [formInputOptions]="selectOptions" [mask]="mask"></form-field>
                 <div class="field-card__edit-actions">
                     <button class="btn btn-primary btn-sm" (click)="saveEdit()">Save</button>
-                    <button class="btn btn-secondary-outline btn-sm" (click)="cancelEdit()">Cancel</button>
+                    <button class="btn btn-primary-outline btn-sm" (click)="cancelEdit()">Cancel</button>
                 </div>
             </div>
         } @else {

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.html
@@ -39,7 +39,7 @@
                  jump between right-panel CTA and sidebar between states. The label and confirm
                  dialog text change with state but the click target stays put. -->
             <div class="review-sidebar__rerun">
-                <button class="btn btn-secondary-outline btn-block" (click)="confirmExtract()" [disabled]="isExtracting()"
+                <button class="btn btn-primary-outline btn-block" (click)="confirmExtract()" [disabled]="isExtracting()"
                         [title]="pageData.hasResult ? 'Replace the AI-extracted suggestions with a fresh run. Saved sections on the WQMP are preserved.' : 'Run AI extraction against the uploaded PDF.'">
                     @if (isExtracting()) {
                         <i class="fa fa-spinner fa-spin"></i> Extracting...

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-modal/wqmp-modal.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-modal/wqmp-modal.component.html
@@ -81,6 +81,6 @@
 </div>
 <div class="modal-footer">
     <button class="btn btn-primary" (click)="save()">Save</button>
-    <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
+    <button class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
 </div>
 </div>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-upload-modal/wqmp-upload-modal.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-upload-modal/wqmp-upload-modal.component.html
@@ -53,5 +53,5 @@
 </div>
 <div class="modal-footer">
     <button class="btn btn-primary" (click)="upload()" [disabled]="isUploading()">Upload</button>
-    <button class="btn btn-secondary-outline" (click)="cancel()" [disabled]="isUploading()">Cancel</button>
+    <button class="btn btn-primary-outline" (click)="cancel()" [disabled]="isUploading()">Cancel</button>
 </div>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-verifications/wqmp-verifications.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-verifications/wqmp-verifications.component.ts
@@ -51,6 +51,7 @@ export class WqmpVerificationsComponent {
                 const actions: any[] = [
                     {
                         ActionName: "View",
+                        ActionIcon: "fas fa-file-alt",
                         ActionHandler: () => this.router.navigate(["/water-quality-management-plans", wqmpID, "verifications", verifyID, "view"]),
                     },
                 ];
@@ -62,7 +63,7 @@ export class WqmpVerificationsComponent {
                     });
                     actions.push({
                         ActionName: "Delete",
-                        ActionIcon: "fa fa-trash text-danger",
+                        ActionIcon: "fas fa-trash text-danger",
                         ActionHandler: () => this.confirmDeleteVerification(wqmpID, verifyID, params.data.WaterQualityManagementPlanName, params.data.VerificationDate),
                     });
                 }

--- a/Neptune.Web/src/app/shared/components/ag-grid/context-menu/context-menu-renderer.component.scss
+++ b/Neptune.Web/src/app/shared/components/ag-grid/context-menu/context-menu-renderer.component.scss
@@ -33,6 +33,11 @@
             margin-top: 0.5rem;
         }
 
+        // Action icons sit to the left of the label; give them a little breathing room.
+        [class*="fa-"] {
+            margin-right: 0.4rem;
+        }
+
         &:hover {
             text-decoration: underline;
         }

--- a/Neptune.Web/src/app/shared/components/clear-grid-filters-button/clear-grid-filters-button.component.html
+++ b/Neptune.Web/src/app/shared/components/clear-grid-filters-button/clear-grid-filters-button.component.html
@@ -1,1 +1,1 @@
-<button class="btn btn-secondary btn-sm" [disabled]="!gridFiltersApplied" (click)="onClick()">Clear Filters</button>
+<button class="btn btn-primary-outline btn-sm" [disabled]="!gridFiltersApplied" (click)="onClick()">Clear Filters</button>

--- a/Neptune.Web/src/app/shared/components/custom-rich-text/custom-rich-text.component.html
+++ b/Neptune.Web/src/app/shared/components/custom-rich-text/custom-rich-text.component.html
@@ -22,7 +22,7 @@
       </div>
       <div class="flex-end">
         <button type="button" class="btn btn-secondary mt-1 mr-2" (click)="saveEdit()">Save</button>
-        <button type="button" class="btn btn-secondary-outline mt-1" (click)="cancelEdit()">Cancel</button>
+        <button type="button" class="btn btn-primary-outline mt-1" (click)="cancelEdit()">Cancel</button>
       </div>
     </div>
   }

--- a/Neptune.Web/src/app/shared/components/custom-rich-text/custom-rich-text.component.html
+++ b/Neptune.Web/src/app/shared/components/custom-rich-text/custom-rich-text.component.html
@@ -4,7 +4,7 @@
       @if (showEditButton()) {
         <div class="hoverEditButton">
           <div style="transform: translate3d(-10px, 20px, 0)">
-            <button type="button" class="btn btn-secondary" (click)="enterEdit()">Edit</button>
+            <button type="button" class="btn btn-primary-outline" (click)="enterEdit()">Edit</button>
           </div>
         </div>
       }
@@ -21,7 +21,7 @@
         <editor #tinyMceEditor [init]="tinyMceConfig" [(ngModel)]="editedContent"></editor>
       </div>
       <div class="flex-end">
-        <button type="button" class="btn btn-secondary mt-1 mr-2" (click)="saveEdit()">Save</button>
+        <button type="button" class="btn btn-primary mt-1 mr-2" (click)="saveEdit()">Save</button>
         <button type="button" class="btn btn-primary-outline mt-1" (click)="cancelEdit()">Cancel</button>
       </div>
     </div>

--- a/Neptune.Web/src/app/shared/components/edit-photo-caption-modal/edit-photo-caption-modal.component.html
+++ b/Neptune.Web/src/app/shared/components/edit-photo-caption-modal/edit-photo-caption-modal.component.html
@@ -18,6 +18,6 @@
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-primary" [disabled]="formGroup.invalid" (click)="save()">Save</button>
-        <button type="button" class="btn btn-secondary" (click)="cancel()">Cancel</button>
+        <button type="button" class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
     </div>
 </div>

--- a/Neptune.Web/src/app/shared/components/field-definition/field-definition.component.html
+++ b/Neptune.Web/src/app/shared/components/field-definition/field-definition.component.html
@@ -35,7 +35,7 @@
           <editor #tinyMceEditor [init]="tinyMceConfig" [(ngModel)]="editedContent"></editor>
           <div class="editor-buttons">
             <button type="button" class="btn btn-sm btn-primary mt-1 mr-1 mb-1" (click)="saveEdit()">Save</button>
-            <button type="button" class="btn btn-sm btn-secondary mt-1 mb-1" (click)="cancelEdit()">Cancel</button>
+            <button type="button" class="btn btn-sm btn-primary-outline mt-1 mb-1" (click)="cancelEdit()">Cancel</button>
           </div>
         </div>
       }

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-description-update-modal/file-description-update-modal.component.ts
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-description-update-modal/file-description-update-modal.component.ts
@@ -18,8 +18,13 @@ export class FileDescriptionUpdateModalComponent implements OnInit {
     });
 
     ngOnInit(): void {
+        // The dialog is opened with data: { FileResource: fileResource }, so the description
+        // lives at ref.data.FileResource.DocumentDescription — not ref.data.DocumentDescription.
+        // Reading the wrong path yielded undefined, and FormGroup.setValue throws on an undefined
+        // value, which aborted ngOnInit and left the modal with no textarea (NPT-1053 rework).
+        // Default to "" so the control always gets a defined value.
         this.formGroup.setValue({
-            FileDescription: this.ref.data.DocumentDescription,
+            FileDescription: this.ref.data.FileResource?.DocumentDescription ?? "",
         });
     }
 

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-resource-list.component.html
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-resource-list.component.html
@@ -16,55 +16,49 @@
             </div>
         </div>
     }
-    <div class="existing-file-container mb-4">
+    <div class="document-entries mb-4">
         @for (fileResource of fileResources; track fileResource) {
-            <div class="existing-file">
-                <div class="grid-12 file-row">
-                    <div class="g-col-8">
-                        <div class="file-info mb-2">
-                            <icon [icon]="'File'" [enableFontSize]="true" class="mr-1" style="font-size: 16px"></icon>
-                            <span class="file-name">
-                                <b>{{ fileResource.OriginalBaseFilename }}</b>
-                            </span>
-                        </div>
-                        <div class="file-description mb-2">
-                            <em>{{ fileResource.DocumentDescription }}</em>
-                        </div>
-                        <div>
-                            <b>Uploaded {{ fileResource.CreateDate | date: "short" }}</b>
-                        </div>
-                    </div>
-                    <div class="g-col-4 actions">
+            <div class="document-entry">
+                <div class="document-entry-header">
+                    <span class="document-name">{{ fileResource.OriginalBaseFilename }}</span>
+                    <span class="document-entry-actions">
                         @if (fileResource.IsImage) {
                             @if (imagePreviewUrls[fileResource.FileResourceGUID]) {
-                                <a href="javascript:void(0);" (click)="hideImagePreview(fileResource)" class="download-link mr-2">
-                                    <icon class="download-icon-button mr-1" icon="Resend"></icon>
-                                    <span>Hide Preview</span>
-                                </a>
+                                <button type="button" class="btn btn-sm btn-primary-outline btn-icon" (click)="hideImagePreview(fileResource)" title="Hide preview" aria-label="Hide preview">
+                                    <i class="fa fa-eye-slash"></i>
+                                </button>
                             } @else {
-                                <a href="javascript:void(0);" (click)="loadImagePreview(fileResource)" class="download-link mr-2">
-                                    <icon class="download-icon-button mr-1" icon="Question"></icon>
-                                    <span>Preview</span>
-                                </a>
+                                <button type="button" class="btn btn-sm btn-primary-outline btn-icon" (click)="loadImagePreview(fileResource)" title="Preview" aria-label="Preview">
+                                    <i class="fa fa-eye"></i>
+                                </button>
                             }
                         }
-
-                        <a href="javascript:void(0);" (click)="downloadFileResource(fileResource)" class="download-link mr-2">
-                            <icon class="download-icon-button mr-1" icon="Download"></icon>
-                            <span>Download</span>
+                        <a href="javascript:void(0);" class="btn btn-sm btn-primary-outline btn-icon" (click)="downloadFileResource(fileResource)" title="Download document" aria-label="Download document">
+                            <i class="fa fa-download"></i>
                         </a>
-
                         @if (allowEditing) {
-                            <icon class="edit-file-icon-button mr-2" [icon]="'CirclePencil'" (click)="openFileDescriptionUpdateModal(fileResource)"></icon>
-                            <button type="button" class="btn-delete-row delete-file-icon-button" aria-label="Delete file" title="Delete" (click)="deleteFileResource(fileResource)"></button>
+                            <button type="button" class="btn btn-sm btn-primary-outline btn-icon" (click)="openFileDescriptionUpdateModal(fileResource)" title="Edit document" aria-label="Edit document">
+                                <i class="fa fa-pencil"></i>
+                            </button>
+                            <button type="button" class="btn btn-sm btn-danger-outline btn-icon" (click)="deleteFileResource(fileResource)" title="Delete document" aria-label="Delete document">
+                                <i class="fa fa-trash"></i>
+                            </button>
                         }
-                    </div>
-                    @if (fileResource.IsImage && imagePreviewUrls[fileResource.FileResourceGUID]) {
-                        <div class="g-col-12 image-preview-row">
-                            <img [src]="imagePreviewUrls[fileResource.FileResourceGUID]" alt="Image preview" class="file-image-preview" />
-                        </div>
-                    }
+                    </span>
                 </div>
+                <dl class="kv document-details">
+                    <dt>Uploaded On</dt>
+                    <dd>{{ fileResource.CreateDate | date: "MM/dd/yyyy" }}</dd>
+                    <dt>File Type</dt>
+                    <dd>{{ fileResource.OriginalFileExtension || "—" }}</dd>
+                    <dt>Description</dt>
+                    <dd>{{ fileResource.DocumentDescription || "—" }}</dd>
+                </dl>
+                @if (fileResource.IsImage && imagePreviewUrls[fileResource.FileResourceGUID]) {
+                    <div class="image-preview-row">
+                        <img [src]="imagePreviewUrls[fileResource.FileResourceGUID]" alt="Image preview" class="file-image-preview" />
+                    </div>
+                }
             </div>
         }
     </div>

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-resource-list.component.html
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-resource-list.component.html
@@ -17,7 +17,7 @@
         </div>
     }
     <div class="document-entries mb-4">
-        @for (fileResource of fileResources; track fileResource) {
+        @for (fileResource of fileResources; track fileResource.FileResourceGUID) {
             <div class="document-entry">
                 <div class="document-entry-header">
                     <span class="document-name">{{ fileResource.OriginalBaseFilename }}</span>
@@ -33,9 +33,9 @@
                                 </button>
                             }
                         }
-                        <a href="javascript:void(0);" class="btn btn-sm btn-primary-outline btn-icon" (click)="downloadFileResource(fileResource)" title="Download document" aria-label="Download document">
+                        <button type="button" class="btn btn-sm btn-primary-outline btn-icon" (click)="downloadFileResource(fileResource)" title="Download document" aria-label="Download document">
                             <i class="fa fa-download"></i>
-                        </a>
+                        </button>
                         @if (allowEditing) {
                             <button type="button" class="btn btn-sm btn-primary-outline btn-icon" (click)="openFileDescriptionUpdateModal(fileResource)" title="Edit document" aria-label="Edit document">
                                 <i class="fa fa-pencil"></i>

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-resource-list.component.scss
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-resource-list.component.scss
@@ -41,138 +41,50 @@
     top: 2px;
 }
 
-.existing-file {
+// Match the WQMP detail documents styling: bordered entry panels in a responsive grid, an
+// icon-button action row, and the shared .kv key/value detail grid. No document-type sections
+// here — BMP documents aren't typed — so entries flow directly into the grid.
+.document-entries {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(28rem, 1fr));
+    gap: $spacing-400 $spacing-500;
+}
+
+.document-entry {
+    border: 1px solid $gray-200;
+    border-radius: $border-radius-200;
+    padding: $spacing-400;
+}
+
+.document-entry-header {
     display: flex;
     align-items: center;
-    background: #fff;
-    border: 1px solid #ddd; // Light gray border
-    border-radius: 8px; // Rounded corners
-    padding: 1rem;
-    box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.1); // Subtle shadow
-    margin-bottom: 1rem;
+    justify-content: space-between;
+    gap: $spacing-300;
 }
 
-.file-description {
-    color: $gray-700;
+// Document title: larger and bolder than the field labels below it, same body text color.
+.document-name {
+    font-size: $type-size-300;
+    font-weight: 700;
 }
 
-.file-upload-date {
-    color: $gray-950;
-}
-
-.existing-file .grid-12 {
-    width: 100%;
-    gap: 0.5rem;
-}
-
-.existing-file .grid-12 .g-col-12 {
-    width: 100%;
-    display: block;
-}
-
-.existing-file .g-col-2 {
-    display: inline-block;
-    vertical-align: middle;
-    font-size: 1.5rem;
-    text-align: center;
-}
-
-.file-info {
-    width: 100%;
-}
-
-.file-info .file-name {
-    margin-bottom: 2px;
-    font-size: $type-size-400;
-}
-
-.existing-file .g-col-8 {
-    display: inline-block;
-    vertical-align: middle;
-    padding: 0 1rem;
-}
-
-.actions {
-    display: flex;
-    align-items: center;
-    position: relative;
-    height: 100%;
-}
-
-@include desktop-small {
-    .actions {
-        text-align: left;
-        justify-content: flex-start;
-    }
-}
-
-@include desktop-medium {
-    .actions {
-        text-align: right;
-        justify-content: flex-end;
-    }
-}
-
-.actions > * {
-    vertical-align: middle;
-}
-
-.download-link {
+.document-entry-actions {
     display: inline-flex;
-    align-items: center;
-    vertical-align: middle;
-    text-decoration: none;
+    gap: $spacing-200;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
-.download-icon-button {
-    cursor: pointer;
-    ::ng-deep {
-        svg {
-            height: 2rem;
-            width: 2rem;
-            transition: color 0.2s ease-in-out;
-        }
-    }
+// Icon-only action buttons use the shared .btn-icon class (see _btn.scss).
+
+.document-details {
+    margin-top: $spacing-100;
+    margin-left: $spacing-300;
 }
 
-.edit-file-icon-button {
-    cursor: pointer;
-    ::ng-deep {
-        svg {
-            height: 2rem;
-            width: 2rem;
-            color: $gray-400;
-            transition: color 0.2s ease-in-out;
-        }
-    }
-}
-
-.edit-file-icon-button:hover {
-    ::ng-deep {
-        svg {
-            color: $gray-600;
-        }
-    }
-}
-
-.delete-file-icon-button {
-    cursor: pointer;
-    ::ng-deep {
-        svg {
-            height: 2rem;
-            width: 2rem;
-            color: $gray-400;
-            transition: color 0.2s ease-in-out;
-        }
-    }
-}
-
-.delete-file-icon-button:hover {
-    ::ng-deep {
-        svg {
-            color: $red-default;
-        }
-    }
+.image-preview-row {
+    margin-top: $spacing-300;
 }
 
 .file-image-preview {

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.html
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.html
@@ -11,7 +11,15 @@
                 <label class="required field-label">Document</label>
                 <div class="file-upload-wrapper pb-2">
                     <label for="file-upload" class="custom-file-upload">
-                        <input #fileUploadField type="file" class="form-control" name="file-upload" id="fileUpload" (change)="updateFile($event)" required />
+                        <input
+                            #fileUploadField
+                            type="file"
+                            class="form-control"
+                            name="file-upload"
+                            id="fileUpload"
+                            [accept]="uploadFileAccepts"
+                            (change)="updateFile($event)"
+                            required />
                         <span class="file-name" [title]="fileName + fileExtension || 'No file chosen...'">
                             <span class="base"> {{ fileName }} </span
                             ><span class="ext">
@@ -21,6 +29,9 @@
                         <button class="btn btn-primary" (click)="onClickFileUpload($event)"><i class="fas fa-folder-open"></i> Browse</button>
                     </label>
                 </div>
+                @if (fileError) {
+                    <div class="text-danger mb-1">{{ fileError }}</div>
+                }
                 <em>Accepted extensions: PDF, PNG, JPG, DOCX, DOC, XLSX, CSV, TXT</em>
                 <i class="fas fa-file-open"></i>
             </div>

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.html
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.html
@@ -20,7 +20,7 @@
                             [accept]="uploadFileAccepts"
                             (change)="updateFile($event)"
                             required />
-                        <span class="file-name" [title]="fileName + fileExtension || 'No file chosen...'">
+                        <span class="file-name" [title]="fileName ? fileName + fileExtension : 'No file chosen...'">
                             <span class="base"> {{ fileName }} </span
                             ><span class="ext">
                                 {{ fileExtension }}

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.html
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.html
@@ -10,7 +10,7 @@
             <div class="field g-col-12">
                 <label class="required field-label">Document</label>
                 <div class="file-upload-wrapper pb-2">
-                    <label for="file-upload" class="custom-file-upload">
+                    <label for="fileUpload" class="custom-file-upload">
                         <input
                             #fileUploadField
                             type="file"

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.ts
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.ts
@@ -16,21 +16,18 @@ export class FileUploadModalComponent {
     @ViewChild("fileUploadField") fileUploadField: any;
     @Output() fileChanged = new EventEmitter<File>();
 
-    //pdf, jpg, png, csv, txt, xlsx, docx, doc
-    public allowedFileTypes: string[] = [
-        "application/pdf",
-        "image/jpeg",
-        "image/png",
-        "text/csv",
-        "text/plain",
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "application/msword",
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    ];
+    // Mirror FileResources.ValidateFileUpload's accepted extensions exactly so the client can't
+    // pick a file the server will reject. uploadFileAccepts feeds the input's accept attribute;
+    // allowedExtensions backs the explicit check in updateFile() (accept alone is only a hint and
+    // doesn't block drag-drop or "All files" selection). NPT-1053 rework: previously there was no
+    // validation, so an unsupported file (e.g. .gdb) silently closed the modal with no error.
+    public uploadFileAccepts = ".pdf,.png,.jpg,.jpeg,.doc,.docx,.xlsx,.txt,.csv";
+    private allowedExtensions = [".pdf", ".png", ".jpg", ".jpeg", ".doc", ".docx", ".xlsx", ".txt", ".csv"];
 
     public file: File;
     public fileName: string;
     public fileExtension: string;
+    public fileError: string;
 
     public formGroup: FormGroup<FileResourceUploadForm> = new FormGroup<FileResourceUploadForm>({
         File: new FormControl<File>(null),
@@ -43,13 +40,31 @@ export class FileUploadModalComponent {
     }
 
     updateFile(event: any): void {
-        this.file = event.target.files.item(0);
-        if (this.file) {
-            const name = this.file.name;
+        const selectedFile: File = event.target.files.item(0);
+        this.fileError = null;
+
+        if (selectedFile) {
+            const name = selectedFile.name;
             const i = name.lastIndexOf(".");
+            const extension = i > 0 ? name.slice(i) : "";
+
+            if (!this.allowedExtensions.includes(extension.toLowerCase())) {
+                // Reject the file and surface a clear message instead of letting it through to a
+                // silent server-side rejection. Clear the input so the user can re-pick.
+                this.file = null;
+                this.fileName = null;
+                this.fileExtension = null;
+                event.target.value = "";
+                this.fileError = `${extension ? extension.slice(1).toUpperCase() : "This file type"} is not an accepted file type. Accepted extensions: PDF, PNG, JPG, DOCX, DOC, XLSX, CSV, TXT.`;
+                this.fileChanged.emit(null);
+                return;
+            }
+
+            this.file = selectedFile;
             this.fileName = i > 0 ? name.slice(0, i) : name;
-            this.fileExtension = i > 0 ? name.slice(i) : "";
+            this.fileExtension = extension;
         } else {
+            this.file = null;
             this.fileName = null;
             this.fileExtension = null;
         }

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.ts
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.ts
@@ -21,8 +21,8 @@ export class FileUploadModalComponent {
     // allowedExtensions backs the explicit check in updateFile() (accept alone is only a hint and
     // doesn't block drag-drop or "All files" selection). NPT-1053 rework: previously there was no
     // validation, so an unsupported file (e.g. .gdb) silently closed the modal with no error.
-    public uploadFileAccepts = ".pdf,.png,.jpg,.jpeg,.doc,.docx,.xlsx,.txt,.csv";
     private allowedExtensions = [".pdf", ".png", ".jpg", ".jpeg", ".doc", ".docx", ".xlsx", ".txt", ".csv"];
+    public uploadFileAccepts = this.allowedExtensions.join(",");
 
     public file: File;
     public fileName: string;

--- a/Neptune.Web/src/app/shared/components/image-editor/image-editor.component.html
+++ b/Neptune.Web/src/app/shared/components/image-editor/image-editor.component.html
@@ -72,6 +72,6 @@
 @if (!useCaptionModal) {
     <div class="page-footer">
         <button type="button" class="btn btn-primary mr-2" [disabled]="isLoadingSubmit || captionControlForm.pristine" (click)="save()">Save</button>
-        <button type="button" class="btn btn-secondary" [disabled]="isLoadingSubmit" (click)="cancel()">Cancel</button>
+        <button type="button" class="btn btn-primary-outline" [disabled]="isLoadingSubmit" (click)="cancel()">Cancel</button>
     </div>
 }

--- a/Neptune.Web/src/app/shared/components/lat-lon-picker/lat-lon-picker.component.html
+++ b/Neptune.Web/src/app/shared/components/lat-lon-picker/lat-lon-picker.component.html
@@ -14,7 +14,7 @@
         </div>
 
         <div class="buttons-row">
-            <button class="btn btn-secondary" type="button" (click)="useCurrentLocation()">
+            <button class="btn btn-primary-outline" type="button" (click)="useCurrentLocation()">
                 <icon name="crosshair"></icon>
                 Use Current Location
             </button>

--- a/Neptune.Web/src/app/shared/components/lat-lon-picker/lat-lon-picker.component.html
+++ b/Neptune.Web/src/app/shared/components/lat-lon-picker/lat-lon-picker.component.html
@@ -18,7 +18,7 @@
                 <icon name="crosshair"></icon>
                 Use Current Location
             </button>
-            <button class="btn btn-outline-secondary" type="button" (click)="clearLocation()">Clear</button>
+            <button class="btn btn-primary-outline" type="button" (click)="clearLocation()">Clear</button>
         </div>
     </div>
 

--- a/Neptune.Web/src/app/shared/components/neptune-grid-header/neptune-grid-header.component.html
+++ b/Neptune.Web/src/app/shared/components/neptune-grid-header/neptune-grid-header.component.html
@@ -32,13 +32,13 @@
         @if (selectedRowsCount > 0) {
           <span class="selection-info"> {{ selectedRowsCount }} of {{ rowDataCount }} Selected </span>
         }
-        <button class="btn btn-sm btn-secondary" (click)="onSelectAll()" [class.disabled]="allRowsSelected">
+        <button class="btn btn-sm btn-primary-outline" (click)="onSelectAll()" [class.disabled]="allRowsSelected">
           Select All
           @if (anyFilterPresent) {
             <span>(filtered)</span>
           }
         </button>
-        <button class="btn btn-sm btn-secondary" (click)="onDeselectAll()" [class.disabled]="selectedRowsCount < 1">
+        <button class="btn btn-sm btn-primary-outline" (click)="onDeselectAll()" [class.disabled]="selectedRowsCount < 1">
           Deselect All
           @if (anyFilterPresent) {
             <span>(filtered)</span>

--- a/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.html
+++ b/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.html
@@ -39,9 +39,9 @@
     (gridReady)="onGridReady($event)"
     (firstDataRendered)="onFirstDataRendered($event)"
     (gridColumnsChanged)="onGridColumnsChanged($event)"
+    (gridSizeChanged)="onGridSizeChanged($event)"
     (selectionChanged)="this.onSelectionChanged($event)"
-    (filterChanged)="onFilterChanged($event)"
-  (rowDataUpdated)="onRowDataUpdated($event)"></ag-grid-angular>
+  (filterChanged)="onFilterChanged($event)"></ag-grid-angular>
 
   <div class="table-footer flex-between">
     <div style="display: flex">

--- a/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.ts
+++ b/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from "@angular/core";
+import { Component, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { AgGridAngular, AgGridModule } from "ag-grid-angular";
 import {
@@ -9,7 +9,7 @@ import {
     GridApi,
     GridColumnsChangedEvent,
     GridReadyEvent,
-    RowDataUpdatedEvent,
+    GridSizeChangedEvent,
     SelectionChangedEvent,
 } from "ag-grid-community";
 import { AgGridHelper } from "src/app/shared/helpers/ag-grid-helper";
@@ -80,6 +80,8 @@ export class NeptuneGridComponent implements OnInit, OnChanges {
 
     public fullscreenTitleText = "Make grid full screen";
 
+    constructor(private elementRef: ElementRef) {}
+
     ngOnInit(): void {
         this.autoSizeStrategy = { type: this.sizeColumnsToFitGrid ? "fitGridWidth" : "fitCellContents" };
         this.multiSelectEnabled = this.rowSelection == "multiple";
@@ -111,14 +113,40 @@ export class NeptuneGridComponent implements OnInit, OnChanges {
     }
 
     public onFirstDataRendered(event: FirstDataRenderedEvent) {
-        event.api.sizeColumnsToFit();
+        // The initial fit is owned by [autoSizeStrategy] (fitGridWidth or fitCellContents, set in
+        // ngOnInit). We no longer call sizeColumnsToFit()/autoSizeAllColumns() here — the old code
+        // ran BOTH a width-fit (here) and a content-fit (onRowDataUpdated) on every load, and they
+        // fought each other. Worse, when the container had no width yet (hybrid map grids, hidden
+        // tabs) the width-fit collapsed every column to its min, hiding header and data until the
+        // user dragged them. Responsive re-fitting now happens in the guarded onGridSizeChanged. (NPT-1079)
         this.gridLoaded = true;
 
         this.gridRefReady.emit(this.gridref);
     }
 
     public onGridColumnsChanged(event: GridColumnsChangedEvent) {
-        event.api.sizeColumnsToFit();
+        // Re-fit when the column set changes (e.g. dynamic custom-attribute columns), but only when
+        // the grid is actually laid out — fitting a zero-width container collapses the columns.
+        if (!this.gridHasWidth()) return;
+        if (this.sizeColumnsToFitGrid) {
+            event.api.sizeColumnsToFit();
+        } else {
+            event.api.autoSizeAllColumns();
+        }
+    }
+
+    public onGridSizeChanged(event: GridSizeChangedEvent) {
+        // Fires on container resize and when a hidden grid becomes visible. Only fit-to-width grids
+        // re-flow on resize, and only once the grid has real width — the clientWidth guard is what
+        // prevents the "columns collapsed until manually resized" bug. (NPT-1079)
+        if (this.sizeColumnsToFitGrid && event.clientWidth > 0) {
+            event.api.sizeColumnsToFit();
+        }
+    }
+
+    private gridHasWidth(): boolean {
+        const wrapper = this.elementRef.nativeElement?.querySelector(".ag-root-wrapper");
+        return !!wrapper && wrapper.clientWidth > 0;
     }
 
     public onSelectionChanged(event: SelectionChangedEvent) {
@@ -142,10 +170,6 @@ export class NeptuneGridComponent implements OnInit, OnChanges {
         this.filteredRowsCount = filteredRowsCount;
     }
 
-    public onRowDataUpdated(event: RowDataUpdatedEvent) {
-        event.api.autoSizeAllColumns();
-    }
-
     onSelectAll() {
         this.gridApi.selectAllFiltered();
     }
@@ -160,7 +184,12 @@ export class NeptuneGridComponent implements OnInit, OnChanges {
     }
 
     public handleScreenSizeChangedEvent() {
-        if (this.gridApi) {
+        // Toggling fullscreen changes the grid's available width. Re-fit using the grid's own
+        // strategy (width-fit vs content-fit), guarded so we never fit a zero-width container.
+        if (!this.gridApi || !this.gridHasWidth()) return;
+        if (this.sizeColumnsToFitGrid) {
+            this.gridApi.sizeColumnsToFit();
+        } else {
             this.gridApi.autoSizeAllColumns();
         }
     }

--- a/Neptune.Web/src/app/shared/components/treatment-bmp-editors/custom-attributes-form/treatment-bmp-custom-attributes-form.component.html
+++ b/Neptune.Web/src/app/shared/components/treatment-bmp-editors/custom-attributes-form/treatment-bmp-custom-attributes-form.component.html
@@ -10,7 +10,7 @@
                 <button type="button" class="btn btn-primary mr-2" (click)="save(treatmentBMPTypeCustomAttributeTypes)" [disabled]="isLoadingSubmit || formGroup.invalid">
                     Save
                 </button>
-                <button type="button" class="btn btn-secondary" (click)="cancel()">Cancel</button>
+                <button type="button" class="btn btn-primary-outline" (click)="cancel()">Cancel</button>
             </div>
         }
     }

--- a/Neptune.Web/src/app/shared/components/treatment-bmp-editors/location-editor/treatment-bmp-location-editor.component.html
+++ b/Neptune.Web/src/app/shared/components/treatment-bmp-editors/location-editor/treatment-bmp-location-editor.component.html
@@ -23,7 +23,7 @@
     @if (!hideFooter) {
         <div class="page-footer">
             <button type="button" class="btn btn-primary" (click)="save()" [disabled]="isLoadingSubmit">Save</button>
-            <button type="button" class="btn btn-secondary-outline" (click)="cancel()" [disabled]="isLoadingSubmit">Cancel</button>
+            <button type="button" class="btn btn-primary-outline" (click)="cancel()" [disabled]="isLoadingSubmit">Cancel</button>
         </div>
     }
 }

--- a/Neptune.Web/src/app/shared/observation-types/observation-type-preview-modal.component.ts
+++ b/Neptune.Web/src/app/shared/observation-types/observation-type-preview-modal.component.ts
@@ -35,7 +35,7 @@ export interface ObservationTypePreviewModalData {
                 }
             </div>
             <div class="modal-footer">
-                <button class="btn btn-secondary-outline" (click)="close()">Close</button>
+                <button class="btn btn-primary-outline" (click)="close()">Close</button>
             </div>
         </div>
     `,

--- a/Neptune.Web/src/scss/components/_btn.scss
+++ b/Neptune.Web/src/scss/components/_btn.scss
@@ -399,3 +399,35 @@ button.btn:not(.btn-sm):not(.btn-text) {
         margin-left: 1px; // visually center the pencil glyph
     }
 }
+
+// Icon-only button — square, centered glyph, no text padding. Compose with `.btn` and a
+// color class (e.g. `btn btn-primary-outline btn-icon`, `btn btn-danger-outline btn-icon`),
+// or use bare for a borderless inline icon affordance. Single source of truth for icon
+// buttons — replaces the per-component .doc-action copies and previously-undefined usages.
+.btn-icon {
+    width: 2rem;
+    height: 2rem;
+    min-width: 0;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    .fa,
+    .fas,
+    .far,
+    icon,
+    svg {
+        margin: 0;
+        font-size: 0.875rem;
+    }
+}
+
+// Danger color for a bare (chrome-less) icon button, e.g. an inline delete affordance.
+.btn-icon-danger {
+    color: $red-default;
+
+    &:hover {
+        color: $red-dark;
+    }
+}

--- a/Neptune.Web/src/scss/components/_dl.scss
+++ b/Neptune.Web/src/scss/components/_dl.scss
@@ -37,17 +37,36 @@ dl.kv {
     }
 }
 
+// Detail-page key/value list. Renders as a compact two-column grid whose label column
+// hugs its content and values sit immediately beside it (no cavernous gutter, no ragged
+// right-aligned labels). The auto/1fr layout governs regardless of any grid-12 / g-col-*
+// spans the markup carries, so every detail page reads consistently — mirrors .kv.
 dl.key-value-list {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    column-gap: $spacing-300;
+    row-gap: $spacing-200;
+    align-items: baseline;
+
     &.grid-12 {
         row-gap: $spacing-300;
+    }
+
+    // Neutralize the grid-12 g-col-* spans (out-specify `.grid-12 > .g-col-N`) so the
+    // auto/1fr label/value layout governs.
+    &.grid-12 > dt,
+    &.grid-12 > dd {
+        grid-column: auto;
     }
 
     dt {
         padding-bottom: 0;
         text-align: left;
+        font-weight: 600;
+        font-size: inherit;
+    }
 
-        @include desktop-small {
-            text-align: right;
-        }
+    dd {
+        margin: 0;
     }
 }

--- a/Neptune.Web/src/scss/components/_tables.scss
+++ b/Neptune.Web/src/scss/components/_tables.scss
@@ -5,6 +5,13 @@
     font-size: $type-size-200;
     border-collapse: separate;
 
+    // Center-aligned cells (header + body). Previously referenced as an undefined class;
+    // scoped under .table so it out-specifies the default left-aligned th/td rules.
+    th.cell-center,
+    td.cell-center {
+        text-align: center;
+    }
+
     thead {
         th {
             text-align: left;

--- a/Neptune.Web/src/scss/utilities/_headings.scss
+++ b/Neptune.Web/src/scss/utilities/_headings.scss
@@ -98,8 +98,7 @@ h6 {
 }
 
 .module-title {
-    font-size: $type-size-200;
-    text-transform: uppercase;
+    font-size: $type-size-300;
     letter-spacing: 0.05em;
     font-weight: bold;
     padding-bottom: 0.5rem;


### PR DESCRIPTION
## Summary

Pilot pass of the UI/UX audit recommendations, applying the design-system baseline (`audit/_rubric.md`) across form editors, detail pages, and grids. The bulk of the diff is visual/structural, but it also includes one intentional behavior change uncovered during the audit — see **Behavior change** below.

## Behavior change (NPT-1079)

The Treatment BMP `List` endpoint now filters results for public (anonymous) and Unassigned-role users down to verified BMPs only (`InventoryIsVerified`), matching the legacy Find-a-BMP behavior. This adds a per-BMP verified gate the SPA list endpoint was previously missing, and is backed by a new `InventoryIsVerified` column on `vTreatmentBMPDetailed`. Reviewers should validate the public/unassigned list results.

## What's included

**Form editors (latest pass)**
- **Create Treatment BMP** — `Details`/`Location` `.module-title` headings, removed empty spacer `g-col` divs, cleaned up the Save footer. Left bare under the page-header (no redundant card).
- **Edit BMP Basic Info** — read-only BMP Type/Jurisdiction now render as aligned disabled-style fields instead of oversized unboxed text; Notes given its `g-col`.
- **WQMP Edit Quick BMPs** — "Set all to 'Yes'" DWF control moved into the has-rows branch (was showing in the empty state); Save/Cancel → `.page-footer`; Add → `btn-primary-outline` (Save is the lone solid primary); trash icon moved right and goes white on hover; first-row border-top; hardcoded `#ddd`/`#6c757d`/px replaced with tokens.
- **lat-lon-picker** — Clear button off the undefined `btn-outline-secondary` onto `btn-primary-outline`.
- **Treatment BMP upload** — standard back pattern (`.back__link` + `templateRight` Download button); nested `grid-12` field gaps; Upload button in a `.page-footer`.

**Earlier on the branch** — detail-page key/value list compaction, WQMP detail Documents card rework, button-semantics/icon-button consolidation, grid action-dropdown icon consolidation, and the NPT-1079 public BMP-list visibility work.

## Testing
- `npm run build` green throughout (note: `npm run lint` is currently broken project-wide due to an eslint-config-prettier/ESLint-9 issue, unrelated to this work).

## Notes
- Source Control BMPs editor was evaluated and intentionally left as-is.
- Remaining upload siblings and the OVTA Initiate form are deferred to a follow-up.
