### PR TITLE
NPT-1068: Fix legacy FileResource URLs in NeptunePage rich text

### DIFF
--- a/Neptune.Database/Neptune.Database.sqlproj
+++ b/Neptune.Database/Neptune.Database.sqlproj
@@ -440,6 +440,7 @@
     <None Include="Scripts\ReleaseScripts\019 - Add Dry Weather Flow Override custom attribute for all Modeled Treatment BMPs without it.sql" />
     <None Include="Scripts\ReleaseScripts\020 - Drop WaterQualityManagementPlanDocumentVectorStore table.sql" />
     <None Include="Scripts\ReleaseScripts\036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql" />
+    <None Include="Scripts\ReleaseScripts\037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content.sql" />
     <Build Include="dbo\Tables\dbo.WaterQualityManagementPlanExtractionResult.sql" />
     <Build Include="dbo\Tables\dbo.AITokenUsage.sql" />
   </ItemGroup>

--- a/Neptune.Database/Scripts/ReleaseScripts/037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content.sql
@@ -1,0 +1,31 @@
+DECLARE @MigrationName VARCHAR(200);
+SET @MigrationName = '037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content'
+
+IF NOT EXISTS(SELECT * FROM dbo.DatabaseMigration DM WHERE DM.ReleaseScriptFileName = @MigrationName)
+BEGIN
+
+    PRINT @MigrationName;
+
+    /*
+        NeptunePage rich text (<img src> / <a href>) contains absolute links to the retired WebMvc
+        FileResource route, e.g. https://www.ocstormwatertools.org/FileResource/DisplayResource/{guid}.
+        The MVC app and that route are gone; the live endpoint is /file-resources/{guid} on the API.
+
+        Strip the scheme + host so the stored value becomes the RELATIVE /file-resources/{guid}. The SPA's
+        custom-rich-text component rewrites that relative path to the absolute API URL at render time, so we
+        avoid baking an environment-specific host (which moved under NPT-1078) into the database. Replacing
+        only the host+legacy-path leaves the trailing {guid} intact.
+
+        This is naturally idempotent (the pattern no longer matches after the first run), but it's guarded by
+        DatabaseMigration per the ReleaseScripts convention.
+    */
+    UPDATE dbo.NeptunePage
+    SET NeptunePageContent =
+        REPLACE(
+            REPLACE(NeptunePageContent, 'https://www.ocstormwatertools.org/FileResource/DisplayResource/', '/file-resources/'),
+            'http://www.ocstormwatertools.org/FileResource/DisplayResource/', '/file-resources/')
+    WHERE NeptunePageContent LIKE '%ocstormwatertools.org/FileResource/DisplayResource/%';
+
+    INSERT INTO dbo.DatabaseMigration(MigrationAuthorName, ReleaseScriptFileName, MigrationReason)
+    SELECT 'Ray Lee', @MigrationName, 'Retire legacy MVC FileResource URLs in NeptunePage rich text content (WebMvc retirement / NPT-1068); convert to the relative /file-resources/{guid} the SPA resolves at render.'
+END

--- a/Neptune.Database/Scripts/ReleaseScripts/037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content.sql
@@ -19,11 +19,18 @@ BEGIN
         This is naturally idempotent (the pattern no longer matches after the first run), but it's guarded by
         DatabaseMigration per the ReleaseScripts convention.
     */
+    -- Cover www/non-www x http/https so every row the WHERE selects is actually rewritten (no recording the
+    -- migration while silently leaving a host variant un-rewritten). Any other residual host form is still
+    -- repaired for display by the SPA's custom-rich-text render-time rewrite (which matches any host).
     UPDATE dbo.NeptunePage
     SET NeptunePageContent =
         REPLACE(
-            REPLACE(NeptunePageContent, 'https://www.ocstormwatertools.org/FileResource/DisplayResource/', '/file-resources/'),
-            'http://www.ocstormwatertools.org/FileResource/DisplayResource/', '/file-resources/')
+        REPLACE(
+        REPLACE(
+        REPLACE(NeptunePageContent, 'https://www.ocstormwatertools.org/FileResource/DisplayResource/', '/file-resources/'),
+                                    'http://www.ocstormwatertools.org/FileResource/DisplayResource/',  '/file-resources/'),
+                                    'https://ocstormwatertools.org/FileResource/DisplayResource/',      '/file-resources/'),
+                                    'http://ocstormwatertools.org/FileResource/DisplayResource/',       '/file-resources/')
     WHERE NeptunePageContent LIKE '%ocstormwatertools.org/FileResource/DisplayResource/%';
 
     INSERT INTO dbo.DatabaseMigration(MigrationAuthorName, ReleaseScriptFileName, MigrationReason)

