### PR TITLE
NPT-1095: Update transect line for legacy un-flagged backing assessments

### DIFF
--- a/Neptune.Database/Neptune.Database.sqlproj
+++ b/Neptune.Database/Neptune.Database.sqlproj
@@ -441,6 +441,7 @@
     <None Include="Scripts\ReleaseScripts\020 - Drop WaterQualityManagementPlanDocumentVectorStore table.sql" />
     <None Include="Scripts\ReleaseScripts\036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql" />
     <None Include="Scripts\ReleaseScripts\037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content.sql" />
+    <None Include="Scripts\ReleaseScripts\038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs.sql" />
     <Build Include="dbo\Tables\dbo.WaterQualityManagementPlanExtractionResult.sql" />
     <Build Include="dbo\Tables\dbo.AITokenUsage.sql" />
   </ItemGroup>

--- a/Neptune.Database/Scripts/ReleaseScripts/038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs.sql
@@ -1,0 +1,87 @@
+DECLARE @MigrationName VARCHAR(200);
+SET @MigrationName = '038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs'
+
+IF NOT EXISTS(SELECT * FROM dbo.DatabaseMigration DM WHERE DM.ReleaseScriptFileName = @MigrationName)
+BEGIN
+
+    PRINT @MigrationName;
+
+    /*
+        OVTA assessments finalized before the IsTransectBackingAssessment flag existed have it = 0, so areas
+        with no flagged backing assessment never updated their stored TransectLine when the backing points were
+        edited (NPT-1095). The code fix adds a runtime "no other backing exists" fallback, but for legacy
+        multi-assessment areas that would anchor to whichever assessment is edited first. Stamp the correct
+        backing up front: the earliest-completed assessment per area, matching
+        OnlandVisualTrashAssessmentAreas.RecomputeTransectLine (Complete status + MIN(CompletedDate),
+        tie-broken by OnlandVisualTrashAssessmentID).
+
+        Touches only areas that currently have ZERO assessments flagged backing, so it's idempotent. Geometry
+        is NOT recomputed here — existing TransectLines refresh on the next edit via the code fix.
+    */
+    ;WITH AreasMissingBacking AS
+    (
+        SELECT ovta.OnlandVisualTrashAssessmentAreaID
+        FROM dbo.OnlandVisualTrashAssessment ovta
+        WHERE ovta.OnlandVisualTrashAssessmentAreaID IS NOT NULL
+        GROUP BY ovta.OnlandVisualTrashAssessmentAreaID
+        HAVING SUM(CASE WHEN ovta.IsTransectBackingAssessment = 1 THEN 1 ELSE 0 END) = 0
+    ),
+    EarliestCompletedPerArea AS
+    (
+        SELECT ovta.OnlandVisualTrashAssessmentID,
+               ROW_NUMBER() OVER (
+                   PARTITION BY ovta.OnlandVisualTrashAssessmentAreaID
+                   ORDER BY ovta.CompletedDate ASC, ovta.OnlandVisualTrashAssessmentID ASC
+               ) AS RowNum
+        FROM dbo.OnlandVisualTrashAssessment ovta
+        INNER JOIN AreasMissingBacking a ON a.OnlandVisualTrashAssessmentAreaID = ovta.OnlandVisualTrashAssessmentAreaID
+        WHERE ovta.OnlandVisualTrashAssessmentStatusID = 2 -- Complete
+    )
+    UPDATE ovta
+    SET ovta.IsTransectBackingAssessment = 1
+    FROM dbo.OnlandVisualTrashAssessment ovta
+    INNER JOIN EarliestCompletedPerArea ec ON ec.OnlandVisualTrashAssessmentID = ovta.OnlandVisualTrashAssessmentID
+    WHERE ec.RowNum = 1;
+
+    PRINT '  Stamped backing assessment on ' + CAST(@@ROWCOUNT AS VARCHAR) + ' legacy OVTA area(s).';
+
+    /*
+        De-duplicate any area that has MORE THAN ONE assessment flagged backing. Keep only the
+        earliest-completed Complete assessment flagged (matching RecomputeTransectLine) and demote the rest.
+        Observed in QA/prod where an InProgress assessment (no CompletedDate) was erroneously left flagged
+        alongside the real Complete backing. Only acts on areas that have a Complete keeper, and never demotes
+        the keeper itself.
+    */
+    ;WITH AreasWithMultipleBacking AS
+    (
+        SELECT ovta.OnlandVisualTrashAssessmentAreaID
+        FROM dbo.OnlandVisualTrashAssessment ovta
+        WHERE ovta.OnlandVisualTrashAssessmentAreaID IS NOT NULL
+        GROUP BY ovta.OnlandVisualTrashAssessmentAreaID
+        HAVING SUM(CASE WHEN ovta.IsTransectBackingAssessment = 1 THEN 1 ELSE 0 END) > 1
+    ),
+    KeeperPerArea AS
+    (
+        SELECT ovta.OnlandVisualTrashAssessmentAreaID,
+               ovta.OnlandVisualTrashAssessmentID,
+               ROW_NUMBER() OVER (
+                   PARTITION BY ovta.OnlandVisualTrashAssessmentAreaID
+                   ORDER BY ovta.CompletedDate ASC, ovta.OnlandVisualTrashAssessmentID ASC
+               ) AS RowNum
+        FROM dbo.OnlandVisualTrashAssessment ovta
+        INNER JOIN AreasWithMultipleBacking a ON a.OnlandVisualTrashAssessmentAreaID = ovta.OnlandVisualTrashAssessmentAreaID
+        WHERE ovta.OnlandVisualTrashAssessmentStatusID = 2 -- Complete
+    )
+    UPDATE ovta
+    SET ovta.IsTransectBackingAssessment = 0
+    FROM dbo.OnlandVisualTrashAssessment ovta
+    INNER JOIN AreasWithMultipleBacking a ON a.OnlandVisualTrashAssessmentAreaID = ovta.OnlandVisualTrashAssessmentAreaID
+    WHERE ovta.IsTransectBackingAssessment = 1
+      AND EXISTS (SELECT 1 FROM KeeperPerArea k WHERE k.OnlandVisualTrashAssessmentAreaID = ovta.OnlandVisualTrashAssessmentAreaID AND k.RowNum = 1)
+      AND NOT EXISTS (SELECT 1 FROM KeeperPerArea k WHERE k.OnlandVisualTrashAssessmentID = ovta.OnlandVisualTrashAssessmentID AND k.RowNum = 1);
+
+    PRINT '  Demoted ' + CAST(@@ROWCOUNT AS VARCHAR) + ' duplicate backing flag(s) in multi-backing area(s).';
+
+    INSERT INTO dbo.DatabaseMigration(MigrationAuthorName, ReleaseScriptFileName, MigrationReason)
+    SELECT 'Ray Lee', @MigrationName, 'Normalize IsTransectBackingAssessment for legacy OVTA areas (NPT-1095): stamp the earliest-completed assessment where none is flagged, and demote duplicates where more than one is flagged, so each area resolves to exactly one (Complete) backing.'
+END

