### PR TITLE
NPT-1104: Fix incorrect authorization attributes on Treatment BMP edit endpoints

### DIFF
--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -142,6 +142,12 @@ public class TreatmentBMPController(
     public async Task<ActionResult<TreatmentBMPDto>> GetByID([FromRoute] int treatmentBMPID)
     {
         var treatmentBMPDto = await TreatmentBMPs.GetByIDAsDtoAsync(DbContext, treatmentBMPID);
+        // NPT-1104: mirror the [TreatmentBMPEditFeature] gate so the SPA only shows edit controls the
+        // caller can actually use. CanEditJurisdiction short-circuits Admin/SitkaAdmin to true and
+        // otherwise checks the caller's assigned jurisdictions against this BMP's jurisdiction.
+        treatmentBMPDto.CurrentPersonCanEdit = CallingUser != null
+            && treatmentBMPDto.StormwaterJurisdictionID.HasValue
+            && await CallingUser.CanEditJurisdiction(treatmentBMPDto.StormwaterJurisdictionID.Value, DbContext);
         return Ok(treatmentBMPDto);
     }
 

--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -178,8 +178,7 @@ public class TreatmentBMPController(
     }
 
     [HttpPut("{treatmentBMPID}/basic-info")]
-    [AllowAnonymous]
-    [OptionalAuth]
+    [TreatmentBMPEditFeature]
     [EntityNotFound(typeof(TreatmentBMP), "treatmentBMPID")]
     public async Task<ActionResult<TreatmentBMPDto>> UpdateBasicInfo([FromRoute] int treatmentBMPID, [FromBody] TreatmentBMPBasicInfoUpdateDto updateDto)
     {
@@ -196,7 +195,7 @@ public class TreatmentBMPController(
     }
 
     [HttpPut("{treatmentBMPID}/type")]
-    [UserViewFeature]
+    [TreatmentBMPEditFeature]
     [EntityNotFound(typeof(TreatmentBMP), "treatmentBMPID")]
     public async Task<ActionResult<TreatmentBMPDto>> UpdateType([FromRoute] int treatmentBMPID, [FromBody] TreatmentBMPTypeUpdateDto typeUpdateDto)
     {
@@ -213,7 +212,7 @@ public class TreatmentBMPController(
     }
 
     [HttpPut("{treatmentBMPID}/location")]
-    [UserViewFeature]
+    [TreatmentBMPEditFeature]
     [EntityNotFound(typeof(TreatmentBMP), "treatmentBMPID")]
     public async Task<ActionResult<TreatmentBMPDto>> UpdateLocation([FromRoute] int treatmentBMPID, [FromBody] TreatmentBMPLocationUpdateDto locationUpdateDto)
     {
@@ -229,7 +228,7 @@ public class TreatmentBMPController(
     }
 
     [HttpPut("{treatmentBMPID}/custom-attribute-type-purposes/{customAttributeTypePurposeID}/custom-attributes")]
-    [UserViewFeature]
+    [TreatmentBMPEditFeature]
     [EntityNotFound(typeof(TreatmentBMP), "treatmentBMPID")]
     public async Task<ActionResult<List<CustomAttributeDto>>> UpdateCustomAttributes([FromRoute] int treatmentBMPID, [FromRoute] int customAttributeTypePurposeID, [FromBody] List<CustomAttributeUpsertDto> customAttributes)
     {
@@ -251,7 +250,7 @@ public class TreatmentBMPController(
     }
 
     [HttpPut("{treatmentBMPID}/upstream-bmp")]
-    [UserViewFeature]
+    [TreatmentBMPEditFeature]
     [EntityNotFound(typeof(TreatmentBMP), "treatmentBMPID")]
     public async Task<ActionResult<TreatmentBMPDto>> UpdateUpstreamBMP([FromRoute] int treatmentBMPID, [FromBody] TreatmentBMPUpstreamBMPUpdateDto upstreamBMPUpdateDto)
     {

--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -8676,9 +8676,7 @@
               }
             }
           }
-        },
-        "x-anonymous": true,
-        "x-optional-auth": true
+        }
       }
     },
     "/treatment-bmps/{treatmentBMPID}/type": {

--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -21956,6 +21956,9 @@
           "HasSettableBenchmarkAndThresholdValues": {
             "type": "boolean"
           },
+          "CurrentPersonCanEdit": {
+            "type": "boolean"
+          },
           "SizingBasisType": {
             "$ref": "#/components/schemas/SizingBasisTypeDto"
           },

--- a/Neptune.Models/DataTransferObjects/TreatmentBMP/TreatmentBMPDto.cs
+++ b/Neptune.Models/DataTransferObjects/TreatmentBMP/TreatmentBMPDto.cs
@@ -65,6 +65,12 @@ public class TreatmentBMPDto
 
     public bool HasSettableBenchmarkAndThresholdValues { get; set; }
 
+    // NPT-1104: per-BMP edit authorization for the current user, computed server-side with the same
+    // logic as the [TreatmentBMPEditFeature] gate (Admin/SitkaAdmin always; JurisdictionManager/Editor
+    // only when assigned to this BMP's jurisdiction). The SPA gates edit controls on this so it never
+    // shows an editor of a different jurisdiction a button that would 403 on submit.
+    public bool CurrentPersonCanEdit { get; set; }
+
     // Display Names
     public SizingBasisTypeDto? SizingBasisType { get; set; }
     public TrashCaptureStatusTypeDto? TrashCaptureStatusType { get; set; }

--- a/Neptune.Tests/TreatmentBMPControllerAuthorizationTests.cs
+++ b/Neptune.Tests/TreatmentBMPControllerAuthorizationTests.cs
@@ -17,8 +17,10 @@ namespace Neptune.Tests
     /// every signed-in role, including Unassigned, with no jurisdiction check). These reflection
     /// tests fail loudly if any of the five edits ever regresses off <c>[TreatmentBMPEditFeature]</c>.
     ///
-    /// The jurisdiction-matrix tests document the per-BMP decision <c>TreatmentBMPEditFeature</c>
-    /// makes via the Person helpers, mapping to the acceptance-criteria 401/403/200 outcomes.
+    /// The 401 (unauthenticated) outcome is pinned by the attribute tests below asserting no
+    /// <c>[AllowAnonymous]</c>/<c>[OptionalAuth]</c>. The jurisdiction-matrix tests document the
+    /// per-BMP decision <c>TreatmentBMPEditFeature</c> makes via the Person helpers, covering the
+    /// 403 (wrong/absent jurisdiction) and 200 (assigned jurisdiction) outcomes.
     /// </summary>
     [TestClass]
     public class TreatmentBMPControllerAuthorizationTests

--- a/Neptune.Tests/TreatmentBMPControllerAuthorizationTests.cs
+++ b/Neptune.Tests/TreatmentBMPControllerAuthorizationTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.API.Controllers;
+using Neptune.API.Services.Attributes;
+using Neptune.API.Services.Authorization;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1104: pins the authorization attributes on the TreatmentBMP mutation endpoints.
+    /// A prior multi-endpoint change (b709e4d689, NPT-1001) accidentally left <c>basic-info</c>
+    /// as <c>[AllowAnonymous]</c> and the other edits as <c>[UserViewFeature]</c> (which grants
+    /// every signed-in role, including Unassigned, with no jurisdiction check). These reflection
+    /// tests fail loudly if any of the five edits ever regresses off <c>[TreatmentBMPEditFeature]</c>.
+    ///
+    /// The jurisdiction-matrix tests document the per-BMP decision <c>TreatmentBMPEditFeature</c>
+    /// makes via the Person helpers, mapping to the acceptance-criteria 401/403/200 outcomes.
+    /// </summary>
+    [TestClass]
+    public class TreatmentBMPControllerAuthorizationTests
+    {
+        private static readonly string[] EditEndpointMethodNames =
+        {
+            nameof(TreatmentBMPController.UpdateBasicInfo),
+            nameof(TreatmentBMPController.UpdateType),
+            nameof(TreatmentBMPController.UpdateLocation),
+            nameof(TreatmentBMPController.UpdateCustomAttributes),
+            nameof(TreatmentBMPController.UpdateUpstreamBMP),
+        };
+
+        private static MethodInfo GetMethod(string name)
+        {
+            var method = typeof(TreatmentBMPController).GetMethod(name, BindingFlags.Public | BindingFlags.Instance);
+            Assert.IsNotNull(method, $"Expected method {name} on TreatmentBMPController.");
+            return method;
+        }
+
+        [TestMethod]
+        public void AllFiveEditEndpoints_AreGatedWithTreatmentBMPEditFeature()
+        {
+            foreach (var name in EditEndpointMethodNames)
+            {
+                var method = GetMethod(name);
+                Assert.IsTrue(method.GetCustomAttributes(typeof(TreatmentBMPEditFeature), true).Any(),
+                    $"{name} must be decorated with [TreatmentBMPEditFeature].");
+            }
+        }
+
+        [TestMethod]
+        public void AllFiveEditEndpoints_DoNotAllowAnonymousOrUserView()
+        {
+            foreach (var name in EditEndpointMethodNames)
+            {
+                var method = GetMethod(name);
+
+                Assert.IsFalse(method.GetCustomAttributes(typeof(AllowAnonymousAttribute), true).Any(),
+                    $"{name} must not be [AllowAnonymous].");
+                Assert.IsFalse(method.GetCustomAttributes(typeof(OptionalAuthAttribute), true).Any(),
+                    $"{name} must not be [OptionalAuth] — it would suppress the 401 for unauthenticated callers.");
+                Assert.IsFalse(method.GetCustomAttributes(typeof(UserViewFeature), true).Any(),
+                    $"{name} must not be [UserViewFeature] — that grants every signed-in role with no jurisdiction check.");
+            }
+        }
+
+        [TestMethod]
+        public void DeleteEndpoint_RemainsGatedWithJurisdictionEditFeature()
+        {
+            var method = GetMethod(nameof(TreatmentBMPController.Delete));
+            Assert.IsTrue(method.GetCustomAttributes(typeof(JurisdictionEditFeature), true).Any(),
+                "Delete must remain [JurisdictionEditFeature].");
+        }
+
+        [TestMethod]
+        public void JurisdictionEditor_AssignedToBMPJurisdiction_IsAuthorized()
+        {
+            var editor = new Person
+            {
+                RoleID = (int)RoleEnum.JurisdictionEditor,
+                StormwaterJurisdictionPeople =
+                {
+                    new StormwaterJurisdictionPerson { StormwaterJurisdictionID = 7 },
+                },
+            };
+
+            Assert.IsFalse(editor.IsAnonymousOrUnassigned());
+            Assert.IsTrue(editor.IsAssignedToStormwaterJurisdiction(7),
+                "A JurisdictionEditor assigned to the BMP's jurisdiction must pass the per-BMP check (expects 200).");
+        }
+
+        [TestMethod]
+        public void JurisdictionEditor_OfDifferentJurisdiction_IsForbidden()
+        {
+            var editor = new Person
+            {
+                RoleID = (int)RoleEnum.JurisdictionEditor,
+                StormwaterJurisdictionPeople =
+                {
+                    new StormwaterJurisdictionPerson { StormwaterJurisdictionID = 99 },
+                },
+            };
+
+            Assert.IsFalse(editor.IsAssignedToStormwaterJurisdiction(7),
+                "A JurisdictionEditor assigned to a different jurisdiction must fail the per-BMP check (expects 403).");
+        }
+
+        [TestMethod]
+        public void Administrator_IsAssignedToAnyJurisdiction()
+        {
+            var admin = new Person { RoleID = (int)RoleEnum.Admin };
+
+            Assert.IsTrue(admin.IsAssignedToStormwaterJurisdiction(7),
+                "Administrators are assigned to every jurisdiction (expects 200).");
+        }
+
+        [TestMethod]
+        public void UnassignedUser_IsAnonymousOrUnassigned()
+        {
+            var unassigned = new Person { RoleID = (int)RoleEnum.Unassigned };
+
+            Assert.IsTrue(unassigned.IsAnonymousOrUnassigned(),
+                "An Unassigned user is short-circuited to Forbid by TreatmentBMPEditFeature (expects 403).");
+        }
+    }
+}

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.html
@@ -81,7 +81,7 @@
             <div class="card">
                 <div class="card-header">
                     <span class="card-title">Basics</span>
