### PR TITLE
NPT-1094: Hide admin/edit create actions from anonymous (Funding Sources + BMP)

### DIFF
--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -28,7 +28,7 @@ public class TreatmentBMPController(
     : SitkaController<TreatmentBMPController>(dbContext, logger, neptuneConfiguration)
 {
     [HttpPost]
-    [UserViewFeature]
+    [JurisdictionEditFeature]
     public async Task<ActionResult<TreatmentBMPDto>> Create([FromBody] TreatmentBMPCreateDto treatmentBMPCreateDto)
     {
         var errors = await TreatmentBMPs.ValidateCreateAsync(DbContext, treatmentBMPCreateDto);

--- a/Neptune.Web/src/app/app.routes.ts
+++ b/Neptune.Web/src/app/app.routes.ts
@@ -431,7 +431,8 @@ export const routes: Routes = [
                 title: "Create New BMP",
                 // Create is editor-gated (POST /treatment-bmps is [JurisdictionEditFeature]); guard the route so
                 // anonymous/non-editors can't reach the create page by URL, not just via the hidden button (NPT-1094).
-                canActivate: [JurisdictionManagerOrEditorOnlyGuard],
+                // authGuardFn first so the role guard never evaluates for anonymous users (matches other edit routes).
+                canActivate: [authGuardFn, JurisdictionManagerOrEditorOnlyGuard],
                 loadComponent: () => import("./pages/treatment-bmps/create-treatment-bmp/create-treatment-bmp.component").then((m) => m.CreateTreatmentBmpComponent),
                 canDeactivate: [UnsavedChangesGuard],
             },

--- a/Neptune.Web/src/app/app.routes.ts
+++ b/Neptune.Web/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { ManagerOrAdminOnlyGuard } from "./shared/guards/unauthenticated-access/
 import { JurisdictionManagerOrEditorOnlyGuard } from "./shared/guards/unauthenticated-access/jurisdiction-manager-or-editor-only-guard.guard";
 import { UnsavedChangesGuard } from "./shared/guards/unsaved-changes.guard";
 import { OCTAGrantReviewerOnlyGuard } from "./shared/guards/unauthenticated-access/octa-grant-reviewer-only.guard";
+import { AdminOnlyGuard } from "./shared/guards/unauthenticated-access/admin-only-guard";
 import { authGuardFn } from "@auth0/auth0-angular";
 import { AuthCallbackComponent } from "./auth-callback.component";
 
@@ -428,6 +429,9 @@ export const routes: Routes = [
             {
                 path: "treatment-bmps/new",
                 title: "Create New BMP",
+                // Create is editor-gated (POST /treatment-bmps is [JurisdictionEditFeature]); guard the route so
+                // anonymous/non-editors can't reach the create page by URL, not just via the hidden button (NPT-1094).
+                canActivate: [JurisdictionManagerOrEditorOnlyGuard],
                 loadComponent: () => import("./pages/treatment-bmps/create-treatment-bmp/create-treatment-bmp.component").then((m) => m.CreateTreatmentBmpComponent),
                 canDeactivate: [UnsavedChangesGuard],
             },
@@ -818,6 +822,9 @@ export const routes: Routes = [
             {
                 path: "funding-sources",
                 title: "Funding Sources",
+                // Admin-only: the list/create endpoints are [AdminFeature]. Without this guard an anonymous user
+                // reached the page, the list call 403'd, and the error interceptor bounced them (NPT-1094).
+                canActivate: [authGuardFn, AdminOnlyGuard],
                 loadComponent: () => import("./pages/funding-sources/funding-sources.component").then((m) => m.FundingSourcesComponent),
             },
             {

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.html
@@ -1,6 +1,6 @@
 <page-header pageTitle="All Treatment BMPs" [customRichTextTypeID]="customRichTextTypeID" [templateRight]="headerActions"></page-header>
 <ng-template #headerActions>
-    @if (currentPersonCanEdit) {
+    @if (currentPersonCanEdit$ | async) {
         <button class="btn btn-orange" [routerLink]="['/treatment-bmps/new']" type="button">+ Create New Treatment BMP</button>
     }
 </ng-template>

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.html
@@ -1,6 +1,8 @@
 <page-header pageTitle="All Treatment BMPs" [customRichTextTypeID]="customRichTextTypeID" [templateRight]="headerActions"></page-header>
 <ng-template #headerActions>
-    <button class="btn btn-orange" [routerLink]="['/treatment-bmps/new']" type="button">+ Create New Treatment BMP</button>
+    @if (currentPersonCanEdit) {
+        <button class="btn btn-orange" [routerLink]="['/treatment-bmps/new']" type="button">+ Create New Treatment BMP</button>
+    }
 </ng-template>
 
 <app-alert-display></app-alert-display>

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
@@ -76,6 +76,8 @@ export class TreatmentBmpsComponent {
     public selectionFromMap: boolean;
     public boundingBox$: Observable<BoundingBoxDto>;
     public customRichTextTypeID = NeptunePageTypeEnum.TreatmentBMP;
+    // Gates the "+ Create New Treatment BMP" button — hidden from anonymous/unassigned (NPT-1094).
+    public currentPersonCanEdit = false;
 
     public OverlayMode = OverlayMode;
 
@@ -100,6 +102,7 @@ export class TreatmentBmpsComponent {
 
     ngOnInit(): void {
         const canEdit = this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission();
+        this.currentPersonCanEdit = canEdit;
         const isAnonymousOrUnassigned = this.authenticationService.isCurrentUserAnonymousOrUnassigned();
         const columnDefs: ColDef[] = [
             this.utilityFunctionsService.createActionsColumnDef((params: any) => {

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
@@ -76,8 +76,10 @@ export class TreatmentBmpsComponent {
     public selectionFromMap: boolean;
     public boundingBox$: Observable<BoundingBoxDto>;
     public customRichTextTypeID = NeptunePageTypeEnum.TreatmentBMP;
-    // Gates the "+ Create New Treatment BMP" button — hidden from anonymous/unassigned (NPT-1094).
-    public currentPersonCanEdit = false;
+    // Gates the "+ Create New Treatment BMP" button — hidden from anonymous/unassigned (NPT-1094). Driven off
+    // getCurrentUser() + async pipe so it reflects the resolved user even if Auth0 / people/me finishes after
+    // first render (zoneless: a once-computed boolean could leave the button hidden for an editor until reload).
+    public currentPersonCanEdit$: Observable<boolean>;
 
     public OverlayMode = OverlayMode;
 
@@ -101,8 +103,13 @@ export class TreatmentBmpsComponent {
     ) {}
 
     ngOnInit(): void {
+        this.currentPersonCanEdit$ = this.authenticationService
+            .getCurrentUser()
+            .pipe(
+                map(() => this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission()),
+                shareReplay(1)
+            );
         const canEdit = this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission();
-        this.currentPersonCanEdit = canEdit;
         const isAnonymousOrUnassigned = this.authenticationService.isCurrentUserAnonymousOrUnassigned();
         const columnDefs: ColDef[] = [
             this.utilityFunctionsService.createActionsColumnDef((params: any) => {

--- a/Neptune.Web/src/app/shared/guards/unauthenticated-access/admin-only-guard.ts
+++ b/Neptune.Web/src/app/shared/guards/unauthenticated-access/admin-only-guard.ts
@@ -26,7 +26,9 @@ export class AdminOnlyGuard {
 
         return this.authenticationService.currentUserSetObservable.pipe(
             map((x) => {
-                if (x.RoleID == RoleEnum.Admin || x.RoleID == RoleEnum.SitkaAdmin) {
+                // currentUserSetObservable can emit null (anonymous / auth0.user$ falsy) — treat that as unauthorized
+                // rather than dereferencing RoleID and throwing during route evaluation.
+                if (x?.RoleID == RoleEnum.Admin || x?.RoleID == RoleEnum.SitkaAdmin) {
                     return true;
                 } else {
                     return this.returnUnauthorized();

--- a/Neptune.Web/src/app/shared/guards/unauthenticated-access/admin-only-guard.ts
+++ b/Neptune.Web/src/app/shared/guards/unauthenticated-access/admin-only-guard.ts
@@ -1,0 +1,44 @@
+import { ActivatedRouteSnapshot, RouterStateSnapshot, Router } from "@angular/router";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { Injectable } from "@angular/core";
+import { AlertService } from "../../services/alert.service";
+import { AuthenticationService } from "src/app/services/authentication.service";
+import { RoleEnum } from "src/app/shared/generated/enum/role-enum";
+
+// Admin/SitkaAdmin-only route guard — matches the backend [AdminFeature] attribute. Use for routes whose API
+// is admin-gated (e.g. Funding Sources, whose list endpoint is [AdminFeature]) so anonymous/non-admin users are
+// blocked at the route instead of loading the page and hitting a 403.
+@Injectable({
+    providedIn: "root",
+})
+export class AdminOnlyGuard {
+    constructor(private router: Router, private alertService: AlertService, private authenticationService: AuthenticationService) {}
+
+    canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
+        if (!this.authenticationService.isCurrentUserNullOrUndefined()) {
+            if (this.authenticationService.isCurrentUserAnAdministrator()) {
+                return true;
+            } else {
+                return this.returnUnauthorized();
+            }
+        }
+
+        return this.authenticationService.currentUserSetObservable.pipe(
+            map((x) => {
+                if (x.RoleID == RoleEnum.Admin || x.RoleID == RoleEnum.SitkaAdmin) {
+                    return true;
+                } else {
+                    return this.returnUnauthorized();
+                }
+            })
+        );
+    }
+
+    private returnUnauthorized() {
+        this.router.navigate(["/"]).then(() => {
+            this.alertService.pushNotFoundUnauthorizedAlert();
+        });
+        return false;
+    }
+}


### PR DESCRIPTION
Round-2 rework for NPT-1094 (the original nit list all passed; these are the two new 6/24 findings).

## Item 1 — Funding Sources list broke for anonymous + admin-only Add button
`GET /funding-sources` is `[AdminFeature]`, but the `/funding-sources` route had **no guard** — so an anonymous user reached the page, the list call 403'd, and `httpErrorInterceptor` bounced them after a failed render (the reported "console error / won't load"), with the "Add New Funding Source" button visible to boot.

**Fix:** new `AdminOnlyGuard` (Admin/SitkaAdmin, matching `[AdminFeature]`) on the `/funding-sources` route. The page is now unreachable for non-admins — which removes the console error **and** hides the admin-only button (only admins ever see the page). No component/template change needed.

## Item 2 — Hide "Create New Treatment BMP" from anonymous + tighten the API
The BMP list stays public (Find-a-BMP); only the create action is gated:
- **Button:** gated on `currentPersonCanEdit` (jurisdiction-edit permission) in `treatment-bmps.component`.
- **Route:** `/treatment-bmps/new` guarded with `JurisdictionManagerOrEditorOnlyGuard` so it can't be reached by URL either.
- **API:** `POST /treatment-bmps` `[UserViewFeature]` → `[JurisdictionEditFeature]`. The view feature allowed the Unassigned/anonymous sentinel to create a BMP; the create page is only reached from the editor-gated Add button, so editor-gating the endpoint is consistent and closes the gap.

## Verification (QA)
1. **Anonymous → `/funding-sources`:** blocked by the guard, no console error. Admin/SitkaAdmin: page loads, Add button works. Non-admin authenticated: blocked (matches the admin-gated GET).
2. **Anonymous → Treatment BMP list:** page still loads (public), but "+ Create New Treatment BMP" is hidden; editor/admin still sees it. `/treatment-bmps/new` by URL redirects non-editors; `POST /treatment-bmps` as anonymous/Unassigned now 403s.
3. `npm run build-dev` clean; `Neptune.API` builds clean.

No DTO/codegen changes. (A `swagger.json` regeneration artifact was left out — the auth-attribute change doesn't alter the contract.)