### PR TITLE
NPT-1062: Mark BMP dirty when Modeling attributes are saved (awaiting + hourly recalc)

### DIFF
--- a/Neptune.EFModels/Entities/CustomAttributes.cs
+++ b/Neptune.EFModels/Entities/CustomAttributes.cs
@@ -124,6 +124,17 @@ public static class CustomAttributes
         await dbContext.SaveChangesAsync();
 
         var purposeEnum = (CustomAttributeTypePurposeEnum) customAttributeTypePurposeID;
+
+        // NPT-1062: Modeling-purpose custom attributes feed the Nereid model, so editing them must mark the BMP
+        // dirty (mirrors the delineation-verify path in DelineationController). Without this no DirtyModelNode is
+        // created, so the detail page never shows "awaiting calculation" and the hourly delta solve has nothing to
+        // recalculate — results sit at zero until the nightly total solve. Scoped to Modeling so non-modeling
+        // custom-attribute edits don't trigger needless recalcs.
+        if (purposeEnum == CustomAttributeTypePurposeEnum.Modeling)
+        {
+            await Nereid.NereidUtilities.MarkTreatmentBMPDirty(treatmentBMP, dbContext);
+        }
+
         var updatedCustomAttributes = ListByTreatmentBMPIDAndPurposes(dbContext, treatmentBMPID, purposeEnum);
         var updatedCustomAttributeDtos = updatedCustomAttributes.Select(x => x.AsDto()).ToList();
         return updatedCustomAttributeDtos;

--- a/Neptune.EFModels/Entities/CustomAttributes.cs
+++ b/Neptune.EFModels/Entities/CustomAttributes.cs
@@ -121,19 +121,24 @@ public static class CustomAttributes
             }
         }
 
-        await dbContext.SaveChangesAsync();
-
         var purposeEnum = (CustomAttributeTypePurposeEnum) customAttributeTypePurposeID;
 
         // NPT-1062: Modeling-purpose custom attributes feed the Nereid model, so editing them must mark the BMP
-        // dirty (mirrors the delineation-verify path in DelineationController). Without this no DirtyModelNode is
-        // created, so the detail page never shows "awaiting calculation" and the hourly delta solve has nothing to
-        // recalculate — results sit at zero until the nightly total solve. Scoped to Modeling so non-modeling
+        // dirty (mirrors the delineation-verify path in DelineationController) — otherwise no DirtyModelNode is
+        // created, the detail page never shows "awaiting calculation", and the hourly delta solve has nothing to
+        // recalculate (results sit at zero until the nightly total solve). Add it to the same unit of work as the
+        // attribute changes so it commits atomically in one SaveChanges. Scoped to Modeling so non-modeling
         // custom-attribute edits don't trigger needless recalcs.
         if (purposeEnum == CustomAttributeTypePurposeEnum.Modeling)
         {
-            await Nereid.NereidUtilities.MarkTreatmentBMPDirty(treatmentBMP, dbContext);
+            await dbContext.DirtyModelNodes.AddAsync(new DirtyModelNode
+            {
+                CreateDate = DateTime.UtcNow,
+                TreatmentBMPID = treatmentBMPID
+            });
         }
+
+        await dbContext.SaveChangesAsync();
 
         var updatedCustomAttributes = ListByTreatmentBMPIDAndPurposes(dbContext, treatmentBMPID, purposeEnum);
         var updatedCustomAttributeDtos = updatedCustomAttributes.Select(x => x.AsDto()).ToList();

