### PR TITLE
NPT-1093: Troubleshoot delineation GDB upload issues (layer-name casing + bulk delete)

### DIFF
--- a/Neptune.EFModels/Entities/Delineation.cs
+++ b/Neptune.EFModels/Entities/Delineation.cs
@@ -70,5 +70,37 @@ namespace Neptune.EFModels.Entities
             await dbContext.ProjectNereidResults.Where(x => x.DelineationID == delineationID).ExecuteDeleteAsync();
             await dbContext.Delineations.Where(x => x.DelineationID == delineationID).ExecuteDeleteAsync();
         }
+
+        /// <summary>
+        /// Set-based equivalent of <see cref="DeleteFull"/> for many delineations at once. Issues a fixed number of
+        /// ExecuteDelete statements (one per child table) regardless of how many delineations are passed, instead of
+        /// the ~12 statements per delineation that calling DeleteFull in a loop produces. This matters for large
+        /// jurisdiction re-uploads (e.g. 1,000+ delineations, which would otherwise be ~13k sequential roundtrips).
+        /// IDs are chunked to stay under SQL Server's ~2,100 parameter cap on the generated IN (...) clauses.
+        /// </summary>
+        public static async Task DeleteFullForMany(NeptuneDbContext dbContext, List<int> delineationIDs)
+        {
+            if (delineationIDs == null || delineationIDs.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var chunk in delineationIDs.Chunk(2000))
+            {
+                var ids = chunk.ToList();
+                await dbContext.DelineationOverlaps.Where(x => ids.Contains(x.DelineationID)).ExecuteDeleteAsync();
+                await dbContext.DelineationOverlaps.Where(x => ids.Contains(x.OverlappingDelineationID)).ExecuteDeleteAsync();
+                await dbContext.DirtyModelNodes.Where(x => x.DelineationID != null && ids.Contains(x.DelineationID.Value)).ExecuteDeleteAsync();
+                await dbContext.HRUCharacteristics.Where(x => x.LoadGeneratingUnit.DelineationID != null && ids.Contains(x.LoadGeneratingUnit.DelineationID.Value)).ExecuteDeleteAsync();
+                await dbContext.LoadGeneratingUnits.Where(x => x.DelineationID != null && ids.Contains(x.DelineationID.Value)).ExecuteDeleteAsync();
+                await dbContext.NereidResults.Where(x => x.DelineationID != null && ids.Contains(x.DelineationID.Value)).ExecuteDeleteAsync();
+                await dbContext.ProjectHRUCharacteristics.Where(x => x.ProjectLoadGeneratingUnit.DelineationID != null && ids.Contains(x.ProjectLoadGeneratingUnit.DelineationID.Value)).ExecuteDeleteAsync();
+                await dbContext.ProjectLoadGeneratingUnits.Where(x => x.DelineationID != null && ids.Contains(x.DelineationID.Value)).ExecuteDeleteAsync();
+                await dbContext.TrashGeneratingUnit4326s.Where(x => x.DelineationID != null && ids.Contains(x.DelineationID.Value)).ExecuteDeleteAsync();
+                await dbContext.TrashGeneratingUnits.Where(x => x.DelineationID != null && ids.Contains(x.DelineationID.Value)).ExecuteDeleteAsync();
+                await dbContext.ProjectNereidResults.Where(x => x.DelineationID != null && ids.Contains(x.DelineationID.Value)).ExecuteDeleteAsync();
+                await dbContext.Delineations.Where(x => ids.Contains(x.DelineationID)).ExecuteDeleteAsync();
+            }
+        }
     }
 }

--- a/Neptune.EFModels/Entities/DelineationStagings.StaticHelpers.cs
+++ b/Neptune.EFModels/Entities/DelineationStagings.StaticHelpers.cs
@@ -151,18 +151,17 @@ public static class DelineationStagings
                         && stagedNames.Contains(x.TreatmentBMP.TreatmentBMPName))
             .Select(x => x.DelineationID)
             .ToList();
