### PR TITLE
NPT-1065: Loosen OVTA progress-score rule to 1 OVTA within 5 years

### DIFF
--- a/Neptune.Database/Neptune.Database.sqlproj
+++ b/Neptune.Database/Neptune.Database.sqlproj
@@ -439,6 +439,7 @@
     <Build Include="dbo\Views\dbo.vTreatmentBMPModelingAttribute.sql" />
     <None Include="Scripts\ReleaseScripts\019 - Add Dry Weather Flow Override custom attribute for all Modeled Treatment BMPs without it.sql" />
     <None Include="Scripts\ReleaseScripts\020 - Drop WaterQualityManagementPlanDocumentVectorStore table.sql" />
+    <None Include="Scripts\ReleaseScripts\036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql" />
     <Build Include="dbo\Tables\dbo.WaterQualityManagementPlanExtractionResult.sql" />
     <Build Include="dbo\Tables\dbo.AITokenUsage.sql" />
   </ItemGroup>

--- a/Neptune.Database/Scripts/ReleaseScripts/036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql
@@ -34,7 +34,7 @@ BEGIN
 				--OnlandVisualTrashAssessmentStatusName = Complete
 			WHERE ovta2.OnlandVisualTrashAssessmentStatusID = 2
 			  AND ovta2.IsProgressAssessment = 1
-			  AND ovta2.CompletedDate >= DATEADD(year, -5, GETDATE())
+			  AND ovta2.CompletedDate >= DATEADD(year, -5, CAST(GETDATE() AS date))
 		) ranked
 		WHERE rn <= 3
 		GROUP BY OnlandVisualTrashAssessmentAreaID

--- a/Neptune.Database/Scripts/ReleaseScripts/036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql
@@ -1,0 +1,48 @@
+DECLARE @MigrationName VARCHAR(200);
+SET @MigrationName = '020 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule'
+
+IF NOT EXISTS(SELECT * FROM dbo.DatabaseMigration DM WHERE DM.ReleaseScriptFileName = @MigrationName)
+BEGIN
+
+	PRINT @MigrationName;
+
+	-- NPT-1065: The progress-score rule was loosened from "2 completed progress OVTAs within 4 years"
+	-- to "1 completed progress OVTA within 5 years" so Track 2 permittees (who may revisit sites only
+	-- every 5 years) can update Trash Generation Rates. The stored OnlandVisualTrashAssessmentProgressScoreID
+	-- is only recalculated when an OVTA for an area is created/edited/deleted, so this one-time backfill
+	-- applies the new rule retroactively to all existing areas. The score is the average (rounded) of the
+	-- top 3 most recent qualifying progress assessments, matching CalculateProgressScore() and
+	-- dbo.vOnlandVisualTrashAssessmentAreaProgress.
+	UPDATE ovta
+	SET ovta.OnlandVisualTrashAssessmentProgressScoreID = ovtas.OnlandVisualTrashAssessmentScoreID
+		FROM dbo.OnlandVisualTrashAssessmentArea ovta
+	LEFT JOIN (
+		SELECT
+			OnlandVisualTrashAssessmentAreaID,
+			AVG(NumericValue) AS Top3AverageNumericValue
+		FROM (
+			SELECT
+				ovta2.OnlandVisualTrashAssessmentAreaID,
+				ovtas2.NumericValue,
+				ROW_NUMBER() OVER (
+					PARTITION BY ovta2.OnlandVisualTrashAssessmentAreaID
+					ORDER BY ovta2.CompletedDate DESC
+				) AS rn
+			FROM dbo.OnlandVisualTrashAssessment ovta2
+			JOIN dbo.OnlandVisualTrashAssessmentScore ovtas2
+				ON ovta2.OnlandVisualTrashAssessmentScoreID = ovtas2.OnlandVisualTrashAssessmentScoreID
+				--OnlandVisualTrashAssessmentStatusName = Complete
+			WHERE ovta2.OnlandVisualTrashAssessmentStatusID = 2
+			  AND ovta2.IsProgressAssessment = 1
+			  AND ovta2.CompletedDate >= DATEADD(year, -5, GETDATE())
+		) ranked
+		WHERE rn <= 3
+		GROUP BY OnlandVisualTrashAssessmentAreaID
+		HAVING COUNT(*) >= 1
+	) ovtaa ON ovta.OnlandVisualTrashAssessmentAreaID = ovtaa.OnlandVisualTrashAssessmentAreaID
+		LEFT JOIN dbo.OnlandVisualTrashAssessmentScore ovtas
+		ON ROUND(ovtaa.Top3AverageNumericValue, 0) = ovtas.NumericValue
+
+	INSERT INTO dbo.DatabaseMigration(MigrationAuthorName, ReleaseScriptFileName, MigrationReason)
+	SELECT 'Shannon Bulloch', @MigrationName, 'NPT-1065 - Recalculate OVTA Progress Scores under 1-OVTA-within-5-years rule'
+END

