### PR TITLE
Apply npm audit security fixes; pin geoman to 2.19.2

### DIFF
--- a/Neptune.Web/package-lock.json
+++ b/Neptune.Web/package-lock.json
@@ -21,7 +21,7 @@
                 "@angular/platform-server": "^21.2.8",
                 "@angular/router": "^21.2.8",
                 "@auth0/auth0-angular": "^2.5.0",
-                "@geoman-io/leaflet-geoman-free": "^2.18.3",
+                "@geoman-io/leaflet-geoman-free": "2.19.2",
                 "@ng-select/ng-select": "^21.0.0",
                 "@ngneat/dialog": "^5.2.0",
                 "@popperjs/core": "^2.11.8",
@@ -1247,43 +1247,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
-        "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.27.3",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
@@ -2215,6 +2178,12 @@
             "funding": {
                 "url": "https://opencollective.com/turf"
             }
+        },
+        "node_modules/@geoman-io/leaflet-geoman-free/node_modules/lodash": {
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "license": "MIT"
         },
         "node_modules/@harperfast/extended-iterable": {
             "version": "1.0.3",
@@ -4945,9 +4914,9 @@
             }
         },
         "node_modules/@tufjs/models/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10117,13 +10086,13 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-            "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+            "version": "8.5.2",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+            "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ip-address": "10.1.0"
+                "ip-address": "^10.2.0"
             },
             "engines": {
                 "node": ">= 16"
@@ -10711,9 +10680,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11075,9 +11044,9 @@
             }
         },
         "node_modules/ignore-walk/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11170,9 +11139,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12099,9 +12068,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.merge": {

--- a/Neptune.Web/package.json
+++ b/Neptune.Web/package.json
@@ -39,7 +39,7 @@
         "@angular/platform-server": "^21.2.8",
         "@angular/router": "^21.2.8",
         "@auth0/auth0-angular": "^2.5.0",
-        "@geoman-io/leaflet-geoman-free": "^2.18.3",
+        "@geoman-io/leaflet-geoman-free": "2.19.2",
         "@ng-select/ng-select": "^21.0.0",
         "@ngneat/dialog": "^5.2.0",
         "@popperjs/core": "^2.11.8",


### PR DESCRIPTION
## What

Applies the safe subset of `npm audit fix` security bumps and pins geoman to keep the build green.

### Kept (security fixes)
| Package | Change |
|---|---|
| `express-rate-limit` | 8.3.2 → 8.5.2 |
| `ip-address` | 10.1.0 → 10.2.0 |
| `lodash` | 4.17.23 → 4.18.1 |
| `brace-expansion` | 5.0.5 → 5.0.6 |

### Held back
`npm audit fix` also tried to bump `@geoman-io/leaflet-geoman-free` **2.19.2 → 2.19.3**, which **breaks the build**: 2.19.3 changed its Leaflet event-type augmentation, so the `pm:create` handlers that read `event.shape` across ~9 map components fail with `TS2769: No overload matches this call`.

Pinned geoman to exact `2.19.2` (dropped the `^` caret) so it can't float to 2.19.3. The pin should be loosened once the `pm:*` handler typings are fixed (also blocks Dependabot #466).

## Verification
- `npm run build-dev` passes (clean, exit 0)