-        foreach (var delineationID in delineationsToDelete)
+        // ExecuteDelete bypasses the change tracker, so detach any tracked instances from earlier in this
+        // DbContext's lifetime first — otherwise they'd still occupy the 1:1 nav slot and collide with the new
+        // Delineations added below. Then delete the whole set with a fixed number of statements rather than
+        // ~12 per delineation (a 1,000+ delineation re-upload would otherwise be ~13k sequential roundtrips).
+        var idsToDelete = delineationsToDelete.ToHashSet();
+        foreach (var tracked in dbContext.ChangeTracker.Entries<Delineation>()
+                     .Where(e => idsToDelete.Contains(e.Entity.DelineationID)).ToList())
         {
-            // ExecuteDelete bypasses the change tracker, so any tracked instance from earlier in this DbContext's
-            // lifetime would still occupy the 1:1 nav slot and collide with the new Delineation we add below.
-            var tracked = dbContext.ChangeTracker.Entries<Delineation>()
-                .FirstOrDefault(e => e.Entity.DelineationID == delineationID);
-            if (tracked != null)
-            {
-                tracked.State = EntityState.Detached;
-            }
-            await Delineation.DeleteFull(dbContext, delineationID);
+            tracked.State = EntityState.Detached;
         }
+        await Delineation.DeleteFullForMany(dbContext, delineationsToDelete);
 
         var bmpsToUpdate = dbContext.TreatmentBMPs.AsNoTracking()
             .Where(x => x.StormwaterJurisdictionID == stormwaterJurisdictionID && stagedNames.Contains(x.TreatmentBMPName))

--- a/Neptune.EFModels/Entities/DelineationStagings.StaticHelpers.cs
+++ b/Neptune.EFModels/Entities/DelineationStagings.StaticHelpers.cs
@@ -52,10 +52,15 @@ public static class DelineationStagings
         dbContext.DelineationStagings.AddRange(validDelineationStagings);
         await dbContext.SaveChangesAsync();
 
-        var stagedNames = validDelineationStagings.Select(x => x.TreatmentBMPName).ToList();
+        // Match staged names with a server-side subquery (not an in-memory list) so very large uploads don't
+        // exceed SQL Server's ~2,100-parameter cap on an IN (@p0..@pN) clause. The staging rows were just
+        // persisted above, so this subquery is exactly this user's current upload.
+        var stagedNamesQuery = dbContext.DelineationStagings
+            .Where(s => s.UploadedByPersonID == currentPerson.PersonID)
+            .Select(s => s.TreatmentBMPName);
         var bmpsWithUpstreamSet = dbContext.TreatmentBMPs.AsNoTracking()
             .Where(x => x.StormwaterJurisdictionID == stagingJurisdictionID
-                        && stagedNames.Contains(x.TreatmentBMPName)
+                        && stagedNamesQuery.Contains(x.TreatmentBMPName)
                         && x.UpstreamBMPID != null)
             .Select(x => x.TreatmentBMPName)
             .ToList();
@@ -139,8 +144,15 @@ public static class DelineationStagings
             .ToList();
         Check.Assert(stagings.Count > 0, "No staged delineations were found for the current user.");
 
-        var stagedNames = stagings.Select(x => x.TreatmentBMPName).ToList();
         var stormwaterJurisdictionID = stagings.Select(x => x.StormwaterJurisdictionID).Distinct().Single();
+
+        // Match staged BMP names with a server-side subquery rather than an in-memory list: a list translates
+        // to IN (@p0..@pN) — one parameter per staged name — which exceeds SQL Server's ~2,100-parameter cap
+        // on very large uploads. The subquery matches in the DB (case-insensitive via collation) with no
+        // per-name parameters.
+        var stagedNamesQuery = dbContext.DelineationStagings
+            .Where(s => s.UploadedByPersonID == currentPerson.PersonID)
+            .Select(s => s.TreatmentBMPName);
 
         // Scope to the staging's jurisdiction AND distributed type so a same-named BMP in another jurisdiction
         // (or a centralized delineation in this one) doesn't get deleted by a Distributed-only upload.