--- a/Neptune.Tests/CustomAttributesMarkDirtyTests.cs
+++ b/Neptune.Tests/CustomAttributesMarkDirtyTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.Common.GeoSpatial;
+using Neptune.EFModels.Entities;
+using Neptune.Models.DataTransferObjects;
+using NetTopologySuite.Geometries;
+
+namespace Neptune.Tests
+{
+    [TestClass]
+    public class CustomAttributesMarkDirtyTests
+    {
+        private NeptuneDbContext _dbContext = null!;
+        private IDbContextTransaction _transaction = null!;
+        private int _jurisdictionID;
+        private int _treatmentBMPTypeID;
+        private PersonDto _callingUser = null!;
+
+        private static NeptuneDbContext GetDbContext()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<NeptuneDbContext>();
+            optionsBuilder.UseSqlServer(
+                "Data Source=localhost;Initial Catalog=NeptuneDB;Persist Security Info=True;Integrated Security=true;Encrypt=False;",
+                x =>
+                {
+                    x.CommandTimeout((int)TimeSpan.FromMinutes(3).TotalSeconds);
+                    x.UseNetTopologySuite();
+                });
+            return new NeptuneDbContext(optionsBuilder.Options);
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _dbContext = GetDbContext();
+            _transaction = _dbContext.Database.BeginTransaction();
+
+            _jurisdictionID = _dbContext.StormwaterJurisdictions.AsNoTracking()
+                .OrderBy(x => x.StormwaterJurisdictionID).Select(x => x.StormwaterJurisdictionID).First();
+
+            _treatmentBMPTypeID = _dbContext.TreatmentBMPTypes.AsNoTracking()
+                .OrderBy(x => x.TreatmentBMPTypeID).Select(x => x.TreatmentBMPTypeID).First();
+
+            var personID = _dbContext.People.AsNoTracking().OrderBy(x => x.PersonID).Select(x => x.PersonID).First();
+            _callingUser = new PersonDto { PersonID = personID };
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _transaction.Rollback();
+            _transaction.Dispose();
+            _dbContext.Dispose();
+        }
+
+        private TreatmentBMP CreateBMP(string name)
+        {
+            var loc4326 = new Point(-117.85 + new Random().NextDouble() * 0.01, 33.65 + new Random().NextDouble() * 0.01) { SRID = 4326 };
+            var bmp = new TreatmentBMP
+            {
+                TreatmentBMPName = name,
+                TreatmentBMPTypeID = _treatmentBMPTypeID,
+                StormwaterJurisdictionID = _jurisdictionID,
+                OwnerOrganizationID = _dbContext.StormwaterJurisdictions.AsNoTracking().Single(x => x.StormwaterJurisdictionID == _jurisdictionID).OrganizationID,
+                LocationPoint4326 = loc4326,
+                LocationPoint = loc4326.ProjectTo2771(),
+                InventoryIsVerified = false,
+                TreatmentBMPLifespanTypeID = (int)TreatmentBMPLifespanTypeEnum.Unspecified,
+                SizingBasisTypeID = (int)SizingBasisTypeEnum.NotProvided,
+                TrashCaptureStatusTypeID = (int)TrashCaptureStatusTypeEnum.None,
+            };
+            _dbContext.TreatmentBMPs.Add(bmp);
+            _dbContext.SaveChanges();
+            return bmp;
+        }
+
+        [TestMethod]
+        public async Task UpdateModelingCustomAttributes_MarksBMPDirty()
+        {
+            // NPT-1062: editing a BMP's Modeling attributes must create a DirtyModelNode so the detail page shows
+            // "awaiting calculation" and the hourly delta solve recalculates it (previously it never marked dirty).
+            var bmp = CreateBMP($"NPT-1062-{Guid.NewGuid():N}");
+            Assert.IsFalse(_dbContext.DirtyModelNodes.Any(x => x.TreatmentBMPID == bmp.TreatmentBMPID),
+                "Precondition: no dirty node before the modeling-attribute save.");
+
+            await CustomAttributes.UpdateCustomAttributesAsync(_dbContext, bmp.TreatmentBMPID,
+                (int)CustomAttributeTypePurposeEnum.Modeling, new List<CustomAttributeUpsertDto>(), _callingUser);
+
+            Assert.IsTrue(_dbContext.DirtyModelNodes.Any(x => x.TreatmentBMPID == bmp.TreatmentBMPID),
+                "Saving Modeling custom attributes should mark the BMP dirty.");
+        }
+
+        [TestMethod]
+        public async Task UpdateNonModelingCustomAttributes_DoesNotMarkBMPDirty()
+        {
+            // Scoping guard: non-modeling custom-attribute purposes must NOT mark the BMP dirty.
+            var nonModelingPurposeID = CustomAttributeTypePurpose.All
+                .Select(x => x.CustomAttributeTypePurposeID)
+                .FirstOrDefault(id => id != (int)CustomAttributeTypePurposeEnum.Modeling);
+            if (nonModelingPurposeID == 0)
+            {
+                Assert.Inconclusive("No non-Modeling CustomAttributeTypePurpose exists to test the negative case.");
+                return;
+            }
+
+            var bmp = CreateBMP($"NPT-1062-NM-{Guid.NewGuid():N}");
+
+            await CustomAttributes.UpdateCustomAttributesAsync(_dbContext, bmp.TreatmentBMPID,
+                nonModelingPurposeID, new List<CustomAttributeUpsertDto>(), _callingUser);
+
+            Assert.IsFalse(_dbContext.DirtyModelNodes.Any(x => x.TreatmentBMPID == bmp.TreatmentBMPID),
+                "Non-Modeling custom-attribute edits should not mark the BMP dirty.");
+        }
+    }
+}