--- a/Neptune.Database/Scripts/ReleaseScripts/038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs.sql
@@ -11,9 +11,10 @@ BEGIN
         with no flagged backing assessment never updated their stored TransectLine when the backing points were
         edited (NPT-1095). The code fix adds a runtime "no other backing exists" fallback, but for legacy
         multi-assessment areas that would anchor to whichever assessment is edited first. Stamp the correct
-        backing up front: the earliest-completed assessment per area, matching
-        OnlandVisualTrashAssessmentAreas.RecomputeTransectLine (Complete status + MIN(CompletedDate),
-        tie-broken by OnlandVisualTrashAssessmentID).
+        backing up front: the earliest-completed assessment per area (Complete status + MIN(CompletedDate)) —
+        the same selection as OnlandVisualTrashAssessmentAreas.RecomputeTransectLine, plus an
+        OnlandVisualTrashAssessmentID tie-break for deterministic results (RecomputeTransectLine's
+        MinBy(CompletedDate) does not itself tie-break).
 
         Touches only areas that currently have ZERO assessments flagged backing, so it's idempotent. Geometry
         is NOT recomputed here — existing TransectLines refresh on the next edit via the code fix.

--- a/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -82,4 +82,6 @@ GO
 GO
 :r ".\037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content.sql"
 GO