@@ -148,7 +160,7 @@ public static class DelineationStagings
             .Include(x => x.TreatmentBMP)
             .Where(x => x.TreatmentBMP.StormwaterJurisdictionID == stormwaterJurisdictionID
                         && x.DelineationTypeID == (int)DelineationTypeEnum.Distributed
-                        && stagedNames.Contains(x.TreatmentBMP.TreatmentBMPName))
+                        && stagedNamesQuery.Contains(x.TreatmentBMP.TreatmentBMPName))
             .Select(x => x.DelineationID)
             .ToList();
         // ExecuteDelete bypasses the change tracker, so detach any tracked instances from earlier in this
@@ -164,7 +176,7 @@ public static class DelineationStagings
         await Delineation.DeleteFullForMany(dbContext, delineationsToDelete);
 
         var bmpsToUpdate = dbContext.TreatmentBMPs.AsNoTracking()
-            .Where(x => x.StormwaterJurisdictionID == stormwaterJurisdictionID && stagedNames.Contains(x.TreatmentBMPName))
+            .Where(x => x.StormwaterJurisdictionID == stormwaterJurisdictionID && stagedNamesQuery.Contains(x.TreatmentBMPName))
             .Select(x => new { x.TreatmentBMPID, x.TreatmentBMPName })
             .ToList();
 

--- a/Neptune.GDALAPI/Controllers/OgrInfoController.cs
+++ b/Neptune.GDALAPI/Controllers/OgrInfoController.cs
@@ -45,7 +45,10 @@ public class OgrInfoController : ControllerBase
             {
                 var featureClassInfo = new FeatureClassInfo();
                 var features = featureClassBlob.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
-                featureClassInfo.LayerName = features.First().ToLower();
+                // Preserve the original casing of the feature-class name. It is used verbatim in the ogr2ogr
+                // "SELECT ... FROM <layer>" statement, and OGR's SQL is case-sensitive on Linux/Docker, so a
+                // lowercased name (e.g. "dma" for a "DMA" layer) is not found and the conversion fails.
+                featureClassInfo.LayerName = features.First();
                 featureClassInfo.FeatureType = features.First(x => x.StartsWith("Geometry: ")).Substring("Geometry: ".Length);
                 featureClassInfo.FeatureCount = int.Parse(features.First(x => x.StartsWith("Feature Count: ")).Substring("Feature Count: ".Length));
 

--- a/Neptune.Tests/DelineationGdbHelpersTests.cs
+++ b/Neptune.Tests/DelineationGdbHelpersTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -103,6 +104,33 @@ namespace Neptune.Tests
                 { "DelineationStatus", delineationStatus },
             };
             var fc = new FeatureCollection { new Feature(geom, attrs) };
+            return GeoJsonSerializer.SerializeToByteArray(fc, GeoJsonSerializer.DefaultSerializerOptions);
+        }
+
+        private byte[] SampleStagingGeoJsonForNames(IReadOnlyList<string> treatmentBMPNames)
+        {
+            var fc = new FeatureCollection();
+            for (var i = 0; i < treatmentBMPNames.Count; i++)
+            {
+                var x0 = -117.85 + i * 0.02;
+                var poly4326 = new Polygon(new LinearRing(new[]
+                {
+                    new Coordinate(x0, 33.65),
+                    new Coordinate(x0 + 0.01, 33.65),
+                    new Coordinate(x0 + 0.01, 33.66),
+                    new Coordinate(x0, 33.66),
+                    new Coordinate(x0, 33.65),
+                })) { SRID = 4326 };
+                var geom = (Geometry)poly4326.ProjectTo2771();
+                var attrs = new AttributesTable
+                {
+                    { "UploadedByPersonID", _jurisdictionPerson.PersonID },
+                    { "StormwaterJurisdictionID", _jurisdictionID },
+                    { "TreatmentBMPName", treatmentBMPNames[i] },
+                    { "DelineationStatus", (string?)null },
+                };
+                fc.Add(new Feature(geom, attrs));
+            }
             return GeoJsonSerializer.SerializeToByteArray(fc, GeoJsonSerializer.DefaultSerializerOptions);
         }
 