--- a/Neptune.Database/Scripts/ReleaseScripts/036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql
@@ -1,5 +1,5 @@
 DECLARE @MigrationName VARCHAR(200);
-SET @MigrationName = '020 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule'
+SET @MigrationName = '036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule';
 
 IF NOT EXISTS(SELECT * FROM dbo.DatabaseMigration DM WHERE DM.ReleaseScriptFileName = @MigrationName)
 BEGIN

--- a/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -78,4 +78,6 @@ GO
 GO
 :r ".\035 - NPT-1078 Rename WebServices query param from x-api-key to token.sql"
 GO
+:r ".\036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql"
+GO
 

--- a/Neptune.Database/dbo/Views/dbo.vOnlandVisualTrashAssessmentAreaProgress.sql
+++ b/Neptune.Database/dbo/Views/dbo.vOnlandVisualTrashAssessmentAreaProgress.sql
@@ -22,7 +22,7 @@ From (
 		from dbo.OnlandVisualTrashAssessment ovta
 			inner join dbo.OnlandVisualTrashAssessmentScore score
 				on ovta.OnlandVisualTrashAssessmentScoreID = score.OnlandVisualTrashAssessmentScoreID
-		where IsProgressAssessment = 1 and CompletedDate >= DATEADD(year, -5, CURRENT_TIMESTAMP)
+		where IsProgressAssessment = 1 and CompletedDate >= DATEADD(year, -5, CAST(CURRENT_TIMESTAMP AS date))
 		) subq
 	where RoWNumber <=3
 	group by (OnlandVisualTrashAssessmentAreaID)

--- a/Neptune.Database/dbo/Views/dbo.vOnlandVisualTrashAssessmentAreaProgress.sql
+++ b/Neptune.Database/dbo/Views/dbo.vOnlandVisualTrashAssessmentAreaProgress.sql
@@ -10,7 +10,7 @@ From (
 	Select
 		OnlandVisualTrashAssessmentAreaID,
 		Avg(NumericValue) as NumericValue,
-		-- we only care about areas with two or more progress assessments, so we need this additional agg
+		-- we only care about areas with one or more progress assessments within the last 5 years, so we need this additional agg
 		Count(*) as NumberOfProgressAssessments
 	From (
 		-- get the progress assessments
@@ -22,11 +22,11 @@ From (
 		from dbo.OnlandVisualTrashAssessment ovta
 			inner join dbo.OnlandVisualTrashAssessmentScore score
 				on ovta.OnlandVisualTrashAssessmentScoreID = score.OnlandVisualTrashAssessmentScoreID
-		where IsProgressAssessment = 1 and CompletedDate >= DATEADD(year, -4, CURRENT_TIMESTAMP)
+		where IsProgressAssessment = 1 and CompletedDate >= DATEADD(year, -5, CURRENT_TIMESTAMP)
 		) subq
 	where RoWNumber <=3
 	group by (OnlandVisualTrashAssessmentAreaID)
-	having count(*) > 1
+	having count(*) >= 1
 ) subq inner join dbo.OnlandVisualTrashAssessmentScore score
 	on subq.NumericValue = score.NumericValue
 Go

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessments.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessments.cs
@@ -466,12 +466,12 @@ public static class OnlandVisualTrashAssessments
 
     public static OnlandVisualTrashAssessmentScore? CalculateProgressScore(List<OnlandVisualTrashAssessment> onlandVisualTrashAssessments)
     {
-        var fourYearAgo = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-4));
+        var fiveYearsAgo = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-5));
         var completedAndIsProgressAssessment = onlandVisualTrashAssessments.Where(x =>
             x.OnlandVisualTrashAssessmentStatusID == OnlandVisualTrashAssessmentStatus.Complete
-                .OnlandVisualTrashAssessmentStatusID && x.IsProgressAssessment && x.CompletedDate >= fourYearAgo).ToList();
+                .OnlandVisualTrashAssessmentStatusID && x.IsProgressAssessment && x.CompletedDate >= fiveYearsAgo).ToList();
 
