### PR TITLE
NPT-1091: Add Find-a-BMP features to the Treatment BMP hybrid page

### DIFF
--- a/Neptune.Web/src/app/app.routes.ts
+++ b/Neptune.Web/src/app/app.routes.ts
@@ -406,11 +406,6 @@ export const routes: Routes = [
                 canActivate: [JurisdictionManagerOrEditorOnlyGuard],
             },
             {
-                path: "find-bmp",
-                title: "Find a BMP",
-                loadComponent: () => import("./pages/find-bmp/find-bmp.component").then((m) => m.FindBmpComponent),
-            },
-            {
                 path: "modeling-attributes",
                 title: "Modeling Attributes",
                 loadComponent: () => import("./pages/modeling-attributes/modeling-attributes.component").then((m) => m.ModelingAttributesComponent),

--- a/Neptune.Web/src/app/pages/find-bmp/find-bmp.component.html
+++ b/Neptune.Web/src/app/pages/find-bmp/find-bmp.component.html
@@ -1,1 +1,0 @@
-<!-- Placeholder for Find BMP component template -->

--- a/Neptune.Web/src/app/pages/find-bmp/find-bmp.component.scss
+++ b/Neptune.Web/src/app/pages/find-bmp/find-bmp.component.scss
@@ -1,1 +1,0 @@
-/* Placeholder for Find BMP component styles */

--- a/Neptune.Web/src/app/pages/find-bmp/find-bmp.component.ts
+++ b/Neptune.Web/src/app/pages/find-bmp/find-bmp.component.ts
@@ -1,3 +1,0 @@
-import { Component } from "@angular/core";
-@Component({ selector: "find-bmp", standalone: true, template: "<h2>Find a BMP</h2>" })
-export class FindBmpComponent {}

--- a/Neptune.Web/src/app/pages/site-layout/site-layout.component.html
+++ b/Neptune.Web/src/app/pages/site-layout/site-layout.component.html
@@ -9,10 +9,9 @@
                     <ul #bmpMenu class="dropdown-menu">
                         <!-- BMP Inventory item gates, mirroring MVC's per-controller [Feature]
                              attributes. Anonymous + Unassigned see only the AnonymousUnclassified
-                             items (Find a BMP, View All BMPs, Water Quality Management Plans);
+                             items (View All BMPs, Water Quality Management Plans);
                              Editor+ adds the NeptuneViewFeature-gated items; Admin adds
                              Jurisdictions (NeptuneAdminFeature). -->
-                        <li><a [routerLink]="['/find-bmp']" class="dropdown-item">Find a BMP</a></li>
                         @if (isCurrentUserEditorOrHigher()) {
                             <li><a [routerLink]="['/modeling-attributes']" class="dropdown-item">Modeling Attributes</a></li>
                         }

--- a/Neptune.Web/src/app/pages/site-layout/site-layout.component.ts
+++ b/Neptune.Web/src/app/pages/site-layout/site-layout.component.ts
@@ -50,7 +50,7 @@ export class SiteLayoutComponent implements OnInit {
     // that backs all user updates.
     //
     // Anonymous and Unassigned users see only the public-facing list pages (WQMP List + BMP
-    // List + WQMP Map + Find a BMP); everything else in the top nav routes to pages they
+    // List + WQMP Map); everything else in the top nav routes to pages they
     // don't have permission to access. Mirrors the MVC behavior where each nav item is gated
     // by its controller's feature attribute. NPT-1064.
     private currentUserSignal = toSignal(this.authenticationService.currentUserSetObservable.pipe(map((u) => u ?? null)), { initialValue: null });

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.html
@@ -6,8 +6,37 @@
 <app-alert-display></app-alert-display>
 
 <div class="page-body" [loadingSpinner]="{ isLoading, loadingHeight: 100 }">
+    <div class="filter-bar">
+        <div class="filter-field">
+            <label class="field-label" for="treatmentBMPTypeFilter">Filter by Type</label>
+            <ng-select
+                labelForId="treatmentBMPTypeFilter"
+                [items]="typeOptions$ | async"
+                bindValue="ID"
+                bindLabel="Name"
+                [multiple]="true"
+                [(ngModel)]="selectedTypeIDs"
+                placeholder="All Types"
+                (change)="onFilterChange()">
+            </ng-select>
+        </div>
+        <div class="filter-field">
+            <label class="field-label" for="jurisdictionFilter">Filter by Jurisdiction</label>
+            <ng-select
+                labelForId="jurisdictionFilter"
+                [items]="jurisdictionOptions$ | async"
+                bindValue="ID"
+                bindLabel="Name"
+                [multiple]="true"
+                [(ngModel)]="selectedJurisdictionIDs"
+                placeholder="All Jurisdictions"
+                (change)="onFilterChange()">
+            </ng-select>
+        </div>
+    </div>
+
     <hybrid-map-grid
-        [rowData]="treatmentBmps$ | async"
+        [rowData]="filteredTreatmentBmps$ | async"
         [columnDefs]="columnDefs"
         downloadFileName="treatment-bmps"
         entityIDField="TreatmentBMPID"
@@ -16,5 +45,13 @@
         [selectionFromMap]="selectionFromMap"
         (selectedValueChange)="onSelectedTreatmentBMPChangedFromGrid($event)"
         [boundingBox]="boundingBox$ | async">
+        <ng-container mapLayers>
+            @if (map) {
+                <regional-subbasins-layer [mode]="OverlayMode.ReferenceOnly" [map]="map" [layerControl]="layerControl" [sortOrder]="10"></regional-subbasins-layer>
+                <stormwater-network-layer [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="20"></stormwater-network-layer>
+                <jurisdictions-layer [mode]="OverlayMode.ReferenceOnly" [map]="map" [layerControl]="layerControl" [sortOrder]="30"></jurisdictions-layer>
+                <zoom-to-my-location-control [map]="map"></zoom-to-my-location-control>
+            }
+        </ng-container>
     </hybrid-map-grid>
 </div>

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.scss
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.scss
@@ -1,1 +1,20 @@
-// moved from bmp-inventory
+@use "/src/scss/abstracts" as *;
+
+.filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.filter-field {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 250px;
+    min-width: 250px;
+    max-width: 400px;
+
+    .field-label {
+        margin-bottom: 0.25rem;
+    }
+}

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
@@ -212,7 +212,12 @@ export class TreatmentBmpsComponent {
     }
 
     onFilterChange(): void {
-        this.filter$.next({ typeIDs: this.selectedTypeIDs, jurisdictionIDs: this.selectedJurisdictionIDs });
+        // ng-select sets the model to null when the clear-all (x) button is used; normalize to []
+        // and clone so the emitted filter state stays immutable and the length checks never throw.
+        this.filter$.next({
+            typeIDs: [...(this.selectedTypeIDs ?? [])],
+            jurisdictionIDs: [...(this.selectedJurisdictionIDs ?? [])],
+        });
     }
 
     handleMapReady(event: any) {

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
@@ -11,12 +11,14 @@ import { HybridMapGridComponent } from "src/app/shared/components/hybrid-map-gri
 import "leaflet.markercluster";
 import * as L from "leaflet";
 import { ColDef } from "ag-grid-community";
-import { Observable, shareReplay, tap } from "rxjs";
+import { BehaviorSubject, combineLatest, map, Observable, shareReplay, tap } from "rxjs";
 import { TreatmentBMPService } from "src/app/shared/generated/api/treatment-bmp.service";
 import { FieldVisitService } from "src/app/shared/generated/api/field-visit.service";
 import { UtilityFunctionsService } from "src/app/services/utility-functions.service";
 import { AuthenticationService } from "src/app/services/authentication.service";
 import { AsyncPipe } from "@angular/common";
+import { FormsModule } from "@angular/forms";
+import { NgSelectModule } from "@ng-select/ng-select";
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
 import { BoundingBoxDto } from "src/app/shared/generated/model/bounding-box-dto";
 import { StormwaterJurisdictionService } from "src/app/shared/generated/api/stormwater-jurisdiction.service";
@@ -27,12 +29,36 @@ import {
     BeginFieldVisitModalContext,
 } from "./treatment-bmp-detail/begin-field-visit-modal/begin-field-visit-modal.component";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { RegionalSubbasinsLayerComponent } from "src/app/shared/components/leaflet/layers/regional-subbasins-layer/regional-subbasins-layer.component";
+import { StormwaterNetworkLayerComponent } from "src/app/shared/components/leaflet/layers/stormwater-network-layer/stormwater-network-layer.component";
+import { JurisdictionsLayerComponent } from "src/app/shared/components/leaflet/layers/jurisdictions-layer/jurisdictions-layer.component";
+import { ZoomToMyLocationControlComponent } from "src/app/shared/components/leaflet/features/zoom-to-my-location-control/zoom-to-my-location-control.component";
+import { OverlayMode } from "src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/overlay-mode.enum";
+
+interface FilterOption {
+    ID: number;
+    Name: string;
+}
 
 @Component({
     selector: "treatment-bmps",
     standalone: true,
-    imports: [PageHeaderComponent, AlertDisplayComponent, HybridMapGridComponent, AsyncPipe, LoadingDirective, RouterModule],
+    imports: [
+        PageHeaderComponent,
+        AlertDisplayComponent,
+        HybridMapGridComponent,
+        AsyncPipe,
+        LoadingDirective,
+        RouterModule,
+        FormsModule,
+        NgSelectModule,
+        RegionalSubbasinsLayerComponent,
+        StormwaterNetworkLayerComponent,
+        JurisdictionsLayerComponent,
+        ZoomToMyLocationControlComponent,
+    ],
     templateUrl: "./treatment-bmps.component.html",
+    styleUrl: "./treatment-bmps.component.scss",
 })
 export class TreatmentBmpsComponent {
     private readonly destroyRef = inject(DestroyRef);
@@ -41,13 +67,24 @@ export class TreatmentBmpsComponent {
     public layerControl: any;
     private markerClusterLayer: any;
     private markerMap: Map<number, any> = new Map();
+    private clusterLayerSubscribed = false;
     public treatmentBmps$: Observable<TreatmentBMPGridDto[]>;
+    public filteredTreatmentBmps$: Observable<TreatmentBMPGridDto[]>;
     public columnDefs: ColDef[];
     public isLoading = true;
     public selectedTreatmentBMPID: number;
     public selectionFromMap: boolean;
     public boundingBox$: Observable<BoundingBoxDto>;
     public customRichTextTypeID = NeptunePageTypeEnum.TreatmentBMP;
+
+    public OverlayMode = OverlayMode;
+
+    // Find-a-BMP filter bar: empty selection = show all. Drives both the grid rowData and the map markers.
+    public selectedTypeIDs: number[] = [];
+    public selectedJurisdictionIDs: number[] = [];
+    private filter$ = new BehaviorSubject<{ typeIDs: number[]; jurisdictionIDs: number[] }>({ typeIDs: [], jurisdictionIDs: [] });
+    public typeOptions$: Observable<FilterOption[]>;
+    public jurisdictionOptions$: Observable<FilterOption[]>;
 
     constructor(
         private treatmentBMPService: TreatmentBMPService,
@@ -140,7 +177,42 @@ export class TreatmentBmpsComponent {
                 tap(() => (this.isLoading = false)),
                 shareReplay({ bufferSize: 1, refCount: true })
             );
+
+        this.filteredTreatmentBmps$ = combineLatest([this.treatmentBmps$, this.filter$]).pipe(
+            map(([bmps, f]) =>
+                bmps.filter(
+                    (b) =>
+                        (f.typeIDs.length === 0 || f.typeIDs.includes(b.TreatmentBMPTypeID)) &&
+                        (f.jurisdictionIDs.length === 0 || f.jurisdictionIDs.includes(b.StormwaterJurisdictionID))
+                )
+            ),
+            shareReplay({ bufferSize: 1, refCount: true })
+        );
+
+        // Derive the dropdown options from the loaded data so they always match what's shown.
+        this.typeOptions$ = this.treatmentBmps$.pipe(
+            map((bmps) => this.distinctOptions(bmps, (b) => b.TreatmentBMPTypeID, (b) => b.TreatmentBMPTypeName))
+        );
+        this.jurisdictionOptions$ = this.treatmentBmps$.pipe(
+            map((bmps) => this.distinctOptions(bmps, (b) => b.StormwaterJurisdictionID, (b) => b.StormwaterJurisdictionName))
+        );
+
         this.boundingBox$ = this.stormwaterJurisdictionService.getBoundingBoxStormwaterJurisdiction();
+    }
+
+    private distinctOptions(bmps: TreatmentBMPGridDto[], idSelector: (b: TreatmentBMPGridDto) => number, nameSelector: (b: TreatmentBMPGridDto) => string): FilterOption[] {
+        const byID = new Map<number, string>();
+        bmps.forEach((b) => {
+            const id = idSelector(b);
+            if (id != null && !byID.has(id)) {
+                byID.set(id, nameSelector(b));
+            }
+        });
+        return Array.from(byID, ([ID, Name]) => ({ ID, Name })).sort((a, b) => (a.Name ?? "").localeCompare(b.Name ?? ""));
+    }
+
+    onFilterChange(): void {
+        this.filter$.next({ typeIDs: this.selectedTypeIDs, jurisdictionIDs: this.selectedJurisdictionIDs });
     }
 
     handleMapReady(event: any) {
@@ -150,8 +222,9 @@ export class TreatmentBmpsComponent {
     }
 
     private addOrUpdateClusterLayer() {
-        if (!this.map || !this.treatmentBmps$) return;
-        this.treatmentBmps$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((bmps) => {
+        if (!this.map || !this.filteredTreatmentBmps$ || this.clusterLayerSubscribed) return;
+        this.clusterLayerSubscribed = true;
+        this.filteredTreatmentBmps$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((bmps) => {
             if (this.markerClusterLayer) {
                 this.map.removeLayer(this.markerClusterLayer);
                 this.layerControl.removeLayer(this.markerClusterLayer);

--- a/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
@@ -50,7 +50,7 @@
                 </wqmps-layer>
                 @if (mapIsReady) {
                     <parcel-layer [map]="map" [layerControl]="layerControl"></parcel-layer>
-                    <delineations-layer [map]="map" [layerControl]="layerControl"></delineations-layer>
+                    <delineations-layer [map]="map" [layerControl]="layerControl" [displayOnLoad]="false"></delineations-layer>
                     <jurisdictions-layer [map]="map" [layerControl]="layerControl" [mode]="OverlayMode.ReferenceOnly"></jurisdictions-layer>
                 }
             </hybrid-map-grid>

--- a/Neptune.Web/src/app/shared/components/leaflet/features/zoom-to-my-location-control/zoom-to-my-location-control.component.html
+++ b/Neptune.Web/src/app/shared/components/leaflet/features/zoom-to-my-location-control/zoom-to-my-location-control.component.html
@@ -1,0 +1,1 @@
+<!-- The Leaflet control DOM is created imperatively in the component and added to the map. -->

--- a/Neptune.Web/src/app/shared/components/leaflet/features/zoom-to-my-location-control/zoom-to-my-location-control.component.scss
+++ b/Neptune.Web/src/app/shared/components/leaflet/features/zoom-to-my-location-control/zoom-to-my-location-control.component.scss
@@ -1,0 +1,1 @@
+@use "/src/scss/abstracts" as *;

--- a/Neptune.Web/src/app/shared/components/leaflet/features/zoom-to-my-location-control/zoom-to-my-location-control.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/features/zoom-to-my-location-control/zoom-to-my-location-control.component.ts
@@ -39,6 +39,15 @@ export class ZoomToMyLocationControlComponent implements OnChanges, OnDestroy {
                     L.DomEvent.preventDefault(e);
                     this.zoomToMyLocation();
                 });
+                // Keyboard accessibility: the control is an <a role="button">, so activate it on
+                // Enter/Space for non-mouse users.
+                L.DomEvent.on(button, "keydown", (e: Event) => {
+                    const key = (e as KeyboardEvent).key;
+                    if (key === "Enter" || key === " " || key === "Spacebar") {
+                        L.DomEvent.preventDefault(e);
+                        this.zoomToMyLocation();
+                    }
+                });
                 return container;
             },
         });

--- a/Neptune.Web/src/app/shared/components/leaflet/features/zoom-to-my-location-control/zoom-to-my-location-control.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/features/zoom-to-my-location-control/zoom-to-my-location-control.component.ts
@@ -1,0 +1,100 @@
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from "@angular/core";
+import * as L from "leaflet";
+
+// Self-contained Leaflet control that recenters the map on the user's current location.
+// Projected into a <neptune-map> alongside the reference layers; takes only [map] so it can be
+// dropped onto any map. Geolocation logic mirrors lat-lon-picker.useCurrentLocation().
+@Component({
+    selector: "zoom-to-my-location-control",
+    standalone: true,
+    imports: [],
+    templateUrl: "./zoom-to-my-location-control.component.html",
+    styleUrl: "./zoom-to-my-location-control.component.scss",
+})
+export class ZoomToMyLocationControlComponent implements OnChanges, OnDestroy {
+    @Input() map: L.Map;
+
+    private control: L.Control = null;
+    private marker: L.Marker = null;
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if (changes.map && this.map && !this.control) {
+            this.addControl();
+        }
+    }
+
+    private addControl(): void {
+        const ZoomToLocationControl = L.Control.extend({
+            options: { position: "topleft" as L.ControlPosition },
+            onAdd: () => {
+                const container = L.DomUtil.create("div", "leaflet-bar leaflet-control zoom-to-my-location-control");
+                const button = L.DomUtil.create("a", "", container) as HTMLAnchorElement;
+                button.href = "#";
+                button.title = "Zoom to my location";
+                button.setAttribute("role", "button");
+                button.setAttribute("aria-label", "Zoom to my location");
+                button.innerHTML = '<i class="fa fa-location-arrow"></i>';
+                L.DomEvent.disableClickPropagation(container);
+                L.DomEvent.on(button, "click", (e: Event) => {
+                    L.DomEvent.preventDefault(e);
+                    this.zoomToMyLocation();
+                });
+                return container;
+            },
+        });
+        this.control = new ZoomToLocationControl();
+        this.control.addTo(this.map);
+    }
+
+    private zoomToMyLocation(): void {
+        if (!navigator || !navigator.geolocation) {
+            return;
+        }
+        navigator.geolocation.getCurrentPosition(
+            (pos) => {
+                const lat = pos.coords.latitude;
+                const lon = pos.coords.longitude;
+                this.map.setView([lat, lon], 16);
+                this.updateMarker(lat, lon);
+            },
+            (err) => {
+                console.warn("Geolocation error", err);
+            },
+            { enableHighAccuracy: true }
+        );
+    }
+
+    private updateMarker(lat: number, lon: number): void {
+        if (!this.map) return;
+        if (this.marker) {
+            this.marker.setLatLng([lat, lon]);
+        } else {
+            this.marker = L.marker([lat, lon], {
+                icon: L.icon({
+                    iconUrl: "assets/main/map-icons/marker-icon-blue.png",
+                    iconSize: [25, 41],
+                    iconAnchor: [12, 41],
+                    popupAnchor: [1, -34],
+                    shadowUrl: "assets/main/map-icons/marker-shadow.png",
+                    shadowSize: [41, 41],
+                }),
+            });
+            this.marker.addTo(this.map);
+        }
+    }
+
+    ngOnDestroy(): void {
+        if (this.marker && this.map) {
+            try {
+                this.map.removeLayer(this.marker);
+            } catch {}
+            this.marker = null;
+        }
+        if (this.control && this.map) {
+            try {
+                this.map.removeControl(this.control);
+            } catch {}
+            this.control = null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Brings the legacy "Find a BMP" map capabilities into the Treatment BMP hybrid grid+map page (`/treatment-bmps`, "View All BMPs"), then retires the placeholder Find a BMP nav entry.

- **Filter by Type / Jurisdiction → map updates.** Added a filter bar (two multi-select `ng-select` dropdowns) above the hybrid-map-grid. Selections feed one filtered stream (`combineLatest(treatmentBmps$, filter$)`) that drives **both** the grid `rowData` and the clustered map markers — so it works in Grid, Hybrid, and Map views, and for public/anonymous users (who don't see the grid's per-column filters). Empty selection = show all. Options are derived (distinct, sorted) from the loaded data.
- **Zoom to my Location.** New self-contained `ZoomToMyLocationControlComponent` — a Leaflet control (`[map]` input) that uses `navigator.geolocation` (logic mirrored from `lat-lon-picker`) to recenter the map and drop a marker.
- **Reference layers.** Projected Regional Subbasins, Stormwater Network, and Jurisdictions onto the map via the existing `[mapLayers]` slot, matching the BMP detail page.
- **Removed the placeholder "Find a BMP"** nav item, route, and stub component — its functionality is now the enhanced View All BMPs page.

Frontend-only: `TreatmentBMPGridDto` already carries `Latitude`/`Longitude`/`TreatmentBMPTypeID`/`StormwaterJurisdictionID`, so no backend, DTO, or codegen changes.

> Note: the `NeptunePageType.FindABMP` lookup/enum was intentionally left in place — it's still used by the legacy WebMvc `TreatmentBMPController.FindABMP()` page, so retiring it belongs to a separate MVC-retirement audit.

## Test plan

- [ ] Filtering by Type and/or Jurisdiction narrows both the grid and the map markers (Grid, Hybrid, Map views; and as a public/anonymous user).
- [ ] Clearing the dropdowns restores all BMPs.
- [ ] "Zoom to my Location" prompts for location and recenters the map (over HTTPS).
- [ ] Regional Subbasins / Stormwater Network / Jurisdictions appear in the layer control and toggle correctly.
- [ ] "Find a BMP" no longer appears in the BMP Inventory nav dropdown.