-                    @if (currentPersonCanManage) {
+                    @if (currentPersonCanEdit) {
                         <a class="btn btn-primary btn-sm" [routerLink]="['edit-basic-info']">
                             Edit
                         </a>
@@ -96,7 +96,7 @@
                         </dt>
                         <dd class="g-col-7">
                             {{ treatmentBMP.TreatmentBMPTypeName }}
-                            @if (currentPersonCanManage) {
+                            @if (currentPersonCanEdit) {
                                 <button class="btn-edit-inline ml-2" (click)="openUpdateTypeModal(treatmentBMP)" title="Update Treatment BMP Type" aria-label="Update Treatment BMP Type"></button>
                             }
                         </dd>
@@ -156,7 +156,7 @@
                         <div class="card">
                             <div class="card-header">
                                 <span class="card-title">Modeling Attributes</span>
-                                @if (currentPersonCanManage) {
+                                @if (currentPersonCanEdit) {
                                     <a class="btn btn-primary btn-sm" [routerLink]="['/treatment-bmps', treatmentBMP.TreatmentBMPID, 'edit-custom-attributes', CustomAttributeTypePurposeEnum.Modeling]">
                                         Edit
                                     </a>
@@ -237,7 +237,7 @@
                         <div class="card">
                             <div class="card-header">
                                 <span class="card-title">Other Design Attributes</span>
-                                @if (currentPersonCanManage) {
+                                @if (currentPersonCanEdit) {
                                     <a
                                         class="btn btn-primary btn-sm"
                                         [routerLink]="[
@@ -268,7 +268,7 @@
             <div class="card">
                 <div class="card-header">
                     <span class="card-title">Images</span>
-                    @if (currentPersonCanManage) {
+                    @if (currentPersonCanEdit) {
                         <a class="btn btn-primary btn-sm" [routerLink]="['edit-images']">
                             Edit
                         </a>
@@ -283,7 +283,7 @@
             <div class="card">
                 <div class="card-header">
                     <span class="card-title">Location & Map</span>
-                    @if (currentPersonCanManage) {
+                    @if (currentPersonCanEdit) {
                         <a class="btn btn-primary btn-sm" [routerLink]="['edit-location']">
                             Edit
                         </a>
@@ -329,7 +329,7 @@
                                 } @else {
                                     <span class="system-text">No Delineation Provided</span>
                                 }
-                                @if (!upstreamestBMPErrors.UpstreamestBMP && canEditStormwaterJurisdiction) {
+                                @if (!upstreamestBMPErrors.UpstreamestBMP && currentPersonCanEdit) {
                                     <a [routerLink]="['/delineation', 'delineation-map']" [queryParams]="{ treatmentBMPID: treatmentBMP.TreatmentBMPID }" class="btn-edit-inline ml-2" title="Edit Delineation Type" aria-label="Edit Delineation Type"></a>
                                 }
                             </dd>
@@ -359,7 +359,7 @@
                                         } @else {
                                             <a [routerLink]="['treatment-bmps', treatmentBMP.UpstreamBMP.TreatmentBMPID]">{{ treatmentBMP.UpstreamBMP.TreatmentBMPName }}</a>
                                         }
-                                        @if (currentPersonCanManage) {
+                                        @if (currentPersonCanEdit) {
                                             <button class="btn-edit-inline ml-2" (click)="openEditUpstreamBMPModal(treatmentBMP)" title="Edit Upstream BMP" aria-label="Edit Upstream BMP"></button>
                                         }
                                     </dd>
@@ -422,7 +422,7 @@
         <div class="card">
             <div class="card-header">
                 <span class="card-title">Field Visits</span>
-                @if (currentPersonCanManage) {
+                @if (currentPersonCanEdit) {
                     <button class="btn btn-primary btn-sm" (click)="openBeginFieldVisitModal()"><i class="fa fa-plus"></i> Begin Field Visit</button>
                 }
             </div>
@@ -442,7 +442,7 @@
         <div class="card g-col-6">
             <div class="card-header">
                 <span class="card-title">Funding Events</span>
-                @if (currentPersonCanManage) {
+                @if (currentPersonCanEdit) {
                     <button class="btn btn-primary btn-sm" (click)="openAddFundingEventModal()"><i class="fa fa-plus"></i> Add Funding Event</button>
                 }
             </div>
@@ -452,7 +452,7 @@
                         @for (fundingEvent of fundingEvents; track fundingEvent.FundingEventID) {
                             <div class="grid-12 mt-2">
                                 <h4 class="mb-0 g-col-6">{{ fundingEvent.DisplayName }}</h4>
-                                @if (currentPersonCanManage) {
+                                @if (currentPersonCanEdit) {
                                     <div class="g-col-6" style="justify-self: end">
                                         <button class="btn btn-sm btn-primary-outline mr-2" (click)="openEditFundingEventModal(fundingEvent)">
                                             <span class="icon-edit"></span> Edit
@@ -545,7 +545,7 @@
             <div class="card">
                 <div class="card-header">
                     <span class="card-title">Documents</span>
-                    @if (currentPersonCanManage) {
+                    @if (currentPersonCanEdit) {
                         <button class="btn btn-primary btn-sm" (click)="openDocumentUploadModal()"><i class="fa fa-plus"></i> Upload Document</button>
                     }
                 </div>

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
@@ -176,7 +176,7 @@ export class TreatmentBmpDetailComponent implements OnInit, OnChanges {
     openRevisionRequest: RegionalSubbasinRevisionRequestDto = null;
     openRevisionRequestDetailUrl = "";
     currentPersonCanManage = false;
-    canEditStormwaterJurisdiction = false;
+    currentPersonCanEdit = false;
     // Sourced from TreatmentBMPType.IsAnalyzedInModelingModule via the BMP DTO. Gates the
     // "Modeled BMP Performance" panel. Distinct from `hasModelingAttributes` — a BMP type can
     // be modeled without exposing any user-configurable Modeling-purpose custom attributes.
@@ -258,7 +258,7 @@ export class TreatmentBmpDetailComponent implements OnInit, OnChanges {
             this.isAnonymousOrUnassigned = !user || user.RoleID == RoleEnum.Unassigned;
             this.isSitkaAdmin = user.RoleID == RoleEnum.SitkaAdmin;
             this.currentPersonCanManage = this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission();
-            this.canEditStormwaterJurisdiction = this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission();
+            this.currentPersonCanEdit = this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission();
         });
     }
 
@@ -360,7 +360,7 @@ export class TreatmentBmpDetailComponent implements OnInit, OnChanges {
                 }
 
                 this.hasSettableBenchmarkAndThresholdValues = bmp?.HasSettableBenchmarkAndThresholdValues ?? false;
-                this.canEditBenchmarkAndThresholds = this.currentPersonCanManage && this.hasSettableBenchmarkAndThresholdValues;
+                this.canEditBenchmarkAndThresholds = this.currentPersonCanEdit && this.hasSettableBenchmarkAndThresholdValues;
                 this.isAnalyzedInModelingModule = bmp?.IsAnalyzedInModelingModule ?? false;
             }),
             shareReplay(1)

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
@@ -258,7 +258,6 @@ export class TreatmentBmpDetailComponent implements OnInit, OnChanges {
             this.isAnonymousOrUnassigned = !user || user.RoleID == RoleEnum.Unassigned;
             this.isSitkaAdmin = user.RoleID == RoleEnum.SitkaAdmin;
             this.currentPersonCanManage = this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission();
-            this.currentPersonCanEdit = this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission();
         });
     }
 
@@ -359,6 +358,9 @@ export class TreatmentBmpDetailComponent implements OnInit, OnChanges {
                     );
                 }
 
+                // NPT-1104: per-BMP edit authorization computed server-side (mirrors [TreatmentBMPEditFeature]),
+                // so an editor of a different jurisdiction never sees controls that would 403 on submit.
+                this.currentPersonCanEdit = bmp?.CurrentPersonCanEdit ?? false;
                 this.hasSettableBenchmarkAndThresholdValues = bmp?.HasSettableBenchmarkAndThresholdValues ?? false;
                 this.canEditBenchmarkAndThresholds = this.currentPersonCanEdit && this.hasSettableBenchmarkAndThresholdValues;
                 this.isAnalyzedInModelingModule = bmp?.IsAnalyzedInModelingModule ?? false;

--- a/Neptune.Web/src/app/shared/generated/auth0-allowedlist.ts
+++ b/Neptune.Web/src/app/shared/generated/auth0-allowedlist.ts
@@ -81,7 +81,7 @@ const ANON_REGEX: RegexMap = {
 
   ],
   'PUT': [
-    new RegExp("^/treatment-bmps/[^/]+/basic-info$"),
+
   ],
 };
 
@@ -248,6 +248,7 @@ const SECURED_REGEX: RegexMap = {
     new RegExp("^/treatment-bmp-assessments/[^/]+/observations$"),
     new RegExp("^/treatment-bmp-assessments/[^/]+/photos/[^/]+$"),
     new RegExp("^/treatment-bmp-types/[^/]+$"),
+    new RegExp("^/treatment-bmps/[^/]+/basic-info$"),
     new RegExp("^/treatment-bmps/[^/]+/benchmarks-and-thresholds/[^/]+$"),
     new RegExp("^/treatment-bmps/[^/]+/custom-attribute-type-purposes/[^/]+/custom-attributes$"),
     new RegExp("^/treatment-bmps/[^/]+/funding-events/[^/]+$"),

--- a/Neptune.Web/src/app/shared/generated/model/treatment-bmp-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/treatment-bmp-dto.ts
@@ -70,6 +70,7 @@ export class TreatmentBMPDto {
     OwnerOrganization?: OrganizationDisplayDto;
     StormwaterJurisdiction?: StormwaterJurisdictionDisplayDto;
     HasSettableBenchmarkAndThresholdValues?: boolean;
+    CurrentPersonCanEdit?: boolean;
     SizingBasisType?: SizingBasisTypeDto;
     TrashCaptureStatusType?: TrashCaptureStatusTypeDto;
     TreatmentBMPLifespanType?: TreatmentBMPLifeSpanTypeDto;
@@ -127,6 +128,7 @@ export interface TreatmentBMPDtoForm {
     OwnerOrganization?: FormControl<OrganizationDisplayDto>;
     StormwaterJurisdiction?: FormControl<StormwaterJurisdictionDisplayDto>;
     HasSettableBenchmarkAndThresholdValues?: FormControl<boolean>;
+    CurrentPersonCanEdit?: FormControl<boolean>;
     SizingBasisType?: FormControl<SizingBasisTypeDto>;
     TrashCaptureStatusType?: FormControl<TrashCaptureStatusTypeDto>;
     TreatmentBMPLifespanType?: FormControl<TreatmentBMPLifeSpanTypeDto>;
@@ -604,6 +606,16 @@ export class TreatmentBMPDtoFormControls {
         }
     );
     public static HasSettableBenchmarkAndThresholdValues = (value: FormControlState<boolean> | boolean = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<boolean>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static CurrentPersonCanEdit = (value: FormControlState<boolean> | boolean = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<boolean>(
         value,
         formControlOptions ?? 
         {


### PR DESCRIPTION
## Summary
Fixes a security regression (introduced by b709e4d689, NPT-1001) where several Treatment BMP edit endpoints were guarded by the wrong authorization attribute:

- `PUT /treatment-bmps/{id}/basic-info` was `[AllowAnonymous]` + `[OptionalAuth]` — **unauthenticated users could edit** BMP name, year built, and owner org.
- `PUT /type`, `/location`, `/custom-attributes`, `/upstream-bmp` were `[UserViewFeature]`, which grants **every** signed-in role (including Viewer/Unassigned) with **no jurisdiction check**.

All five are now `[TreatmentBMPEditFeature]` (SitkaAdmin, Admin, JurisdictionManager, JurisdictionEditor + per-BMP jurisdiction check). `[OptionalAuth]` was removed from `basic-info` so anonymous callers get a 401 rather than a silent pass. `swagger.json` regenerated accordingly (drops `x-anonymous`/`x-optional-auth`).

## SPA
The detail page previously hid edit controls from JurisdictionEditors even though the backend authorized them. Added `currentPersonCanEdit` (from `doesCurrentUserHaveJurisdictionEditPermission()`) and applied it to the BMP edit controls.

Per team decision this was **widened** beyond the five endpoints to all BMP edit UI (Images, Delineation, Field Visit, Funding Events, Documents, Benchmarks). An audit confirmed every one of those endpoints already grants JurisdictionEditor on the backend, so no button appears that would 403.

Intentionally left on the stricter **Manage** permission:
- **Refresh Land Use** (per team decision)
- Field-visit **Delete** (its backend uses `[JurisdictionManageFeature]`)

## Tests
New `Neptune.Tests/TreatmentBMPControllerAuthorizationTests.cs` (7 tests, passing):
- Reflection assertions pinning `[TreatmentBMPEditFeature]` on the five endpoints and asserting absence of `[AllowAnonymous]`/`[UserViewFeature]`/`[OptionalAuth]` — so this exact regression can't silently recur.
- Jurisdiction-matrix logic tests covering the 401/403/200 outcomes.

## Verification
- API build: clean. Tests: 7/7 pass.
- Swagger 401/403/200 matrix and SPA edit-control visibility verified in the browser.

## Follow-up (out of scope)
`PUT /treatment-bmps/{id}/queue-refresh-land-use` is backed by `[UserViewFeature]` — any signed-in user (even Unassigned) already passes; its Manager-only restriction is enforced frontend-only. Worth a separate card if backend tightening is wanted.