+:r ".\038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs.sql"
+GO
 

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentObservations.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentObservations.cs
@@ -78,7 +78,15 @@ namespace Neptune.EFModels.Entities
             if (assessment?.OnlandVisualTrashAssessmentArea == null) return;
 
             var wasNeverSet = assessment.OnlandVisualTrashAssessmentArea.TransectLine == null;
-            var isBacking = assessment.IsTransectBackingAssessment || wasNeverSet;
+            // Assessments finalized before the IsTransectBackingAssessment flag existed have it set false even
+            // though they're the area's backing assessment, so the flag-or-wasNeverSet gate silently skipped the
+            // transect update forever. Treat this assessment as backing when no OTHER assessment in the area is
+            // flagged backing, and stamp the flag below so subsequent saves take the flag path directly.
+            var noOtherBackingExists = !dbContext.OnlandVisualTrashAssessments
+                .Any(x => x.OnlandVisualTrashAssessmentAreaID == assessment.OnlandVisualTrashAssessmentAreaID
+                          && x.IsTransectBackingAssessment
+                          && x.OnlandVisualTrashAssessmentID != assessment.OnlandVisualTrashAssessmentID);
+            var isBacking = assessment.IsTransectBackingAssessment || wasNeverSet || noOtherBackingExists;
 
             if (isBacking && assessment.OnlandVisualTrashAssessmentObservations.Count >= 2)
             {
@@ -87,6 +95,7 @@ namespace Neptune.EFModels.Entities
                 {
                     assessment.OnlandVisualTrashAssessmentArea.TransectLine = transect;
                     assessment.OnlandVisualTrashAssessmentArea.TransectLine4326 = transect.ProjectTo4326();
+                    assessment.IsTransectBackingAssessment = true;
                     await dbContext.SaveChangesAsync();
                 }
             }

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentObservations.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentObservations.cs
@@ -82,8 +82,8 @@ namespace Neptune.EFModels.Entities
             // though they're the area's backing assessment, so the flag-or-wasNeverSet gate silently skipped the
             // transect update forever. Treat this assessment as backing when no OTHER assessment in the area is
             // flagged backing, and stamp the flag below so subsequent saves take the flag path directly.
