### PR TITLE
NPT-1062: Modeled BMP Performance rework (recalc job, alerts, planning panel, modeling-attributes grid)

### DIFF
--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -374,13 +374,18 @@ public class TreatmentBMPController(
     public ActionResult<TreatmentBMPParameterizationErrorsDto> GetParameterizationErrors([FromRoute] int treatmentBMPID)
     {
         var treatmentBMP = DbContext.TreatmentBMPs
-            .Include(x => x.Delineation)
             .Include(x => x.WaterQualityManagementPlan)
             .Include(x => x.TreatmentBMPType)
             .Single(x => x.TreatmentBMPID == treatmentBMPID);
 
-        var delineation = treatmentBMP.Delineation;
-        var hasDelineation = delineation != null;
+        // A downstream BMP inherits its upstream BMP's verified delineation (mirrors TreatmentBMPs.GetByIDAsync
+        // and vTreatmentBMPUpstreams). Resolve the effective delineation BMP before deciding whether a delineation
+        // is missing, so a BMP whose upstream already has one (e.g. BMP 318 -> upstream 354) doesn't wrongly show
+        // the "delineation required" alert.
+        var upstreamRow = DbContext.vTreatmentBMPUpstreams.AsNoTracking()
+            .SingleOrDefault(x => x.TreatmentBMPID == treatmentBMPID);
+        var delineationBMPID = upstreamRow?.UpstreamBMPID ?? treatmentBMPID;
+        var hasDelineation = DbContext.Delineations.AsNoTracking().Any(x => x.TreatmentBMPID == delineationBMPID);
         var linkToDelineationMap = !hasDelineation && (treatmentBMP.UpstreamBMPID == null);
         WaterQualityManagementPlanDisplayDto? simplifiedWQMP = null;
         if (treatmentBMP.WaterQualityManagementPlan != null && treatmentBMP.WaterQualityManagementPlan.WaterQualityManagementPlanModelingApproach == WaterQualityManagementPlanModelingApproach.Simplified)

--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -378,10 +378,11 @@ public class TreatmentBMPController(
             .Include(x => x.TreatmentBMPType)
             .Single(x => x.TreatmentBMPID == treatmentBMPID);
 
-        // A downstream BMP inherits its upstream BMP's verified delineation (mirrors TreatmentBMPs.GetByIDAsync
-        // and vTreatmentBMPUpstreams). Resolve the effective delineation BMP before deciding whether a delineation
-        // is missing, so a BMP whose upstream already has one (e.g. BMP 318 -> upstream 354) doesn't wrongly show
-        // the "delineation required" alert.
+        // A downstream BMP inherits its upstream BMP's delineation (resolved via vTreatmentBMPUpstreams, the same
+        // upstream lookup TreatmentBMPs.GetByIDAsync uses). Check whether a delineation row EXISTS for that effective
+        // BMP — existence only, matching the prior `delineation != null` behavior; verification status is not part of
+        // this alert. This stops a BMP whose upstream already has one (e.g. BMP 318 -> upstream 354) from wrongly
+        // showing the "delineation required" alert.
         var upstreamRow = DbContext.vTreatmentBMPUpstreams.AsNoTracking()
             .SingleOrDefault(x => x.TreatmentBMPID == treatmentBMPID);
         var delineationBMPID = upstreamRow?.UpstreamBMPID ?? treatmentBMPID;

--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -21915,6 +21915,9 @@
           "IsAnalyzedInModelingModule": {
             "type": "boolean"
           },
+          "IsAwaitingModelingCalculation": {
+            "type": "boolean"
+          },
           "TreatmentBMPModelingAttribute": {
             "$ref": "#/components/schemas/vTreatmentBMPModelingAttributeDto"
           },
@@ -22261,6 +22264,15 @@
             "nullable": true
           },
           "StormwaterJurisdictionName": {
+            "type": "string",
+            "nullable": true
+          },
+          "WaterQualityManagementPlanID": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "WaterQualityManagementPlanName": {
             "type": "string",
             "nullable": true
           },

--- a/Neptune.EFModels/Entities/TreatmentBMPs.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPs.cs
@@ -528,6 +528,13 @@ public static class TreatmentBMPs
             .SingleOrDefaultAsync(x => x.TreatmentBMPID == treatmentBMPID);
         dto.IsFullyParameterized = bmpForParameterizationCheck.IsFullyParameterized(delineationForParameterizationCheck, modelingAttribute);
 
+        // A DirtyModelNode row for this BMP (created on modeling-attribute/delineation edits via NereidUtilities)
+        // means its results are pending the next delta solve. Surface that so the detail page can show an
+        // "awaiting calculation" message instead of presenting a stale/zero result as current.
+        dto.IsAwaitingModelingCalculation = await dbContext.DirtyModelNodes.AsNoTracking()
+            .AnyAsync(x => x.TreatmentBMPID == treatmentBMPID
+                           || (delineationForParameterizationCheck != null && x.DelineationID == delineationForParameterizationCheck.DelineationID));
+
         if (dto.UpstreamBMPID.HasValue)
         {
             dto.UpstreamBMP = await GetByIDAsDtoAsync(dbContext, dto.UpstreamBMPID.Value);
@@ -891,6 +898,7 @@ public static class TreatmentBMPs
             .ThenInclude(x => x.TreatmentBMPType)
             .Include(x => x.Watershed)
             .Include(x => x.Delineation)
+            .Include(x => x.WaterQualityManagementPlan)
             .AsNoTracking()
             .Where(x => x.TreatmentBMPType.IsAnalyzedInModelingModule &&
                         stormwaterJurisdictionIDsPersonCanView.Contains(x.StormwaterJurisdictionID))
@@ -921,6 +929,8 @@ public static class TreatmentBMPs
                     TreatmentBMPTypeName = bmp.TreatmentBMPType?.TreatmentBMPTypeName,
                     StormwaterJurisdictionID = bmp.StormwaterJurisdictionID,
                     StormwaterJurisdictionName = bmp.StormwaterJurisdiction?.Organization?.OrganizationName,
+                    WaterQualityManagementPlanID = bmp.WaterQualityManagementPlanID,
+                    WaterQualityManagementPlanName = bmp.WaterQualityManagementPlan?.WaterQualityManagementPlanName,
                     WatershedID = bmp.WatershedID,
                     WatershedName = watershedName,
                     PrecipitationZoneID = bmp.PrecipitationZoneID,

--- a/Neptune.Jobs/Hangfire/DeltaSolveJob.cs
+++ b/Neptune.Jobs/Hangfire/DeltaSolveJob.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Hangfire;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Neptune.Common.GeoSpatial;
@@ -15,9 +16,21 @@ public class DeltaSolveJob(
     NereidService nereidService)
     : BlobStorageWritingJob<DeltaSolveJob>(configuration, logger, dbContext)
 {
+    // DisableConcurrentExecution: this job is enqueued both on-edit and by the scheduled DeltaSolveScheduledBackgroundJob;
+    // the distributed mutex prevents two runs from overlapping (double Nereid solve / RemoveRange on already-deleted rows),
+    // which matters if the Hangfire worker count is ever raised above 1. AutomaticRetry self-heals a transient Nereid
+    // failure before the nightly Total Network Solve (the global default is 0 retries).
+    [DisableConcurrentExecution(timeoutInSeconds: 600)]
+    [AutomaticRetry(Attempts = 2)]
     public async Task RunJob()
     {
         var dirtyModelNodes = DbContext.DirtyModelNodes.ToList();
+
+        // Nothing dirty (e.g. a scheduled run with no pending edits) — skip the Nereid round-trips and blob re-uploads.
+        if (dirtyModelNodes.Count == 0)
+        {
+            return;
+        }
 
         await nereidService.DeltaSolve(DbContext, dirtyModelNodes, true);
         await nereidService.DeltaSolve(DbContext, dirtyModelNodes, false);

--- a/Neptune.Jobs/Hangfire/DeltaSolveJob.cs
+++ b/Neptune.Jobs/Hangfire/DeltaSolveJob.cs
@@ -24,7 +24,8 @@ public class DeltaSolveJob(
     [AutomaticRetry(Attempts = 2)]
     public async Task RunJob()
     {
-        var dirtyModelNodes = DbContext.DirtyModelNodes.ToList();
+        // Tracked (not AsNoTracking) because RemoveRange below deletes exactly this snapshot.
+        var dirtyModelNodes = await DbContext.DirtyModelNodes.ToListAsync();
 
         // Nothing dirty (e.g. a scheduled run with no pending edits) — skip the Nereid round-trips and blob re-uploads.
         if (dirtyModelNodes.Count == 0)

--- a/Neptune.Jobs/Hangfire/DeltaSolveScheduledBackgroundJob.cs
+++ b/Neptune.Jobs/Hangfire/DeltaSolveScheduledBackgroundJob.cs
@@ -1,0 +1,28 @@
+using Hangfire;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Neptune.Common.Email;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.Jobs.Hangfire
+{
+    public class DeltaSolveScheduledBackgroundJob : ScheduledBackgroundJobBase<DeltaSolveScheduledBackgroundJob>
+    {
+        public const string JobName = "Nereid Delta Solve";
+
+        public DeltaSolveScheduledBackgroundJob(ILogger<DeltaSolveScheduledBackgroundJob> logger,
+            IWebHostEnvironment webHostEnvironment, NeptuneDbContext neptuneDbContext,
+            IOptions<NeptuneJobConfiguration> neptuneJobConfiguration, SitkaSmtpClientService sitkaSmtpClientService) : base(JobName, logger, webHostEnvironment,
+            neptuneDbContext, neptuneJobConfiguration, sitkaSmtpClientService)
+        {
+        }
+
+        public override List<RunEnvironment> RunEnvironments => new() { RunEnvironment.Staging, RunEnvironment.Production };
+
+        protected override void RunJobImplementation()
+        {
+            BackgroundJob.Enqueue<DeltaSolveJob>(x => x.RunJob());
+        }
+    }
+}

--- a/Neptune.Jobs/Hangfire/DeltaSolveScheduledBackgroundJob.cs
+++ b/Neptune.Jobs/Hangfire/DeltaSolveScheduledBackgroundJob.cs
@@ -22,6 +22,10 @@ namespace Neptune.Jobs.Hangfire
 
         protected override void RunJobImplementation()
         {
+            // This enqueues DeltaSolveJob and returns; the base wrapper's try/catch (and its failure email) only
+            // covers enqueue-time errors, NOT exceptions thrown while DeltaSolveJob later runs on a worker — same
+            // as TotalNetworkSolveScheduledBackgroundJob. A failing DeltaSolveJob surfaces as a Failed job in the
+            // Hangfire dashboard and is retried via [AutomaticRetry] on DeltaSolveJob.RunJob.
             BackgroundJob.Enqueue<DeltaSolveJob>(x => x.RunJob());
         }
     }

--- a/Neptune.Jobs/Hangfire/HRURefreshJob.cs
+++ b/Neptune.Jobs/Hangfire/HRURefreshJob.cs
@@ -124,13 +124,12 @@ public class HRURefreshJob(
             ? updatedNereidResults.Max(x => x.LastUpdate.Value)
             : DateTime.MinValue;
 
+        // A regional-subbasin/topology change requires a full re-solve, which the delta solve does not cover.
+        // Dirty-node delta solving is owned by the dedicated DeltaSolveScheduledBackgroundJob (same cron window),
+        // so we no longer enqueue DeltaSolveJob here.
         if (lastRegionalSubbasinUpdateDate > lastNereidResultUpdateDate)
         {
             BackgroundJob.Enqueue<TotalNetworkSolveScheduledBackgroundJob>(x => x.RunJob(null));
-        }
-        else if (dbContext.DirtyModelNodes.AsNoTracking().Any())
-        {
-            BackgroundJob.Enqueue<DeltaSolveJob>(x => x.RunJob());
         }
     }
 

--- a/Neptune.Jobs/Hangfire/ScheduledBackgroundJobBootstrapper.cs
+++ b/Neptune.Jobs/Hangfire/ScheduledBackgroundJobBootstrapper.cs
@@ -19,9 +19,9 @@ namespace Neptune.Jobs.Hangfire
             AddRecurringJob<HRURefreshScheduledBackgroundJob>(HRURefreshScheduledBackgroundJob.JobName, x => x.RunJob(null), "0 0-4,14-23 * * 1-5", recurringJobIds);
 
             // Recalculate dirty model nodes on the same window as the HRU refresh. That window deliberately skips
-            // 5-13 UTC, where the nightly Total Network Solve runs (1 AM PST = 9 UTC), so the delta solve never
-            // collides with the nightly catch-all. This is decoupled from HRU so it runs regardless of whether the
-            // HRU refresh completes its OCGIS loop.
+            // 5-13 UTC; the nightly Total Network Solve runs at 1 AM Pacific (~8-9 UTC depending on DST), which falls
+            // inside that skipped gap, so the delta solve never collides with the nightly catch-all year-round. This
+            // is decoupled from HRU so it runs regardless of whether the HRU refresh completes its OCGIS loop.
             AddRecurringJob<DeltaSolveScheduledBackgroundJob>(DeltaSolveScheduledBackgroundJob.JobName, x => x.RunJob(null), "0 0-4,14-23 * * 1-5", recurringJobIds);
 
             AddRecurringJob<TotalNetworkSolveScheduledBackgroundJob>(TotalNetworkSolveScheduledBackgroundJob.JobName, x => x.RunJob(null), MakeDailyUtcCronJobStringFromLocalTime(1, 0), recurringJobIds);

--- a/Neptune.Jobs/Hangfire/ScheduledBackgroundJobBootstrapper.cs
+++ b/Neptune.Jobs/Hangfire/ScheduledBackgroundJobBootstrapper.cs
@@ -18,6 +18,12 @@ namespace Neptune.Jobs.Hangfire
 
             AddRecurringJob<HRURefreshScheduledBackgroundJob>(HRURefreshScheduledBackgroundJob.JobName, x => x.RunJob(null), "0 0-4,14-23 * * 1-5", recurringJobIds);
 
+            // Recalculate dirty model nodes on the same window as the HRU refresh. That window deliberately skips
+            // 5-13 UTC, where the nightly Total Network Solve runs (1 AM PST = 9 UTC), so the delta solve never
+            // collides with the nightly catch-all. This is decoupled from HRU so it runs regardless of whether the
+            // HRU refresh completes its OCGIS loop.
+            AddRecurringJob<DeltaSolveScheduledBackgroundJob>(DeltaSolveScheduledBackgroundJob.JobName, x => x.RunJob(null), "0 0-4,14-23 * * 1-5", recurringJobIds);
+
             AddRecurringJob<TotalNetworkSolveScheduledBackgroundJob>(TotalNetworkSolveScheduledBackgroundJob.JobName, x => x.RunJob(null), MakeDailyUtcCronJobStringFromLocalTime(1, 0), recurringJobIds);
 
             // Remove any jobs we haven't explicitly scheduled

--- a/Neptune.Models/DataTransferObjects/TreatmentBMP/TreatmentBMPDto.cs
+++ b/Neptune.Models/DataTransferObjects/TreatmentBMP/TreatmentBMPDto.cs
@@ -45,6 +45,10 @@ public class TreatmentBMPDto
     // same gate to avoid hiding the panel for BMP types that are modeled but have no custom
     // attributes flagged as Modeling-purpose.
     public bool IsAnalyzedInModelingModule { get; set; }
+    // True when this BMP's node is dirty (a DirtyModelNode row exists) and pending recalculation — e.g. after a
+    // modeling-attribute or delineation edit, before the delta solve runs. Drives the "awaiting calculation"
+    // message on the detail page so a stale/zero result isn't shown as if it were current.
+    public bool IsAwaitingModelingCalculation { get; set; }
     public vTreatmentBMPModelingAttributeDto? TreatmentBMPModelingAttribute { get; set; }
 
     // Related Entities

--- a/Neptune.Models/DataTransferObjects/TreatmentBMP/TreatmentBMPModelingAttributesDto.cs
+++ b/Neptune.Models/DataTransferObjects/TreatmentBMP/TreatmentBMPModelingAttributesDto.cs
@@ -8,6 +8,8 @@ public class TreatmentBMPModelingAttributesDto
     public string? TreatmentBMPTypeName { get; set; }
     public int? StormwaterJurisdictionID { get; set; }
     public string? StormwaterJurisdictionName { get; set; }
+    public int? WaterQualityManagementPlanID { get; set; }
+    public string? WaterQualityManagementPlanName { get; set; }
     public int? WatershedID { get; set; }
     public string? WatershedName { get; set; }
     public int? PrecipitationZoneID { get; set; }

--- a/Neptune.Web/src/app/pages/funding-sources/funding-source-detail/funding-source-detail.component.ts
+++ b/Neptune.Web/src/app/pages/funding-sources/funding-source-detail/funding-source-detail.component.ts
@@ -5,7 +5,6 @@ import { DialogService } from "@ngneat/dialog";
 import { BehaviorSubject, catchError, forkJoin, Observable, of, shareReplay, switchMap, map } from "rxjs";
 import { AuthenticationService } from "src/app/services/authentication.service";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
-import { IconComponent } from "src/app/shared/components/icon/icon.component";
 import { NoteComponent } from "src/app/shared/components/note/note.component";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { FundingSourceService } from "src/app/shared/generated/api/funding-source.service";
@@ -32,7 +31,7 @@ interface FundingSourceDetailViewModel {
 @Component({
     selector: "funding-source-detail",
     standalone: true,
-    imports: [AsyncPipe, CurrencyPipe, RouterLink, PageHeaderComponent, AlertDisplayComponent, IconComponent, NoteComponent],
+    imports: [AsyncPipe, CurrencyPipe, RouterLink, PageHeaderComponent, AlertDisplayComponent, NoteComponent],
     templateUrl: "./funding-source-detail.component.html",
     styleUrl: "./funding-source-detail.component.scss",
 })

--- a/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.scss
+++ b/Neptune.Web/src/app/pages/jurisdictions/jurisdiction-detail/jurisdiction-users-modal/jurisdiction-users-modal.component.scss
@@ -1,4 +1,5 @@
 @use "/src/scss/abstracts" as *;
+@use "sass:color";
 
 // Use the project's table-size type so more assigned users fit without scrolling.
 .picker-row,
@@ -34,7 +35,7 @@
         line-height: 1;
 
         &:hover {
-            color: darken($danger, 10%);
+            color: color.adjust($danger, $lightness: -10%);
         }
     }
 }

--- a/Neptune.Web/src/app/pages/modeling-attributes/modeling-attributes.component.ts
+++ b/Neptune.Web/src/app/pages/modeling-attributes/modeling-attributes.component.ts
@@ -33,11 +33,15 @@ export class ModelingAttributesComponent {
             this.utilityFunctionsService.createBooleanColumnDef("Fully Parameterized?", "IsFullyParameterized", {
                 FieldDefinitionType: "FullyParameterized",
                 FieldDefinitionLabelOverride: "Fully Parameterized?",
+                UseCustomDropdownFilter: true,
             }),
             this.utilityFunctionsService.createBasicColumnDef("Delineation Type", "DelineationTypeName", {
                 FieldDefinitionType: "DelineationType",
+                UseCustomDropdownFilter: true,
             }),
-            this.utilityFunctionsService.createBasicColumnDef("Delineation Status", "DelineationStatus"),
+            this.utilityFunctionsService.createBasicColumnDef("Delineation Status", "DelineationStatus", {
+                UseCustomDropdownFilter: true,
+            }),
             this.utilityFunctionsService.createBasicColumnDef("Type", "TreatmentBMPTypeName", {
                 FieldDefinitionType: "TreatmentBMPType",
                 FieldDefinitionLabelOverride: "Type",
@@ -50,6 +54,11 @@ export class ModelingAttributesComponent {
             this.utilityFunctionsService.createLinkColumnDef("Jurisdiction", "StormwaterJurisdictionName", "StormwaterJurisdictionID", {
                 InRouterLink: "/jurisdictions/",
                 FieldDefinitionType: "Jurisdiction",
+            }),
+            this.utilityFunctionsService.createLinkColumnDef("WQMP", "WaterQualityManagementPlanName", "WaterQualityManagementPlanID", {
+                InRouterLink: "/water-quality-management-plans/",
+                FieldDefinitionType: "WaterQualityManagementPlan",
+                FieldDefinitionLabelOverride: "WQMP",
             }),
             this.utilityFunctionsService.createBasicColumnDef("Watershed", "WatershedName", {
                 FieldDefinitionType: "Watershed",
@@ -137,6 +146,7 @@ export class ModelingAttributesComponent {
             this.utilityFunctionsService.createBasicColumnDef("Underlying Hydrologic Soil Group", "UnderlyingHydrologicSoilGroup", {
                 FieldDefinitionType: "UnderlyingHydrologicSoilGroupID",
                 FieldDefinitionLabelOverride: "Underlying Hydrologic Soil Group",
+                UseCustomDropdownFilter: true,
             }),
             this.utilityFunctionsService.createDecimalColumnDef("Underlying Infiltration Rate", "UnderlyingInfiltrationRate", {
                 FieldDefinitionType: "UnderlyingInfiltrationRate",
@@ -162,10 +172,12 @@ export class ModelingAttributesComponent {
             this.utilityFunctionsService.createBooleanColumnDef("Downstream of Non-Modeled BMP?", "DownstreamOfNonModeledBMP", {
                 FieldDefinitionType: "DownstreamOfNonModeledBMP",
                 FieldDefinitionLabelOverride: "Downstream of Non-Modeled BMP?",
+                UseCustomDropdownFilter: true,
             }),
             this.utilityFunctionsService.createBasicColumnDef("Dry Weather Flow Override", "DryWeatherFlowOverride", {
                 FieldDefinitionType: "DryWeatherFlowOverrideID",
                 FieldDefinitionLabelOverride: "Dry Weather Flow Override",
+                UseCustomDropdownFilter: true,
             }),
         ];
         this.modelingAttributes$ = this.treatmentBMPService.listWithModelingAttributesTreatmentBMP();

--- a/Neptune.Web/src/app/pages/organizations/organization-detail/organization-detail.component.ts
+++ b/Neptune.Web/src/app/pages/organizations/organization-detail/organization-detail.component.ts
@@ -5,7 +5,6 @@ import { DialogService } from "@ngneat/dialog";
 import { BehaviorSubject, catchError, forkJoin, map, Observable, of, shareReplay, switchMap } from "rxjs";
 import { AuthenticationService } from "src/app/services/authentication.service";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
-import { IconComponent } from "src/app/shared/components/icon/icon.component";
 import { NoteComponent } from "src/app/shared/components/note/note.component";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { fileResourceUrl } from "src/app/shared/helpers/file-resource-url";
@@ -38,7 +37,7 @@ interface OrganizationDetailViewModel {
 @Component({
     selector: "organization-detail",
     standalone: true,
-    imports: [AsyncPipe, RouterLink, PageHeaderComponent, AlertDisplayComponent, IconComponent, NoteComponent],
+    imports: [AsyncPipe, RouterLink, PageHeaderComponent, AlertDisplayComponent, NoteComponent],
     templateUrl: "./organization-detail.component.html",
     styleUrl: "./organization-detail.component.scss",
 })

--- a/Neptune.Web/src/app/pages/planning-module/projects/project-model-results/project-model-results.component.ts
+++ b/Neptune.Web/src/app/pages/planning-module/projects/project-model-results/project-model-results.component.ts
@@ -111,19 +111,11 @@ export class ProjectModelResultsComponent implements OnInit {
             distinctUntilChanged()
         );
 
-        const hasSucceededHistory$ = this.projectNetworkSolveHistoriesSubject.asObservable().pipe(
-            map((histories) =>
-                Array.isArray(histories) ? histories.some((x) => x.ProjectNetworkSolveHistoryStatusTypeID === ProjectNetworkSolveHistoryStatusTypeEnum.Succeeded) : false
-            ),
-            distinctUntilChanged()
-        );
-
-        const shouldLoadProjectID$ = combineLatest([projectID$, hasSucceededHistory$]).pipe(
-            filter(([_, hasSucceeded]) => hasSucceeded),
-            map(([projectID]) => projectID),
-            distinctUntilChanged(),
-            shareReplay(1)
-        );
+        // Load modeled results whenever we have a project — independent of network-solve history status.
+        // Previously this was gated on a Succeeded ProjectNetworkSolveHistory, which left fully-parameterized
+        // projects that already have results (e.g. from a prior/total solve) stuck on a spinner with no Succeeded
+        // history row. The endpoint returns [] when no results exist, so the empty-state handles that case.
+        const shouldLoadProjectID$ = projectID$.pipe(distinctUntilChanged(), shareReplay(1));
 
         const load$ = shouldLoadProjectID$.pipe(
             switchMap((projectID) =>

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.html
@@ -200,6 +200,9 @@
                                         </p>
                                     }
                                 } @else {
+                                    @if (treatmentBMP.IsAwaitingModelingCalculation) {
+                                        <p class="system-text">This BMP is awaiting calculation. Recently edited Treatment BMPs are recalculated on a schedule; results below may be out of date until then.</p>
+                                    }
                                     @if (loadReducingResult$ | async; as loadReducingResult) {
                                         <modeled-bmp-performance [selectedTreatmentBMPID]="treatmentBMP.TreatmentBMPID" [loadReducingResult]="loadReducingResult" siteRunoffLabel="To BMP"></modeled-bmp-performance>
                                         <div class="modeled-performance-footer">

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
@@ -62,7 +62,6 @@ import { GroupByPipe } from "src/app/shared/pipes/group-by.pipe";
 import { SumPipe } from "src/app/shared/pipes/sum.pipe";
 import { OverlayMode } from "src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/overlay-mode.enum";
 import { HruCharacteristicsGridComponent } from "src/app/shared/components/hru-characteristics-grid/hru-characteristics-grid.component";
-import { IconComponent } from "src/app/shared/components/icon/icon.component";
 import { NoteComponent } from "src/app/shared/components/note/note.component";
 import { TrashCaptureStatusTypeEnum } from "src/app/shared/generated/enum/trash-capture-status-type-enum";
 import {
@@ -116,7 +115,6 @@ import {
         NeptuneGridComponent,
         CustomAttributesDisplayComponent,
         HruCharacteristicsGridComponent,
-        IconComponent,
         NoteComponent,
         FileResourceListComponent,
     ],

--- a/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.ts
+++ b/Neptune.Web/src/app/pages/users/user-detail/user-detail.component.ts
@@ -13,7 +13,6 @@ import { RoleEnum } from "src/app/shared/generated/enum/role-enum";
 import { PersonDetailDto } from "src/app/shared/generated/model/person-detail-dto";
 import { PersonNotificationDto } from "src/app/shared/generated/model/person-notification-dto";
 import { AlertDisplayComponent } from "src/app/shared/components/alert-display/alert-display.component";
-import { IconComponent } from "src/app/shared/components/icon/icon.component";
 import { NeptuneGridComponent } from "src/app/shared/components/neptune-grid/neptune-grid.component";
 import { NoteComponent } from "src/app/shared/components/note/note.component";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
@@ -28,7 +27,7 @@ import { EditJurisdictionsModalComponent } from "./edit-jurisdictions-modal/edit
 @Component({
     selector: "user-detail",
     standalone: true,
-    imports: [AsyncPipe, DatePipe, RouterLink, PageHeaderComponent, AlertDisplayComponent, IconComponent, NeptuneGridComponent, NoteComponent],
+    imports: [AsyncPipe, DatePipe, RouterLink, PageHeaderComponent, AlertDisplayComponent, NeptuneGridComponent, NoteComponent],
     templateUrl: "./user-detail.component.html",
     styleUrl: "./user-detail.component.scss",
 })

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
@@ -14,7 +14,6 @@ import { WqmpsLayerComponent } from "src/app/shared/components/leaflet/layers/wq
 import { OverlayMode } from "src/app/shared/components/leaflet/layers/generic-wms-wfs-layer/overlay-mode.enum";
 import { NeptuneGridComponent } from "src/app/shared/components/neptune-grid/neptune-grid.component";
 import { FieldDefinitionComponent } from "src/app/shared/components/field-definition/field-definition.component";
-import { IconComponent } from "src/app/shared/components/icon/icon.component";
 import { ModeledBmpPerformanceComponent } from "src/app/shared/components/modeled-bmp-performance/modeled-bmp-performance.component";
 import { LandUseTableComponent } from "src/app/shared/components/land-use-table/land-use-table.component";
 import { NoteComponent } from "src/app/shared/components/note/note.component";
@@ -74,7 +73,6 @@ import { environment } from "src/environments/environment";
         NeptuneMapComponent,
         WqmpsLayerComponent,
         NeptuneGridComponent,
-        IconComponent,
         ModeledBmpPerformanceComponent,
         LandUseTableComponent,
         NoteComponent,

--- a/Neptune.Web/src/app/shared/generated/model/treatment-bmp-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/treatment-bmp-dto.ts
@@ -57,6 +57,7 @@ export class TreatmentBMPDto {
     TreatmentBMPAssessmentCount?: number;
     IsFullyParameterized?: boolean | null;
     IsAnalyzedInModelingModule?: boolean;
+    IsAwaitingModelingCalculation?: boolean;
     TreatmentBMPModelingAttribute?: VTreatmentBMPModelingAttributeDto;
     OtherTreatmentBMPsExistInSubbasin?: boolean | null;
     Delineation?: DelineationDto;
@@ -113,6 +114,7 @@ export interface TreatmentBMPDtoForm {
     TreatmentBMPAssessmentCount?: FormControl<number>;
     IsFullyParameterized?: FormControl<boolean>;
     IsAnalyzedInModelingModule?: FormControl<boolean>;
+    IsAwaitingModelingCalculation?: FormControl<boolean>;
     TreatmentBMPModelingAttribute?: FormControl<VTreatmentBMPModelingAttributeDto>;
     OtherTreatmentBMPsExistInSubbasin?: FormControl<boolean>;
     Delineation?: FormControl<DelineationDto>;
@@ -472,6 +474,16 @@ export class TreatmentBMPDtoFormControls {
         }
     );
     public static IsAnalyzedInModelingModule = (value: FormControlState<boolean> | boolean = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<boolean>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static IsAwaitingModelingCalculation = (value: FormControlState<boolean> | boolean = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<boolean>(
         value,
         formControlOptions ?? 
         {

--- a/Neptune.Web/src/app/shared/generated/model/treatment-bmp-modeling-attributes-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/treatment-bmp-modeling-attributes-dto.ts
@@ -17,6 +17,8 @@ export class TreatmentBMPModelingAttributesDto {
     TreatmentBMPTypeName?: string | null;
     StormwaterJurisdictionID?: number | null;
     StormwaterJurisdictionName?: string | null;
+    WaterQualityManagementPlanID?: number | null;
+    WaterQualityManagementPlanName?: string | null;
     WatershedID?: number | null;
     WatershedName?: string | null;
     PrecipitationZoneID?: number | null;
@@ -67,6 +69,8 @@ export interface TreatmentBMPModelingAttributesDtoForm {
     TreatmentBMPTypeName?: FormControl<string>;
     StormwaterJurisdictionID?: FormControl<number>;
     StormwaterJurisdictionName?: FormControl<string>;
+    WaterQualityManagementPlanID?: FormControl<number>;
+    WaterQualityManagementPlanName?: FormControl<string>;
     WatershedID?: FormControl<number>;
     WatershedName?: FormControl<string>;
     PrecipitationZoneID?: FormControl<number>;
@@ -159,6 +163,26 @@ export class TreatmentBMPModelingAttributesDtoFormControls {
         }
     );
     public static StormwaterJurisdictionName = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static WaterQualityManagementPlanID = (value: FormControlState<number> | number = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<number>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static WaterQualityManagementPlanName = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
         value,
         formControlOptions ?? 
         {


### PR DESCRIPTION
Rework for NPT-1062 (Bug: SPA Modeled BMP Performance). Addresses all five PO-testing rework items plus build-warning cleanup. Combined PR per request.

## #1 — Dirty-node recalc as a dedicated scheduled job
**Root cause:** the dirty-node delta solve only ran as a side effect of `HRURefreshJob` finishing its OCGIS loop, so edited BMPs/WQMPs showed zeros/stale results until the nightly Total Network Solve.
- New `DeltaSolveScheduledBackgroundJob` (wrapped in `ScheduledBackgroundJobBase`; note the wrapper only emails on enqueue-time errors — DeltaSolveJob execution failures surface via the Hangfire dashboard + `AutomaticRetry`), registered on the HRU window `0 0-4,14-23 * * 1-5` (skips 5–13 UTC where the nightly solve runs, so no collision).
- `DeltaSolveJob`: empty-set guard, `[DisableConcurrentExecution]`, modest `[AutomaticRetry]`.
- Removed HRU's redundant dirty-node enqueue branch (kept the RSB → full-solve branch).

## #2 — "Delineation required" alert wrong with an upstream BMP
`GetParameterizationErrors` now resolves the effective delineation through the upstream chain (`vTreatmentBMPUpstreams`), mirroring `TreatmentBMPs.GetByIDAsync`, so a BMP inheriting its upstream's delineation no longer shows the alert.

## #3 — "This BMP is awaiting calculation" message
New `IsAwaitingModelingCalculation` on the BMP detail DTO (true when a `DirtyModelNode` exists for the BMP/its delineation); the detail page shows an awaiting message so a stale/zero result isn't presented as current.

## #4 — Planning workflow Model Results panel showed nothing
`project-model-results` no longer gates loading on a Succeeded `ProjectNetworkSolveHistory`; it loads results whenever there is a project (matching the BMP detail page).

## #5 — Modeling Attributes grid
- WQMP column near Jurisdiction, linked to the WQMP detail page (DTO + projection + link column).
- Six picklist columns switched from "contains" to checkbox/set filters (`UseCustomDropdownFilter`).
- Perf: backend already batches with `AsNoTracking` + dictionaries; no change needed (server-side paging noted as a future follow-up).

## Build-warning cleanup (requested)
- Removed unused `IconComponent` imports (NG8113) from 5 detail components.
- Replaced deprecated Sass `darken()` with `color.adjust()`. `build-dev` now has zero warnings.

## Verification
- Backend builds (0 errors); Angular `build-dev` 0 warnings; codegen regenerated (swagger + 2 DTOs).
- Affected tests 148/149 pass; the 1 failure (`TestBMPNameExistsAndMatchingJurisdictionAndType`) is a pre-existing DB-seed dependency, unrelated.
- **Pending QA (post-deploy):** confirm "Nereid Delta Solve" in `/hangfire` with cron `0 0-4,14-23 * * 1-5`; zeros resolved for BMP 497; awaiting message on a freshly-edited BMP; planning panel for projects 290/288. Verify the parent `project.HasModeledResults` gate isn't independently hiding results on those projects.