### PR TITLE
NPT-1079: WQMP Name column on Treatment BMP list + public column set

### DIFF
--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -21996,6 +21996,15 @@
             "type": "string",
             "nullable": true
           },
+          "WaterQualityManagementPlanID": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "WaterQualityManagementPlanName": {
+            "type": "string",
+            "nullable": true
+          },
           "OwnerOrganizationID": {
             "type": "integer",
             "format": "int32"

--- a/Neptune.Database/dbo/Views/dbo.vTreatmentBMPDetailed.sql
+++ b/Neptune.Database/dbo/Views/dbo.vTreatmentBMPDetailed.sql
@@ -18,6 +18,7 @@ as
 
 select	tb.TreatmentBMPID as PrimaryKey,
 		tb.TreatmentBMPID, tb.TreatmentBMPName, tbt.TreatmentBMPTypeID, tbt.TreatmentBMPTypeName, sj.StormwaterJurisdictionID, o.OrganizationName
+		, wqmp.WaterQualityManagementPlanID, wqmp.WaterQualityManagementPlanName
 		, tb.RequiredFieldVisitsPerYear, tb.RequiredPostStormFieldVisitsPerYear, tb.TreatmentBMPLifespanEndDate, tb.YearBuilt, tb.Notes, tb.InventoryIsVerified
 		, tb.OwnerOrganizationID, oo.OrganizationName as OwnerOrganizationName
 		, tblt.TreatmentBMPLifespanTypeID, tblt.TreatmentBMPLifespanTypeDisplayName
@@ -37,6 +38,7 @@ join dbo.TreatmentBMPType tbt on tb.TreatmentBMPTypeID = tbt.TreatmentBMPTypeID
 join dbo.StormwaterJurisdiction sj on tb.StormwaterJurisdictionID = sj.StormwaterJurisdictionID
 join dbo.Organization o on sj.OrganizationID = o.OrganizationID
 join dbo.Organization oo on tb.OwnerOrganizationID = oo.OrganizationID
+left join dbo.WaterQualityManagementPlan wqmp on tb.WaterQualityManagementPlanID = wqmp.WaterQualityManagementPlanID
 join dbo.TrashCaptureStatusType tcst on tb.TrashCaptureStatusTypeID = tcst.TrashCaptureStatusTypeID
 join dbo.SizingBasisType sbt on tb.SizingBasisTypeID = sbt.SizingBasisTypeID
 left join dbo.TreatmentBMPLifespanType tblt on tb.TreatmentBMPLifespanTypeID = tblt.TreatmentBMPLifespanTypeID

--- a/Neptune.EFModels/Entities/Generated/vTreatmentBMPDetailed.cs
+++ b/Neptune.EFModels/Entities/Generated/vTreatmentBMPDetailed.cs
@@ -29,6 +29,12 @@ public partial class vTreatmentBMPDetailed
     [Unicode(false)]
     public string OrganizationName { get; set; } = null!;
 
+    public int? WaterQualityManagementPlanID { get; set; }
+
+    [StringLength(100)]
+    [Unicode(false)]
+    public string? WaterQualityManagementPlanName { get; set; }
+
     public int? RequiredFieldVisitsPerYear { get; set; }
 
     public int? RequiredPostStormFieldVisitsPerYear { get; set; }

--- a/Neptune.EFModels/Entities/vTreatmentBMPDetailedExtensionMethods.cs
+++ b/Neptune.EFModels/Entities/vTreatmentBMPDetailedExtensionMethods.cs
@@ -14,6 +14,8 @@ namespace Neptune.EFModels.Entities
                 TreatmentBMPTypeName = entity.TreatmentBMPTypeName,
                 StormwaterJurisdictionID = entity.StormwaterJurisdictionID,
                 StormwaterJurisdictionName = entity.OrganizationName,
+                WaterQualityManagementPlanID = entity.WaterQualityManagementPlanID,
+                WaterQualityManagementPlanName = entity.WaterQualityManagementPlanName,
                 OwnerOrganizationID = entity.OwnerOrganizationID,
                 OwnerOrganizationName = entity.OwnerOrganizationName,
                 YearBuilt = entity.YearBuilt,

--- a/Neptune.Models/DataTransferObjects/TreatmentBMP/TreatmentBMPGridDto.cs
+++ b/Neptune.Models/DataTransferObjects/TreatmentBMP/TreatmentBMPGridDto.cs
@@ -8,6 +8,8 @@ public class TreatmentBMPGridDto
     public string? TreatmentBMPTypeName { get; set; }
     public int StormwaterJurisdictionID { get; set; }
     public string StormwaterJurisdictionName { get; set; }
+    public int? WaterQualityManagementPlanID { get; set; }
+    public string? WaterQualityManagementPlanName { get; set; }
     public int OwnerOrganizationID { get; set; }
     public string OwnerOrganizationName { get; set; }
     public int? YearBuilt { get; set; }

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
@@ -134,6 +134,9 @@ export class TreatmentBmpsComponent {
                 FieldDefinitionType: "Jurisdiction",
                 UseCustomDropdownFilter: true,
             }),