@@ -295,6 +323,76 @@ namespace Neptune.Tests
 
             Assert.AreEqual(0, errors.Count, "Centralized check should be jurisdiction-scoped; same name in another jurisdiction must not block.");
             Assert.IsTrue(_dbContext.DelineationStagings.Any(x => x.UploadedByPersonID == _jurisdictionPerson.PersonID && x.TreatmentBMPName == sharedName));
+        }
+
+        [TestMethod]
+        public async Task ApproveAsync_HandlesBMPNameCaseMismatchGracefully()
+        {
+            // NPT-1093: the GDB casing can differ from the inventory casing (Brea had "NoName2" in the GDB but
+            // "noName2" in the system). Staging must treat it as a match, and approve must succeed (previously the
+            // case-sensitive in-memory .Single() threw and surfaced as a 500).
+            var suffix = Guid.NewGuid().ToString("N");
+            var dbName = $"noName2-{suffix}";  // inventory casing
+            var gdbName = $"NoName2-{suffix}"; // GDB casing — differs only by the leading N
+
+            var bmp = CreateBMP(dbName);
+            await DelineationStagings.ProcessDeserializedStagingAsync(_dbContext, SampleStagingGeoJson(gdbName), _jurisdictionPerson);
+
+            var report = DelineationStagings.BuildReportForCurrentUser(_dbContext, _jurisdictionPerson);
+            Assert.IsFalse(report.Errors.Any(e => e.Contains("do not match a Treatment BMP Name")),
+                "A case-only mismatch should be reported as a match, not unmatched.");
+            Assert.AreEqual(1, report.NumberOfDelineationsToBeCreated);
+
+            var count = await DelineationStagings.ApproveAsync(_dbContext, _jurisdictionPerson);
+
+            Assert.AreEqual(1, count);
+            var newDel = _dbContext.Delineations.Single(x => x.TreatmentBMPID == bmp.TreatmentBMPID);
+            Assert.AreEqual((int)DelineationTypeEnum.Distributed, newDel.DelineationTypeID);
+            Assert.IsFalse(_dbContext.DelineationStagings.Any(x => x.UploadedByPersonID == _jurisdictionPerson.PersonID),
+                "Staging should be cleared after a successful approve.");
+        }
+
+        [TestMethod]
+        public async Task ApproveAsync_ReplacesMultipleExistingDistributedDelineations()
+        {
+            // NPT-1093 Bug 3: the bulk DeleteFullForMany path must delete every matching existing distributed
+            // delineation and create the new ones in a single approve.
+            var names = Enumerable.Range(0, 3).Select(i => $"NPT-1093-BULK-{i}-{Guid.NewGuid():N}").ToList();
+            var preexistingIDs = new List<int>();
+            foreach (var name in names)
+            {
+                var bmp = CreateBMP(name);
+                var poly4326 = new Polygon(new LinearRing(new[]
+                {
+                    new Coordinate(-117.86, 33.66), new Coordinate(-117.85, 33.66),
+                    new Coordinate(-117.85, 33.67), new Coordinate(-117.86, 33.67), new Coordinate(-117.86, 33.66),
+                })) { SRID = 4326 };
+                _dbContext.Delineations.Add(new Delineation
+                {
+                    TreatmentBMPID = bmp.TreatmentBMPID,
+                    DelineationTypeID = (int)DelineationTypeEnum.Distributed,
+                    DelineationGeometry4326 = poly4326,
+                    DelineationGeometry = poly4326.ProjectTo2771(),
+                    DateLastModified = DateTime.UtcNow,
+                    IsVerified = false,
+                    HasDiscrepancies = false,
+                });
+                _dbContext.SaveChanges();
+                preexistingIDs.Add(_dbContext.Delineations.Single(x => x.TreatmentBMPID == bmp.TreatmentBMPID).DelineationID);
+            }
+
+            await DelineationStagings.ProcessDeserializedStagingAsync(_dbContext, SampleStagingGeoJsonForNames(names), _jurisdictionPerson);
+            var count = await DelineationStagings.ApproveAsync(_dbContext, _jurisdictionPerson);
+
+            Assert.AreEqual(names.Count, count);
+            Assert.IsFalse(_dbContext.Delineations.Any(x => preexistingIDs.Contains(x.DelineationID)),
+                "All pre-existing distributed delineations should be deleted by the bulk path.");
+            foreach (var name in names)
+            {
+                var bmpID = _dbContext.TreatmentBMPs.Single(x => x.TreatmentBMPName == name && x.StormwaterJurisdictionID == _jurisdictionID).TreatmentBMPID;
+                Assert.AreEqual(1, _dbContext.Delineations.Count(x => x.TreatmentBMPID == bmpID), $"Expected exactly one new delineation for {name}.");
+            }
+            Assert.IsFalse(_dbContext.DelineationStagings.Any(x => x.UploadedByPersonID == _jurisdictionPerson.PersonID));
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes from Kathleen's root-cause analysis of City of Brea's 1,112-delineation upload.

## Bug 1 — GDB feature-class name lowercased → ogr2ogr can't find the layer
`OgrInfoController.cs:48` lowercased the detected layer name; it's used verbatim in the ogr2ogr `SELECT … FROM <layer>`, and OGR SQL is **case-sensitive on the Linux/Docker GDAL**, so a mixed-case GDB layer (`DMA`) became `dma` and wasn't found → upload failure. **Fix:** preserve original casing. This also fixes the land-use-block and OVTA GDB uploads, which share the same layer-name path. (Column lowercasing on line 57 is left as-is — the delineation upload's SELECT columns come from user-typed field names, not the ogrinfo columns.)

## Bug 3 — per-row `DeleteFull` loop on approve (perf)
`ApproveAsync` deleted existing distributed delineations by calling `Delineation.DeleteFull` once per delineation, and each `DeleteFull` issues 12 `ExecuteDelete` statements → replacing Brea's 1,112 was ~13k sequential roundtrips (slow/timeout). **Fix:** new `Delineation.DeleteFullForMany` does one set-based `ExecuteDelete` per child table over all IDs (chunked under SQL Server's ~2,100-parameter cap); `ApproveAsync` calls it once. `DeleteFull` kept for single-id callers.

## Bug 2 — case-sensitive BMP-name match on approve → ALREADY FIXED
The `NoName2`/`noName2` crash was the case-sensitive in-memory `.Single()`, already fixed on `develop` by commit `3e03bf1d` (NPT-1068) — `ApproveAsync` now matches with `InvariantCultureIgnoreCase` + `Trim()`. **No code change here**; this PR adds a regression test.

## The production 403 — investigation, no code change
The 403 is **not reproducible from the auth code**: `JurisdictionEditFeature` checks role only (no jurisdiction match) and is the *same attribute* on Upload and Approve, so a role 403 can't explain "staging succeeded, approve 403'd" for one user. Most likely **Auth0 token expiry during the slow 1,112-row staging**, or an ingress/WAF 403. Recommend confirming from prod logs + Taylor's role/token lifetime; if it's expiry, harden the SPA token refresh around long operations. Tracked as investigation — no speculative auth change made.

## Tests (`Neptune.Tests/DelineationGdbHelpersTests.cs`)
- `ApproveAsync_HandlesBMPNameCaseMismatchGracefully` — GDB `NoName2` vs DB `noName2`: staging reports a match, approve succeeds (Bug 2 regression guard).
- `ApproveAsync_ReplacesMultipleExistingDistributedDelineations` — exercises the new bulk `DeleteFullForMany` path.
- Full `DelineationGdbHelpersTests` suite (10 tests) passes against the local DB.

## Verification (QA, post-deploy)
1. **Rebuild the GDAL API container** (Bug 1 is in `Neptune.GDALAPI`).
2. Re-run Brea's `testQA_gdb.zip` with the original mixed-case layer name (`DMA`) — should stage without renaming the layer.
3. Approve the 1,112 batch — should complete promptly (Bug 3) and not crash on `NoName2/noName2` (Bug 2).
4. Re-upload to exercise the replace path; confirm timing.
5. Record the 403 investigation outcome on the ticket.