### PR TITLE
NPT-1068: Fix delineation GDB upload approve flow

### DIFF
--- a/Neptune.EFModels/Entities/DelineationStagings.StaticHelpers.cs
+++ b/Neptune.EFModels/Entities/DelineationStagings.StaticHelpers.cs
@@ -171,7 +171,12 @@ public static class DelineationStagings
 
         foreach (var bmp in bmpsToUpdate)
         {
-            var staging = stagings.Single(z => z.TreatmentBMPName == bmp.TreatmentBMPName);
+            // Mirror the SQL-side comparison that populated bmpsToUpdate: SQL Server collation matches names
+            // case-insensitively and ignores trailing whitespace, so a plain ordinal == here misses case/whitespace-only
+            // differences and throws "Sequence contains no matching element".
+            var staging = stagings.First(z =>
+                string.Equals(z.TreatmentBMPName?.Trim(), bmp.TreatmentBMPName?.Trim(),
+                    StringComparison.InvariantCultureIgnoreCase));
             dbContext.Delineations.Add(new Delineation
             {
                 HasDiscrepancies = false,

--- a/Neptune.Web/src/app/pages/delineation/gdb-approve/gdb-approve.component.html
+++ b/Neptune.Web/src/app/pages/delineation/gdb-approve/gdb-approve.component.html
@@ -14,11 +14,11 @@
       <div class="card-body">
         <dl class="kv">
           <dt>Total Staged</dt>
-          <dd>{{ dto.NumberOfDelineations ?? 0 }}</dd>
+          <dd>{{ (dto.NumberOfDelineations ?? 0) | number }}</dd>
           <dt>Will Replace Existing</dt>
-          <dd>{{ dto.NumberOfDelineationsToBeUpdated ?? 0 }}</dd>
+          <dd>{{ (dto.NumberOfDelineationsToBeUpdated ?? 0) | number }}</dd>
           <dt>Will Be Created New</dt>
-          <dd>{{ dto.NumberOfDelineationsToBeCreated ?? 0 }}</dd>
+          <dd>{{ (dto.NumberOfDelineationsToBeCreated ?? 0) | number }}</dd>
         </dl>
 
         @if (hasErrors()) {
@@ -38,7 +38,9 @@
         }
 
         <div class="actions">
-          <button type="button" class="btn btn-primary" [disabled]="isWorking() || hasErrors()" (click)="approve()">Accept</button>
+          <button type="button" class="btn btn-primary" [disabled]="isWorking() || hasErrors()" (click)="approve()">
+            @if (isWorking()) { <i class="fa fa-spinner fa-spin"></i> Working... } @else { <i class="fa fa-check"></i> Accept }
+          </button>
           <button type="button" class="btn btn-primary-outline" [disabled]="isWorking()" (click)="cancel()">Cancel</button>
         </div>
       </div>

--- a/Neptune.Web/src/app/pages/delineation/gdb-approve/gdb-approve.component.ts
+++ b/Neptune.Web/src/app/pages/delineation/gdb-approve/gdb-approve.component.ts
@@ -1,3 +1,4 @@
+import { DecimalPipe } from "@angular/common";
 import { Component, OnInit, signal } from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
 import { Observable } from "rxjs";
@@ -13,7 +14,7 @@ import { AlertDisplayComponent } from "src/app/shared/components/alert-display/a
     selector: "gdb-approve",
     templateUrl: "./gdb-approve.component.html",
     styleUrl: "./gdb-approve.component.scss",
-    imports: [RouterLink, PageHeaderComponent, AlertDisplayComponent],
+    imports: [RouterLink, PageHeaderComponent, AlertDisplayComponent, DecimalPipe],
 })
 export class GdbApproveComponent implements OnInit {
     public report = signal<DelineationGdbUploadValidationDto | null>(null);
@@ -47,8 +48,11 @@ export class GdbApproveComponent implements OnInit {
             next: (count) => {
                 this.isWorking.set(false);
                 const message = `${count} ${count === 1 ? "delineation was" : "delineations were"} successfully uploaded.`;
-                this.alertService.pushAlert(new Alert(message, AlertContext.Success, true));
-                this.router.navigate(["delineation", "delineation-map"]);
+                // Push the success alert after navigation resolves; AlertDisplayComponent clears alerts on destroy,
+                // so an alert pushed before navigating away never reaches the destination page.
+                this.router.navigate(["delineation", "delineation-map"]).then(() => {
+                    this.alertService.pushAlert(new Alert(message, AlertContext.Success, true));
+                });
             },
             error: () => {
                 this.isWorking.set(false);


### PR DESCRIPTION
## Summary

Bug fixes to the delineation File Geodatabase upload → approve flow, found while testing the NPT-1068 SPA migration. These files already exist on `develop`, so this PR is split out from the larger WebMvc-retirement PR (#582).

### Backend
- **`ApproveAsync` "Sequence contains no matching element"** — `bmpsToUpdate` is selected by an EF/SQL query whose name match is case- and trailing-whitespace-insensitive (SQL Server collation), but the subsequent in-memory `stagings.Single(...)` used an ordinal `==`. A staged BMP name differing only by case or trailing whitespace passed the SQL filter but failed the C# match and threw. Now matches with `InvariantCultureIgnoreCase` + `Trim()`, mirroring the query and consistent with the rest of the file.

### Frontend (`gdb-approve` page)
- **Success alert** — the alert was pushed before `router.navigate()`, so `AlertDisplayComponent` cleared it on component destroy and it never reached the destination. Moved into `navigate(...).then(...)`; it now shows on the delineation map.
- **Loading spinner** — the Accept button shows a `fa-spinner fa-spin` / "Working..." state while the (potentially long) upsert runs, matching the sibling `ovta-area-approve`/`gdb-upload` pages. Button stays disabled during the request.
- **Number formatting** — staged counts now use the `number` pipe (e.g. `1,112` instead of `1112`).

## Testing
- `Neptune.EFModels` builds clean (0 errors).
- Manual: upload a GDB, approve — confirm no exception, spinner during upsert, success alert on the map, formatted counts.