### PR TITLE
NPT-1065: Persist recalculated OVTA scores on assessment delete

### DIFF
--- a/Neptune.API/Controllers/OnlandVisualTrashAssessmentController.cs
+++ b/Neptune.API/Controllers/OnlandVisualTrashAssessmentController.cs
@@ -73,6 +73,9 @@ public class OnlandVisualTrashAssessmentController(
                         ?.OnlandVisualTrashAssessmentScoreID;
             }
 
+            // DeleteFull runs immediate ExecuteDeleteAsync statements, so the recalculated scores above
+            // are only on the tracked area entity until we persist them here.
+            await DbContext.SaveChangesAsync();
         }
         return Ok();
     }


### PR DESCRIPTION
QA found that deleting the only progress OVTA within the last 5 years left the area's stale progress score in place. The Delete action already recalculated the baseline and progress scores after DeleteFull, but DeleteFull runs immediate ExecuteDeleteAsync statements and the action never called SaveChangesAsync, so the recalculated values (including null) lived only on the tracked area entity and were discarded at end of request.

Add the missing SaveChangesAsync after the recalculation, matching the pattern already used by the return-to-edit action. Pre-existing bug surfaced by this card; it affected baseline scores on delete for the same reason.