-            var noOtherBackingExists = !dbContext.OnlandVisualTrashAssessments
-                .Any(x => x.OnlandVisualTrashAssessmentAreaID == assessment.OnlandVisualTrashAssessmentAreaID
+            var noOtherBackingExists = !await dbContext.OnlandVisualTrashAssessments
+                .AnyAsync(x => x.OnlandVisualTrashAssessmentAreaID == assessment.OnlandVisualTrashAssessmentAreaID
                           && x.IsTransectBackingAssessment
                           && x.OnlandVisualTrashAssessmentID != assessment.OnlandVisualTrashAssessmentID);
             var isBacking = assessment.IsTransectBackingAssessment || wasNeverSet || noOtherBackingExists;

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessments.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessments.cs
@@ -178,8 +178,8 @@ public static class OnlandVisualTrashAssessments
             // though they're the area's backing assessment, so the flag-or-wasNeverSet gate silently skipped the
             // transect update forever. Treat this assessment as backing when no OTHER assessment in the area is
             // flagged backing, and stamp the flag below so subsequent saves take the flag path directly.
-            var noOtherBackingExists = !dbContext.OnlandVisualTrashAssessments
-                .Any(x => x.OnlandVisualTrashAssessmentAreaID == onlandVisualTrashAssessment.OnlandVisualTrashAssessmentAreaID
+            var noOtherBackingExists = !await dbContext.OnlandVisualTrashAssessments
+                .AnyAsync(x => x.OnlandVisualTrashAssessmentAreaID == onlandVisualTrashAssessment.OnlandVisualTrashAssessmentAreaID
                           && x.IsTransectBackingAssessment
                           && x.OnlandVisualTrashAssessmentID != onlandVisualTrashAssessment.OnlandVisualTrashAssessmentID);
             var isBackingAssessment = onlandVisualTrashAssessment.IsTransectBackingAssessment || wasNeverSet || noOtherBackingExists;

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessments.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessments.cs
@@ -174,7 +174,15 @@ public static class OnlandVisualTrashAssessments
             // is flagged as the backing one (return-to-edit). Repeat assessments on an area
             // that already has a backing-derived transect leave it alone.
             var wasNeverSet = onlandVisualTrashAssessment.OnlandVisualTrashAssessmentArea.TransectLine == null;
-            var isBackingAssessment = onlandVisualTrashAssessment.IsTransectBackingAssessment || wasNeverSet;
+            // Assessments finalized before the IsTransectBackingAssessment flag existed have it set false even
+            // though they're the area's backing assessment, so the flag-or-wasNeverSet gate silently skipped the
+            // transect update forever. Treat this assessment as backing when no OTHER assessment in the area is
+            // flagged backing, and stamp the flag below so subsequent saves take the flag path directly.
+            var noOtherBackingExists = !dbContext.OnlandVisualTrashAssessments
+                .Any(x => x.OnlandVisualTrashAssessmentAreaID == onlandVisualTrashAssessment.OnlandVisualTrashAssessmentAreaID
+                          && x.IsTransectBackingAssessment
+                          && x.OnlandVisualTrashAssessmentID != onlandVisualTrashAssessment.OnlandVisualTrashAssessmentID);
+            var isBackingAssessment = onlandVisualTrashAssessment.IsTransectBackingAssessment || wasNeverSet || noOtherBackingExists;
 
             if (isBackingAssessment && onlandVisualTrashAssessment.OnlandVisualTrashAssessmentObservations.Count >= 2)
             {
@@ -182,10 +190,10 @@ public static class OnlandVisualTrashAssessments
                 onlandVisualTrashAssessment.OnlandVisualTrashAssessmentArea.TransectLine = transect;
                 onlandVisualTrashAssessment.OnlandVisualTrashAssessmentArea.TransectLine4326 = transect.ProjectTo4326();
 
-                if (wasNeverSet)
+                if (wasNeverSet || noOtherBackingExists)
                 {
-                    // First finalize — stamp this assessment as backing and demote any stale
-                    // flag elsewhere (defensive for odd states).
+                    // First finalize, or a legacy backing assessment that was never stamped — stamp this
+                    // assessment as backing and demote any stale flag elsewhere (defensive for odd states).
                     onlandVisualTrashAssessment.IsTransectBackingAssessment = true;
                     var existingBacking = GetTransectBackingAssessment(dbContext, onlandVisualTrashAssessment.OnlandVisualTrashAssessmentAreaID);
                     if (existingBacking != null && existingBacking.OnlandVisualTrashAssessmentID != onlandVisualTrashAssessment.OnlandVisualTrashAssessmentID)

--- a/Neptune.Tests/OnlandVisualTrashAssessmentTransectBackingTests.cs
+++ b/Neptune.Tests/OnlandVisualTrashAssessmentTransectBackingTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.Common.GeoSpatial;
+using Neptune.EFModels.Entities;
+using Neptune.Models.DataTransferObjects;
+using NetTopologySuite.Geometries;
+
+namespace Neptune.Tests
+{
+    // Regression coverage for NPT-1095: the area's TransectLine must follow the backing assessment's observation
+    // points even for assessments finalized before the IsTransectBackingAssessment flag existed (flag == false,
+    // area already has a TransectLine). Before the fix, the isBacking gate skipped the update forever.
+    [TestClass]
+    public class OnlandVisualTrashAssessmentTransectBackingTests
+    {
+        private NeptuneDbContext _dbContext = null!;
+        private IDbContextTransaction _transaction = null!;
+        private int _jurisdictionID;
+        private int _personID;
+
+        private static NeptuneDbContext GetDbContext()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<NeptuneDbContext>();
+            optionsBuilder.UseSqlServer(
+                "Data Source=localhost;Initial Catalog=NeptuneDB;Persist Security Info=True;Integrated Security=true;Encrypt=False;",
+                x =>
+                {
+                    x.CommandTimeout((int)TimeSpan.FromMinutes(3).TotalSeconds);
+                    x.UseNetTopologySuite();
+                });
+            return new NeptuneDbContext(optionsBuilder.Options);
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _dbContext = GetDbContext();
+            _transaction = _dbContext.Database.BeginTransaction();
+
+            _jurisdictionID = _dbContext.StormwaterJurisdictions.AsNoTracking().OrderBy(x => x.StormwaterJurisdictionID).Select(x => x.StormwaterJurisdictionID).First();
+            _personID = _dbContext.People.AsNoTracking().OrderBy(x => x.PersonID).Select(x => x.PersonID).First();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _transaction.Rollback();
+            _transaction.Dispose();
+            _dbContext.Dispose();
+        }
+
+        private static Geometry MakeSquare(double x0, double y0, double size)
+        {
+            var wkt = $"POLYGON(({x0} {y0}, {x0 + size} {y0}, {x0 + size} {y0 + size}, {x0} {y0 + size}, {x0} {y0}))";
+            return GeometryHelper.FromWKT(wkt, Proj4NetHelper.NAD_83_HARN_CA_ZONE_VI_SRID);
+        }
+
+        // A 3-vertex line in the area's projection — stands in for a pre-existing (legacy) TransectLine. The
+        // observation-driven transect below has 2 vertices, so NumPoints cleanly distinguishes "moved" (->2)
+        // from "untouched" (stays 3) without depending on floating-point coordinate equality.
+        private static Geometry MakeSeedTransect()
+        {
+            return GeometryHelper.FromWKT("LINESTRING (1840000 660000, 1840050 660050, 1840100 660100)", Proj4NetHelper.NAD_83_HARN_CA_ZONE_VI_SRID);
+        }
+
+        private OnlandVisualTrashAssessmentArea CreateAreaWithSeededTransect(string name, double xOffset = 0)
+        {
+            var seedTransect = MakeSeedTransect();
+            var area = new OnlandVisualTrashAssessmentArea
+            {
+                OnlandVisualTrashAssessmentAreaName = name,
+                StormwaterJurisdictionID = _jurisdictionID,
+                OnlandVisualTrashAssessmentAreaGeometry = MakeSquare(1_840_000 + xOffset, 660_000, 100),
+                TransectLine = seedTransect,
+                TransectLine4326 = seedTransect.ProjectTo4326(),
+            };
+            _dbContext.OnlandVisualTrashAssessmentAreas.Add(area);
+            _dbContext.SaveChanges();
+            return area;
+        }
+
+        private OnlandVisualTrashAssessment CreateCompletedAssessment(int areaID, DateOnly completedDate, bool isTransectBacking)
+        {
+            var assessment = new OnlandVisualTrashAssessment
+            {
+                CreatedByPersonID = _personID,
+                CreatedDate = DateTime.UtcNow,
+                OnlandVisualTrashAssessmentAreaID = areaID,
+                StormwaterJurisdictionID = _jurisdictionID,
+                OnlandVisualTrashAssessmentStatusID = (int)OnlandVisualTrashAssessmentStatusEnum.Complete,
+                OnlandVisualTrashAssessmentScoreID = (int)OnlandVisualTrashAssessmentScoreEnum.B,
+                CompletedDate = completedDate,
+                IsTransectBackingAssessment = isTransectBacking,
+                IsProgressAssessment = false,
+            };
+            _dbContext.OnlandVisualTrashAssessments.Add(assessment);
+            _dbContext.SaveChanges();
+            return assessment;
+        }
+
+        private static List<OnlandVisualTrashAssessmentObservationWithPhotoDto> TwoObservations()
+        {
+            return new List<OnlandVisualTrashAssessmentObservationWithPhotoDto>
+            {
+                new() { Latitude = 33.700, Longitude = -117.850, ObservationDatetime = new DateTime(2022, 1, 1, 9, 0, 0, DateTimeKind.Utc) },
+                new() { Latitude = 33.701, Longitude = -117.851, ObservationDatetime = new DateTime(2022, 1, 1, 9, 5, 0, DateTimeKind.Utc) },
+            };
+        }
+
+        private int? GetAreaTransectNumPoints(int areaID)
+        {
+            return _dbContext.OnlandVisualTrashAssessmentAreas.AsNoTracking()
+                .Where(x => x.OnlandVisualTrashAssessmentAreaID == areaID)
+                .Select(x => x.TransectLine)
+                .Single()?.NumPoints;
+        }
+
+        // Core regression: a single Complete assessment, flag false, area already has a TransectLine (the legacy
+        // state). Editing its observations must move the transect and stamp the flag.
+        [TestMethod]
+        public async Task EditingObservations_OnLegacyUnflaggedSoleAssessment_MovesTransectAndStampsFlag()
+        {
+            var unique = Guid.NewGuid().ToString().Substring(0, 8);
+            var area = CreateAreaWithSeededTransect($"NPT-1095 Legacy {unique}", 0);
+            var assessment = CreateCompletedAssessment(area.OnlandVisualTrashAssessmentAreaID, new DateOnly(2021, 5, 1), isTransectBacking: false);
+
+            Assert.AreEqual(3, GetAreaTransectNumPoints(area.OnlandVisualTrashAssessmentAreaID), "Precondition: area starts with the seeded 3-point legacy transect.");
+
+            await OnlandVisualTrashAssessmentObservations.Update(_dbContext, assessment.OnlandVisualTrashAssessmentID, TwoObservations());
+
+            Assert.AreEqual(2, GetAreaTransectNumPoints(area.OnlandVisualTrashAssessmentAreaID),
+                "Transect should have moved to the 2 edited observation points (the NPT-1095 bug left it on the old 3-point line).");
+
+            var refreshed = _dbContext.OnlandVisualTrashAssessments.AsNoTracking().Single(x => x.OnlandVisualTrashAssessmentID == assessment.OnlandVisualTrashAssessmentID);
+            Assert.IsTrue(refreshed.IsTransectBackingAssessment, "The sole assessment should now be stamped as the transect-backing assessment.");
+        }
+
+        // No-regression: a repeat (non-backing) assessment in an area that already has a flagged backing assessment
+        // must NOT move the transect — noOtherBackingExists is false because another assessment is flagged.
+        [TestMethod]
+        public async Task EditingObservations_OnRepeatAssessment_WhenBackingAlreadyFlagged_LeavesTransectAlone()
+        {
+            var unique = Guid.NewGuid().ToString().Substring(0, 8);
+            var area = CreateAreaWithSeededTransect($"NPT-1095 Repeat {unique}", 200);
+            // Earliest, flagged as backing.
+            CreateCompletedAssessment(area.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), isTransectBacking: true);
+            // Later repeat assessment, not backing — the one we edit.
+            var repeat = CreateCompletedAssessment(area.OnlandVisualTrashAssessmentAreaID, new DateOnly(2021, 5, 1), isTransectBacking: false);
+
+            await OnlandVisualTrashAssessmentObservations.Update(_dbContext, repeat.OnlandVisualTrashAssessmentID, TwoObservations());
+
+            Assert.AreEqual(3, GetAreaTransectNumPoints(area.OnlandVisualTrashAssessmentAreaID),
+                "Editing a non-backing repeat assessment must leave the backing-derived transect untouched.");
+
+            var refreshed = _dbContext.OnlandVisualTrashAssessments.AsNoTracking().Single(x => x.OnlandVisualTrashAssessmentID == repeat.OnlandVisualTrashAssessmentID);
+            Assert.IsFalse(refreshed.IsTransectBackingAssessment, "A repeat assessment must not be promoted to backing when one already exists.");
+        }
+    }
+}

--- a/Neptune.Tests/OnlandVisualTrashAssessmentTransectBackingTests.cs
+++ b/Neptune.Tests/OnlandVisualTrashAssessmentTransectBackingTests.cs
@@ -42,8 +42,13 @@ namespace Neptune.Tests
             _dbContext = GetDbContext();
             _transaction = _dbContext.Database.BeginTransaction();
 
-            _jurisdictionID = _dbContext.StormwaterJurisdictions.AsNoTracking().OrderBy(x => x.StormwaterJurisdictionID).Select(x => x.StormwaterJurisdictionID).First();
-            _personID = _dbContext.People.AsNoTracking().OrderBy(x => x.PersonID).Select(x => x.PersonID).First();
+            var jurisdictionID = _dbContext.StormwaterJurisdictions.AsNoTracking().OrderBy(x => x.StormwaterJurisdictionID).Select(x => (int?)x.StormwaterJurisdictionID).FirstOrDefault();
+            Assert.IsNotNull(jurisdictionID, "Tests require at least 1 StormwaterJurisdiction row in the local DB.");
+            _jurisdictionID = jurisdictionID.Value;
+
+            var personID = _dbContext.People.AsNoTracking().OrderBy(x => x.PersonID).Select(x => (int?)x.PersonID).FirstOrDefault();
+            Assert.IsNotNull(personID, "Tests require at least 1 Person row in the local DB.");
+            _personID = personID.Value;
         }
 
         [TestCleanup]


### PR DESCRIPTION
## Summary
Fixes the OVTA transect line not following the backing assessment's observation points when the points are edited — reproduced on **OVTA 14510 (Newport Ave / Park Lane Plaza)**, a single-assessment area, in QA + prod.

### Root cause
Both transect-update sites gate on `IsTransectBackingAssessment || wasNeverSet`:
- `OnlandVisualTrashAssessmentObservations.Update` (return-to-edit path)
- `OnlandVisualTrashAssessments.Update` (finalize path)

`wasNeverSet` is only true on the very first finalize. An assessment finalized **before** the `IsTransectBackingAssessment` flag existed has the flag `false` and its area already has a `TransectLine` (so `wasNeverSet` is `false`) — so the gate is `false` and the transect update is silently skipped on every save. (Per Kathleen's root-cause comment on the ticket.)

### Changes
- **EF gate (both paths)** — add a `noOtherBackingExists` fallback: treat the assessment as backing when no *other* assessment in its area is flagged, and stamp `IsTransectBackingAssessment = true` in that path so future saves take the flag path directly.
- **Release script `038`** — normalizes existing data so each area has exactly one backing assessment:
  - stamps the earliest-completed assessment where an area has **none** flagged (mirrors `RecomputeTransectLine`);
  - de-dups areas with **more than one** flagged (keep earliest-completed Complete, demote the rest — caught a real case where an InProgress assessment was erroneously flagged alongside the Complete backing).
  - `DatabaseMigration`-guarded + idempotent; registered in `Script.PostDeployment.ReleaseScripts.sql` and `Neptune.Database.sqlproj`.
- **Tests** — `OnlandVisualTrashAssessmentTransectBackingTests`: core regression (legacy un-flagged sole assessment → transect moves + flag stamped) and no-regression (repeat assessment with an existing flagged backing → transect untouched).

## Test plan
- [x] `dotnet test --filter OnlandVisualTrashAssessment*` → 30/30 pass
- [x] Backfill dry-run (rolled back): 952 areas stamped, area 2903 de-duped to the Complete assessment, 0 areas left with >1 backing
- [x] QA on OVTA 14510: return-to-edit the backing assessment, move points, save → transect moves and `IsTransectBackingAssessment` is stamped