### PR TITLE
NPT-1098: Make apex (ocstormwatertools.org) the canonical host

### DIFF
--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -671,7 +671,6 @@ stages:
                 global.domains.api="$(domainApi)"
                 global.domains.externalApi="$(domainExternalApi)"
                 global.domains.web="$(domainWeb)"
-                global.domains.planning="$(domainPlanning)"
                 global.domains.geoserver="$(domainGeoserver)"
                 global.env.name="$(Environment)"
                 global.secrets.geoserverSqlServerPassword="$(SQL_GEOSERVER_PASSWORD)"

--- a/Neptune.Web/src/environments/environment.prod.ts
+++ b/Neptune.Web/src/environments/environment.prod.ts
@@ -9,7 +9,7 @@ export const environment = {
     auth0: {
         domain: "ocstormwatertools.us.auth0.com",
         clientId: "ifBEaIsDKHXBQoIyDVl1CB21avZh1xEx",
-        redirectUri: "https://www.ocstormwatertools.org/callback",
+        redirectUri: "https://ocstormwatertools.org/callback",
         audience: "OCSTApi",
     },
 };

--- a/Neptune.Web/src/main.ts
+++ b/Neptune.Web/src/main.ts
@@ -12,13 +12,22 @@ import { AppComponent } from "./app/app.component";
 import { createApplication } from "@angular/platform-browser";
 import { appConfig } from "./app/app.config";
 
-(async () => {
-    const app = createApplication(appConfig);
-    (await app).bootstrap(AppComponent);
+// NPT-1098: the prod canonical host is the apex (ocstormwatertools.org). The ingress serves
+// www.ocstormwatertools.org with TLS, but the azure-application-gateway class can't issue the
+// redirect, so canonicalize here — BEFORE Angular/Auth0 bootstrap. If we let the app start on
+// www, a login returns to the apex (redirectUri) and the origin-scoped sessionStorage
+// (post-auth target) + localStorage (Auth0 token cache) are lost across the host hop.
+if (window.location.hostname === "www.ocstormwatertools.org") {
+    window.location.replace("https://ocstormwatertools.org" + window.location.pathname + window.location.search + window.location.hash);
+} else {
+    (async () => {
+        const app = createApplication(appConfig);
+        (await app).bootstrap(AppComponent);
 
-    // todo: example of creating a custom popup in leaflet
-    // const wriaPopupComponent = createCustomElement(WaterResourceInventoryAreaPopupComponent, {
-    //     injector: (await app).injector,
-    // });
-    // customElements.define("water-resource-inventory-area-popup-custom-element", wriaPopupComponent);
-})();
+        // todo: example of creating a custom popup in leaflet
+        // const wriaPopupComponent = createCustomElement(WaterResourceInventoryAreaPopupComponent, {
+        //     injector: (await app).injector,
+        // });
+        // customElements.define("water-resource-inventory-area-popup-custom-element", wriaPopupComponent);
+    })();
+}

--- a/charts/neptune/charts/neptune-web/templates/ingress.yaml
+++ b/charts/neptune/charts/neptune-web/templates/ingress.yaml
@@ -30,7 +30,6 @@ spec:
     - secretName: neptune-web-tls
       hosts:
         - {{ .Values.global.domains.web }}
-        - {{ .Values.global.domains.planning }}
   {{- if eq .Values.global.env.name "prod" }}
         # NPT-1098: prod canonical host is the apex (domains.web = ocstormwatertools.org).
         # Keep www on the cert so the www -> apex canonical redirect is served over HTTPS.
@@ -74,19 +73,4 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
   {{- end }}
-    - host: {{ .Values.global.domains.planning }}
-      http:
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
 {{- end }}

--- a/charts/neptune/charts/neptune-web/templates/ingress.yaml
+++ b/charts/neptune/charts/neptune-web/templates/ingress.yaml
@@ -32,7 +32,9 @@ spec:
         - {{ .Values.global.domains.web }}
         - {{ .Values.global.domains.planning }}
   {{- if eq .Values.global.env.name "prod" }}