+            this.utilityFunctionsService.createLinkColumnDef("WQMP Name", "WaterQualityManagementPlanName", "WaterQualityManagementPlanID", {
+                InRouterLink: "/water-quality-management-plans/",
+            }),
             this.utilityFunctionsService.createBasicColumnDef("Owner Organization", "OwnerOrganizationName", { UseCustomDropdownFilter: true }),
             this.utilityFunctionsService.createBasicColumnDef("Type", "TreatmentBMPTypeName", {
                 FieldDefinitionType: "TreatmentBMPType",
@@ -166,9 +169,9 @@ export class TreatmentBmpsComponent {
             },
         ];
         // NPT-1079: public (anonymous) + unassigned users see only the fields the legacy "Find a
-        // BMP" map exposed — Name and Type. Hide the actions column and all operational columns
-        // (assessments, maintenance, lifespan, sizing, trash, notes, jurisdiction, owner).
-        const publicHeaders = new Set(["Name", "Type"]);
+        // BMP" map exposed — Name, Type, WQMP Name, Jurisdiction, and Notes. Hide the actions column
+        // and all operational columns (assessments, maintenance, lifespan, sizing, trash, owner).
+        const publicHeaders = new Set(["Name", "Type", "WQMP Name", "Jurisdiction", "Notes"]);
         this.columnDefs = isAnonymousOrUnassigned ? columnDefs.filter((c) => publicHeaders.has(c.headerName as string)) : columnDefs;
 
         this.treatmentBmps$ = this.treatmentBMPService

--- a/Neptune.Web/src/app/shared/generated/model/treatment-bmp-grid-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/treatment-bmp-grid-dto.ts
@@ -17,6 +17,8 @@ export class TreatmentBMPGridDto {
     TreatmentBMPTypeName?: string | null;
     StormwaterJurisdictionID?: number;
     StormwaterJurisdictionName?: string | null;
+    WaterQualityManagementPlanID?: number | null;
+    WaterQualityManagementPlanName?: string | null;
     OwnerOrganizationID?: number;
     OwnerOrganizationName?: string | null;
     YearBuilt?: number | null;
@@ -49,6 +51,8 @@ export interface TreatmentBMPGridDtoForm {
     TreatmentBMPTypeName?: FormControl<string>;
     StormwaterJurisdictionID?: FormControl<number>;
     StormwaterJurisdictionName?: FormControl<string>;
+    WaterQualityManagementPlanID?: FormControl<number>;
+    WaterQualityManagementPlanName?: FormControl<string>;
     OwnerOrganizationID?: FormControl<number>;
     OwnerOrganizationName?: FormControl<string>;
     YearBuilt?: FormControl<number>;
@@ -123,6 +127,26 @@ export class TreatmentBMPGridDtoFormControls {
         }
     );
     public static StormwaterJurisdictionName = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static WaterQualityManagementPlanID = (value: FormControlState<number> | number = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<number>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static WaterQualityManagementPlanName = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
         value,
         formControlOptions ?? 
         {


### PR DESCRIPTION
## NPT-1079 rework — Treatment BMP list grid

Addresses the remaining **Needs Rework** items on NPT-1079 (public/anonymous Treatment BMP list should mirror the legacy "Find a BMP" map fields).

### Changes
- **New WQMP Name column** on the Treatment BMP list — clickable link to the WQMP detail page, blank for BMPs with no associated WQMP. Visible to all users.
- **Public/anonymous column set widened** from `Name, Type` to **`Name, Jurisdiction, WQMP Name, Type, Notes`** — the fields the old Find-a-BMP map exposed. Operational columns and actions stay hidden for public/unassigned users.

### Backend (DB-first)
- `dbo.vTreatmentBMPDetailed` — `LEFT JOIN WaterQualityManagementPlan`, selecting `WaterQualityManagementPlanID` + `WaterQualityManagementPlanName` (FK is nullable).
- `TreatmentBMPGridDto` + `AsGridDto` mapping + scaffolded entity gain the two WQMP fields.
- Regenerated the TypeScript grid DTO model via codegen.

### Verification
- DACPAC deployed; view returns WQMP names for 7,132 of 18,799 rows.
- C# builds clean; Angular typechecks clean.
- Verified in the running app (logged-in + anonymous): WQMP column populates as links, public view shows the widened set, permission-filtered row set unchanged.

### Notes for reviewer
- The scaffolded entity property was added to match `Scaffold-DbContext` output exactly (EF10 cmdlet needs VS Package Manager Console; re-running the official scaffold is a no-op).
- An unrelated openapi-generator version-pin drift (7.13.0 → 7.21.0) was deliberately kept out of this PR to stay scoped — worth a separate chore.