### PR TITLE
NPT-1097: Add OVTA assessment index to speed Trash Analysis Areas grid

### DIFF
--- a/Neptune.Database/dbo/Tables/dbo.OnlandVisualTrashAssessment.sql
+++ b/Neptune.Database/dbo/Tables/dbo.OnlandVisualTrashAssessment.sql
@@ -29,6 +29,19 @@ GO
 CREATE SPATIAL INDEX [SPATIAL_OnlandVisualTrashAssessment_DraftGeometry] ON [dbo].[OnlandVisualTrashAssessment]
 (
 	[DraftGeometry]
-)USING  GEOMETRY_AUTO_GRID 
-WITH (BOUNDING_BOX =(-118, 33, -117, 34), 
+)USING  GEOMETRY_AUTO_GRID
+WITH (BOUNDING_BOX =(-118, 33, -117, 34),
 CELLS_PER_OBJECT = 8, PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+GO
+
+-- Supports the per-area "most recent assessment" (ovtaad) and progress-score
+-- (vOnlandVisualTrashAssessmentAreaProgress) subqueries used by vTrashGeneratingUnitLoadStatistic.
+-- Both do ROW_NUMBER() OVER (PARTITION BY OnlandVisualTrashAssessmentAreaID ORDER BY CompletedDate DESC);
+-- without this index the trash-analysis-areas grid re-scanned + re-sorted this table ~1,680x (4.4M rows, ~2s).
+-- Key order + DESC matches the window so the seek is already ordered; includes cover the projected columns.
+CREATE NONCLUSTERED INDEX [IX_OnlandVisualTrashAssessment_OnlandVisualTrashAssessmentAreaID_CompletedDate] ON [dbo].[OnlandVisualTrashAssessment]
+(
+	[OnlandVisualTrashAssessmentAreaID] ASC,
+	[CompletedDate] DESC
+)
+INCLUDE ([OnlandVisualTrashAssessmentScoreID], [IsProgressAssessment])

--- a/Neptune.EFModels/Entities/Generated/OnlandVisualTrashAssessment.cs
+++ b/Neptune.EFModels/Entities/Generated/OnlandVisualTrashAssessment.cs
@@ -8,6 +8,7 @@ using NetTopologySuite.Geometries;
 namespace Neptune.EFModels.Entities;
 
 [Table("OnlandVisualTrashAssessment")]
+[Index("OnlandVisualTrashAssessmentAreaID", "CompletedDate", Name = "IX_OnlandVisualTrashAssessment_OnlandVisualTrashAssessmentAreaID_CompletedDate", IsDescending = new[] { false, true })]
 [Index("DraftGeometry", Name = "SPATIAL_OnlandVisualTrashAssessment_DraftGeometry")]
 public partial class OnlandVisualTrashAssessment
 {


### PR DESCRIPTION
## Summary

Quick-win performance fix for the **Trash Analysis Areas** grid (`/trash/trash-analysis-areas`), which loads ~147K rows and takes 25s+ in production. Full investigation and the remaining work are tracked on [NPT-1097](https://sitkatech.atlassian.net/browse/NPT-1097).

The shared view `vTrashGeneratingUnitLoadStatistic` re-evaluates the per-area OVTA "most recent" (`ovtaad`) and progress (`vOnlandVisualTrashAssessmentAreaProgress`) subqueries — `ROW_NUMBER() OVER (PARTITION BY OnlandVisualTrashAssessmentAreaID ORDER BY CompletedDate DESC)` — ~1,680× per load, scanning + sorting `OnlandVisualTrashAssessment` into ~4.4M intermediate rows and spilling to tempdb.

## Change

Add a covering index:

```sql
CREATE NONCLUSTERED INDEX IX_OnlandVisualTrashAssessment_OnlandVisualTrashAssessmentAreaID_CompletedDate
ON dbo.OnlandVisualTrashAssessment (OnlandVisualTrashAssessmentAreaID ASC, CompletedDate DESC)
INCLUDE (OnlandVisualTrashAssessmentScoreID, IsProgressAssessment);
```

The key order + `DESC` match the window so the windowed reads seek in index order with **no sort**. Confirmed via actual execution plan: the OVTA sort spill is gone and the index is used. Also benefits the load-based maps and trash result calculations that share the view.

Files: the index definition (`dbo.OnlandVisualTrashAssessment.sql`) + its scaffolded `[Index]` attribute on the generated entity.

## Scope / not in this PR

This is a **~10% quick win**, not the full fix. Per the execution-plan analysis, the dominant remaining costs are `STArea`/`STGeometryType` per-row recompute and the correlated OVTA re-scan, plus tempdb spills from a cardinality misestimate. Those — along with the **freshness contract** (capture-status, land-use-block, and OVTA-assessment edits must stay real-time; geometry stays overnight) — are scoped on NPT-1097.

## Testing

- Verified against the live DB with `SET STATISTICS TIME` + actual execution plan: index is used, OVTA sub-sort no longer spills.
- No app/API code change; behavior and grid values unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)