-        - ocstormwatertools.org
+        # NPT-1098: prod canonical host is the apex (domains.web = ocstormwatertools.org).
+        # Keep www on the cert so the www -> apex canonical redirect is served over HTTPS.
+        - www.ocstormwatertools.org
   {{- end }}
   rules:
     - host: {{ .Values.global.domains.web }}
@@ -51,9 +53,12 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
   {{- if eq .Values.global.env.name "prod" }}
-    # NPT-1068: legacy ocstormwatertools.org moved here from the retired neptune-webmvc ingress.
-    # The SPA serves it and redirects known legacy MVC paths to their SPA equivalents (see app.routes.ts).
-    - host: ocstormwatertools.org
+    # NPT-1098: www is served (with TLS) but the SPA canonical-redirects www -> apex
+    # (ocstormwatertools.org, = domains.web) on bootstrap. The azure-application-gateway ingress
+    # class has no host-redirect annotation, so the 301 cannot be expressed here; it is done
+    # app-side (or via a separate App Gateway redirect rule). The apex itself is served by the
+    # domains.web rule above. (Supersedes the NPT-1068 hardcoded apex host, now redundant.)
+    - host: www.ocstormwatertools.org
       http:
         paths:
           - path: /


### PR DESCRIPTION
Fixes [NPT-1098](https://sitkatech.atlassian.net/browse/NPT-1098).

## Problem

Logging in from the non-www apex (`https://ocstormwatertools.org/...`) left users on the **www** home page, not the page they requested. The apex and www were served as **two separate origins** with no redirect, and the Auth0 `redirectUri` was hardcoded to www. A login started on the apex was returned to www, and the **origin-scoped** `sessionStorage` (post-auth target) + `localStorage` (Auth0 token cache, `cacheLocation: "localstorage"`) were lost across the host hop. Web Storage can't be shared across hosts, so the fix is to collapse to one canonical origin — the **apex**, per product preference.

## Changes

| File | Change |
|---|---|
| `Neptune.Web/src/environments/environment.prod.ts` | `redirectUri` → `https://ocstormwatertools.org/callback` so the whole Auth0 round-trip stays on the apex |
| `Neptune.Web/src/main.ts` | Canonicalize `www` → apex (preserving path/query/hash) **before** Angular/Auth0 bootstrap. Gated on the exact prod www host; qa/dev unaffected |
| `charts/neptune/charts/neptune-web/templates/ingress.yaml` | Apex is now the single served + TLS host via `domains.web`; `www` stays on the cert and is served (so the app-side redirect runs over HTTPS). Removes the redundant hardcoded apex host block, and drops the legacy `planning.*` host |
| `Build/azure-pipelines.yml` | Drops the `global.domains.planning` override (planning is served at `/planning` on the canonical host now) |

**Why the redirect is app-side:** the `azure-application-gateway` ingress class has no host-redirect annotation, so the www→apex 301 can't be expressed in the ingress. It's done in `main.ts` before bootstrap (a real edge App Gateway redirect rule would also work if preferred later).

## ⚠️ Companion changes required to deploy (NOT in this PR — must land together)

1. **Prod pipeline variable** `domainWeb` → `ocstormwatertools.org` (currently `www.ocstormwatertools.org`). This repoints `global.domains.web`, which is both the ingress primary host **and** `OcStormwaterToolsBaseUrl` (email/notification links → apex).
2. **Delete the now-unused `domainPlanning` pipeline variable**, and retire the planning subdomain's DNS record.
3. **Auth0** (OCSTApi app): apex in **Allowed Callback URLs** (already present), plus **Allowed Logout URLs** and **Allowed Web Origins**.

Do **not** merge/deploy this standalone without the `domainWeb` flip, or the served primary host and the redirect target will disagree.

## Testing
- Local typecheck unaffected; QA/dev `redirectUri`s untouched (the `main.ts` guard is scoped to the exact prod www host).
- Post-deploy verification (per NPT-1098 ACs): logged-out apex deep link → login → returns to the same apex page; `www/<path>?q` → `apex/<path>?q`; logout returns to apex; email links use the apex.