-        if (completedAndIsProgressAssessment.Count < 2)
+        if (completedAndIsProgressAssessment.Count < 1)
         {
             return null;
         }

--- a/Neptune.Tests/OnlandVisualTrashAssessmentsTest.cs
+++ b/Neptune.Tests/OnlandVisualTrashAssessmentsTest.cs
@@ -58,9 +58,10 @@ namespace Neptune.Tests
         public void SingleCompletedProgressAssessmentWithinFiveYearsProducesScore()
         {
             // New rule: a single completed progress OVTA within 5 years is now enough (was 2 within 4 years).
+            var fiveYearsAgo = Today.AddYears(-5);
             var assessments = new List<OnlandVisualTrashAssessment>
             {
-                BuildAssessment(OnlandVisualTrashAssessmentScore.B, Today),
+                BuildAssessment(OnlandVisualTrashAssessmentScore.B, fiveYearsAgo),
             };
 
             var result = OnlandVisualTrashAssessments.CalculateProgressScore(assessments);
@@ -81,9 +82,10 @@ namespace Neptune.Tests
         public void ProgressAssessmentOlderThanFiveYearsIsExcluded()
         {
             // Just outside the 5-year window -> filtered out -> no score.
+            var fiveYearsAgo = Today.AddYears(-5);
             var assessments = new List<OnlandVisualTrashAssessment>
             {
-                BuildAssessment(OnlandVisualTrashAssessmentScore.A, Today.AddYears(-6)),
+                BuildAssessment(OnlandVisualTrashAssessmentScore.A, fiveYearsAgo.AddDays(-1)),
             };
 
             var result = OnlandVisualTrashAssessments.CalculateProgressScore(assessments);

--- a/Neptune.Tests/OnlandVisualTrashAssessmentsTest.cs
+++ b/Neptune.Tests/OnlandVisualTrashAssessmentsTest.cs
@@ -1,0 +1,130 @@
+/*-----------------------------------------------------------------------
+<copyright file="OnlandVisualTrashAssessmentsTest.cs" company="Sitka Technology Group">
+Copyright (c) Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// Covers the NPT-1065 progress-score rule: a progress score requires at least 1 completed
+    /// progress OVTA within the last 5 years (previously 2 within 4 years). The score is the rounded
+    /// average of the top 3 most recent qualifying assessments.
+    /// </summary>
+    [TestClass]
+    public class OnlandVisualTrashAssessmentsTest
+    {
+        // NumericValue mapping from OnlandVisualTrashAssessmentScore.Binding.cs: A=4, B=3, C=2, D=1
+        private static OnlandVisualTrashAssessment BuildAssessment(
+            OnlandVisualTrashAssessmentScore score,
+            DateOnly completedDate,
+            bool isProgressAssessment = true,
+            bool isComplete = true)
+        {
+            return new OnlandVisualTrashAssessment
+            {
+                OnlandVisualTrashAssessmentStatusID = isComplete
+                    ? OnlandVisualTrashAssessmentStatus.Complete.OnlandVisualTrashAssessmentStatusID
+                    : OnlandVisualTrashAssessmentStatus.InProgress.OnlandVisualTrashAssessmentStatusID,
+                IsProgressAssessment = isProgressAssessment,
+                CompletedDate = completedDate,
+                OnlandVisualTrashAssessmentScoreID = score.OnlandVisualTrashAssessmentScoreID,
+            };
+        }
+
+        private static DateOnly Today => DateOnly.FromDateTime(DateTime.UtcNow);
+
+        [TestMethod]
+        public void SingleCompletedProgressAssessmentWithinFiveYearsProducesScore()
+        {
+            // New rule: a single completed progress OVTA within 5 years is now enough (was 2 within 4 years).
+            var assessments = new List<OnlandVisualTrashAssessment>
+            {
+                BuildAssessment(OnlandVisualTrashAssessmentScore.B, Today),
+            };
+
+            var result = OnlandVisualTrashAssessments.CalculateProgressScore(assessments);
+
+            Assert.IsNotNull(result, "A single completed progress assessment within 5 years should yield a score.");
+            Assert.AreEqual(OnlandVisualTrashAssessmentScore.B, result);
+        }
+
+        [TestMethod]
+        public void NoCompletedProgressAssessmentsProducesNull()
+        {
+            var result = OnlandVisualTrashAssessments.CalculateProgressScore(new List<OnlandVisualTrashAssessment>());
+
+            Assert.IsNull(result, "With zero qualifying assessments there is no progress score.");
+        }
+
+        [TestMethod]
+        public void ProgressAssessmentOlderThanFiveYearsIsExcluded()
+        {
+            // Just outside the 5-year window -> filtered out -> no score.
+            var assessments = new List<OnlandVisualTrashAssessment>
+            {
+                BuildAssessment(OnlandVisualTrashAssessmentScore.A, Today.AddYears(-6)),
+            };
+
+            var result = OnlandVisualTrashAssessments.CalculateProgressScore(assessments);
+
+            Assert.IsNull(result, "A progress assessment completed more than 5 years ago must not count.");
+        }
+
+        [TestMethod]
+        public void NonProgressAndIncompleteAssessmentsAreExcluded()
+        {
+            var assessments = new List<OnlandVisualTrashAssessment>
+            {
+                // Completed but a baseline (non-progress) assessment -> excluded.
+                BuildAssessment(OnlandVisualTrashAssessmentScore.A, Today, isProgressAssessment: false),
+                // Progress but not completed -> excluded.
+                BuildAssessment(OnlandVisualTrashAssessmentScore.A, Today, isComplete: false),
+            };
+
+            var result = OnlandVisualTrashAssessments.CalculateProgressScore(assessments);
+
+            Assert.IsNull(result, "Only completed progress assessments should contribute to the progress score.");
+        }
+
+        [TestMethod]
+        public void OnlyTopThreeMostRecentAssessmentsAreAveraged()
+        {
+            // 3 most recent are A (numeric 4); the oldest is D (numeric 1).
+            // Top-3 average = 4 -> A. Averaging all 4 would be (4+4+4+1)/4 = 3.25 -> round 3 -> B.
+            // Asserting A proves only the top 3 most recent are used.
+            var assessments = new List<OnlandVisualTrashAssessment>
+            {
+                BuildAssessment(OnlandVisualTrashAssessmentScore.A, Today),
+                BuildAssessment(OnlandVisualTrashAssessmentScore.A, Today.AddDays(-10)),
+                BuildAssessment(OnlandVisualTrashAssessmentScore.A, Today.AddDays(-20)),
+                BuildAssessment(OnlandVisualTrashAssessmentScore.D, Today.AddDays(-30)),
+            };
+
+            var result = OnlandVisualTrashAssessments.CalculateProgressScore(assessments);
+
+            Assert.AreEqual(OnlandVisualTrashAssessmentScore.A, result,
+                "Only the top 3 most recent assessments should be averaged.");
+        }
+    }
+}


### PR DESCRIPTION
## NPT-1065 — Loosen OVTA progress-score rule for Track 2 permittees

### Why
Track 2 permittees may only revisit sites every 5 years, so the prior **"2 completed progress OVTAs within 4 years"** rule structurally locked them out of progress-based Trash Generation Rate (TGR) updates. This loosens the rule to **"1 completed progress OVTA within 5 years"**, applied globally to all permittees.

### What changed
The rule was duplicated in **two** places (the Jira described only one). Both are updated to stay consistent:

| Layer | Change |
|---|---|
| `OnlandVisualTrashAssessments.cs` → `CalculateProgressScore()` | `AddYears(-4)`→`-5`, `Count < 2`→`< 1`. Sets the **stored** area progress score on OVTA save. |
| `dbo.vOnlandVisualTrashAssessmentAreaProgress` view | `DATEADD(year, -4…)`→`-5`, `having count(*) > 1`→`>= 1`. Feeds the **progress loading-rate** calc in `vTrashGeneratingUnitLoadStatistic`. |

- **Release script `036`** backfills stored progress scores for existing areas under the new rule. The stored score is only recomputed on OVTA create/edit/delete, so without this, existing Track 2 areas wouldn't benefit until their next assessment; the view self-corrects on deploy.
- **Unit tests** (`OnlandVisualTrashAssessmentsTest`) cover the 5-year window boundary, the single-assessment case, exclusion of non-progress/incomplete assessments, and the top-3 averaging guard. ✅ 5 passing.

### Notes for reviewers
- The top-3 averaging logic is unchanged.
- **Out of scope (unchanged):** `CalculateBaselineScoreFromBackingData()` (2-baseline rule) and `EquivalentAreaAcreageFromAssessments()` (2-Score-A rule).
- **UI copy:** the literal "2 OVTAs / 4 years" text is not in source — it lives in the DB-backed `FieldDefinition` content for `ProgressScore` (admin-editable). That should be reviewed/updated via the admin UI post-deploy.
- No API/DTO/route changes → no codegen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