--- a/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -80,4 +80,6 @@ GO
 GO
 :r ".\036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql"
 GO
+:r ".\037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content.sql"
+GO
 

--- a/Neptune.Web/src/app/shared/components/custom-rich-text/custom-rich-text.component.ts
+++ b/Neptune.Web/src/app/shared/components/custom-rich-text/custom-rich-text.component.ts
@@ -9,6 +9,7 @@ import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 import { NeptunePageDto } from "src/app/shared/generated/model/neptune-page-dto";
 import { CustomRichTextService } from "src/app/shared/generated/api/custom-rich-text.service";
 import { FormsModule } from "@angular/forms";
+import { fileResourceUrl } from "src/app/shared/helpers/file-resource-url";
 
 import { LoadingDirective } from "src/app/shared/directives/loading.directive";
 import { IconComponent } from "src/app/shared/components/icon/icon.component";
@@ -73,11 +74,25 @@ export class CustomRichTextComponent implements OnInit, AfterViewChecked, OnDest
     private loadCustomRichText(customRichText: NeptunePageDto) {
         this.editedTitle = this.customRichTextTitle;
 
-        this.customRichTextContent = this.sanitizer.bypassSecurityTrustHtml(customRichText.NeptunePageContent);
+        this.customRichTextContent = this.sanitizer.bypassSecurityTrustHtml(this.rewriteFileResourceUrls(customRichText.NeptunePageContent));
         this.editedContent = customRichText.NeptunePageContent;
         this.isEmptyContent = customRichText.IsEmptyContent;
         this.isLoading = false;
         this.cdr.detectChanges();
+    }
+
+    // Stored rich-text content references FileResources two ways the rendered DOM can't resolve directly:
+    //   - relative `/file-resources/{guid}` (the SPA and API are separate origins, so a relative path hits the SPA), and
+    //   - legacy absolute MVC `…/FileResource/DisplayResource/{guid}` URLs left over from before the WebMvc retirement.
+    // Rewrite both to the absolute API URL at render time ONLY. editedContent is left untouched so an admin saving
+    // through the editor never persists an environment-specific host back into the database.
+    private rewriteFileResourceUrls(html: string): string {
+        if (!html) {
+            return html;
+        }
+        return html
+            .replace(/https?:\/\/[^"'()\s]*?\/FileResource\/DisplayResource\/([0-9a-fA-F-]{36})/gi, (_match, guid) => fileResourceUrl(guid))
+            .replace(/(["'(])\/file-resources\/([0-9a-fA-F-]{36})/gi, (_match, prefix, guid) => `${prefix}${fileResourceUrl(guid)}`);
     }
 
     public showEditButton(): boolean {


### PR DESCRIPTION
## Summary
NeptunePage rich-text content (the custom-rich-text panels: Home, About, Modeling home, About Modeling BMP Performance, OVTA Instructions, LandUseBlock) embedded **absolute** links to the retired WebMvc FileResource route:

```
https://www.ocstormwatertools.org/FileResource/DisplayResource/{guid}
```

That MVC app and route are gone, so those `<img>`/`<a>` links were broken. The live endpoint is `/file-resources/{guid}` on the API (the `fileResourceUrl()` helper builds the absolute form).

6 `NeptunePage` rows were affected (5 image `<img src>`, 1 DOCX `<a href>` on the LandUseBlock page).

## Changes
- **`custom-rich-text.component.ts`** — at render time, rewrite both legacy absolute `…/FileResource/DisplayResource/{guid}` **and** relative `/file-resources/{guid}` to the absolute API URL (`fileResourceUrl(guid)`). Render-only: `editedContent` is left untouched so an admin saving through the editor never persists an environment-specific host into the DB. This also covers any environment whose data the release script hasn't reached.
- **Release script `037`** — strips the scheme+host from the stored legacy URLs, leaving the relative `/file-resources/{guid}` the SPA resolves at render (avoids baking an env-specific host — which moved under NPT-1078 — into the database). Idempotent + `DatabaseMigration`-guarded; registered in `Script.PostDeployment.ReleaseScripts.sql` and `Neptune.Database.sqlproj`.

## Notes
- New TinyMCE uploads embed images as base64 data URIs, so nothing reintroduces the FileResource-URL pattern; this is purely legacy MVC content.
- Verified the replacement in a rolled-back transaction: all 6 rows convert to clean relative `/file-resources/{guid}` (GUID intact, img + href), 0 legacy URLs remaining.

## Test plan
- [x] `npm run build-dev` clean
- [x] Release script dry-run (rollback) converts all 6 rows correctly, 0 leftover
- [x] Rich-text images + LandUseBlock doc link load via the rewrite