--- a/Neptune.Tests/CustomAttributesMarkDirtyTests.cs
+++ b/Neptune.Tests/CustomAttributesMarkDirtyTests.cs
@@ -99,19 +99,10 @@ namespace Neptune.Tests
         public async Task UpdateNonModelingCustomAttributes_DoesNotMarkBMPDirty()
         {
             // Scoping guard: non-modeling custom-attribute purposes must NOT mark the BMP dirty.
-            var nonModelingPurposeID = CustomAttributeTypePurpose.All
-                .Select(x => x.CustomAttributeTypePurposeID)
-                .FirstOrDefault(id => id != (int)CustomAttributeTypePurposeEnum.Modeling);
-            if (nonModelingPurposeID == 0)
-            {
-                Assert.Inconclusive("No non-Modeling CustomAttributeTypePurpose exists to test the negative case.");
-                return;
-            }
-
             var bmp = CreateBMP($"NPT-1062-NM-{Guid.NewGuid():N}");
 
             await CustomAttributes.UpdateCustomAttributesAsync(_dbContext, bmp.TreatmentBMPID,
-                nonModelingPurposeID, new List<CustomAttributeUpsertDto>(), _callingUser);
+                (int)CustomAttributeTypePurposeEnum.OtherDesignAttributes, new List<CustomAttributeUpsertDto>(), _callingUser);
 
             Assert.IsFalse(_dbContext.DirtyModelNodes.Any(x => x.TreatmentBMPID == bmp.TreatmentBMPID),
                 "Non-Modeling custom-attribute edits should not mark the BMP dirty.");


### PR DESCRIPTION
Round-2 rework for NPT-1062.

## Root cause
Editing a BMP's **Modeling** custom attributes (the "fill in modeling parameters" action → `UpdateCustomAttributes` → `CustomAttributes.UpdateCustomAttributesAsync`) **never created a `DirtyModelNode`** — unlike the delineation-verify path (`DelineationController` calls `MarkTreatmentBMPDirty`) and CSV upload. With no dirty node:
- `IsAwaitingModelingCalculation` is always false → the **"This BMP is awaiting calculation" message never shows**.
- The hourly `DeltaSolveJob` has nothing to recalculate → **results stay zero until the nightly Total Network Solve** (which clears + recomputes the whole network regardless of dirty state — why the nightly "works").

Confirmed on QA by the PO: the hourly Delta Solve job returns in ~15ms via its empty-set guard (no dirty nodes present).

## Fix
`CustomAttributes.UpdateCustomAttributesAsync` now calls `NereidUtilities.MarkTreatmentBMPDirty` when the purpose is **Modeling** (mirrors the delineation-verify pattern), scoped so non-modeling custom-attribute edits don't trigger needless recalcs. Placed in the repo method (not the controller) so it's centralized and unit-testable.

## Tests (`Neptune.Tests/CustomAttributesMarkDirtyTests.cs`)
- `UpdateModelingCustomAttributes_MarksBMPDirty` — saving Modeling attributes creates a `DirtyModelNode`.
- `UpdateNonModelingCustomAttributes_DoesNotMarkBMPDirty` — scoping guard.
Both pass against the local DB.

## Verification (QA)
Edit a BMP's Modeling attributes (e.g. `/treatment-bmps/4276` → `…/edit-custom-attributes/Modeling`) → the detail page immediately shows "awaiting calculation"; the next hourly `DeltaSolveJob` runs >15ms, processes the node, and the card shows non-zero results. Existing already-zero records resolve on the next nightly run.

## Not included
- **Planning panel (projects 290/288)** — separate subsystem (`ProjectNereidResult`, populated only by a project network solve, not the hourly delta). Pending a QA diagnostic (does a succeeded `ProjectNetworkSolveHistory` / any `ProjectNereidResult` rows exist?) before fixing; likely a follow-up.