### PR TITLE
NPT-1104: Impersonation-faithful authorization, 403 UX, and editor access guard

### DIFF
--- a/Neptune.API/Services/Authorization/BaseAuthorizationAttribute.cs
+++ b/Neptune.API/Services/Authorization/BaseAuthorizationAttribute.cs
@@ -13,6 +13,15 @@ namespace Neptune.API.Services.Authorization
     {
         public int Order { get; set; } = 0; // Default order, higher than EntityNotFoundAttribute
 
+        // NPT-1104 rework: gates evaluate the EFFECTIVE (impersonated) user, so impersonating a
+        // lower-privileged user faithfully exercises authorization. Previously the UI wore the
+        // impersonated identity while every gate passed as the authenticated admin, making
+        // authorization bugs invisible under impersonation. The impersonation start/stop features
+        // override this to true — those actions must authorize the REAL admin even while wearing a
+        // low-privilege identity (otherwise you couldn't stop impersonating). Impersonation no-ops
+        // in production, so production authorization is unchanged.
+        protected virtual bool EvaluateAuthenticatedUserOnly => false;
+
         public void OnAuthorization(AuthorizationFilterContext context)
         {
             var user = context.HttpContext.User;
@@ -29,6 +38,12 @@ namespace Neptune.API.Services.Authorization
             }
 
             var person = UserContext.GetUserFromHttpContext(dbContext, context.HttpContext);
+
+            if (!EvaluateAuthenticatedUserOnly)
+            {
+                var impersonationService = context.HttpContext.RequestServices.GetService(typeof(ImpersonationService)) as ImpersonationService;
+                person = impersonationService?.GetEffectivePerson(dbContext, person) ?? person;
+            }
 
             var isAuthorized = person != null && (grantedRoles.Any(x => (int)x == person.RoleID) || !grantedRoles.Any());
             if (!isAuthorized)

--- a/Neptune.API/Services/Authorization/ImpersonateUserFeature.cs
+++ b/Neptune.API/Services/Authorization/ImpersonateUserFeature.cs
@@ -4,6 +4,10 @@ namespace Neptune.API.Services.Authorization
 {
     public class ImpersonateUserFeature : BaseAuthorizationAttribute
     {
+        // Impersonation start/stop must authorize the REAL (authenticated) admin, even while
+        // they are wearing a low-privilege impersonated identity.
+        protected override bool EvaluateAuthenticatedUserOnly => true;
+
         public ImpersonateUserFeature() : base(new[] { RoleEnum.Admin, RoleEnum.SitkaAdmin })
         {
         }

--- a/Neptune.API/Services/Authorization/StopImpersonationFeature.cs
+++ b/Neptune.API/Services/Authorization/StopImpersonationFeature.cs
@@ -10,6 +10,10 @@ namespace Neptune.API.Services.Authorization
     // stop action. OnAuthorizationCore tightens to "must currently be impersonating."
     public class StopImpersonationFeature : BaseAuthorizationAttribute
     {
+        // Impersonation start/stop must authorize the REAL (authenticated) admin, even while
+        // they are wearing a low-privilege impersonated identity.
+        protected override bool EvaluateAuthenticatedUserOnly => true;
+
         public StopImpersonationFeature() : base(new[] { RoleEnum.Admin, RoleEnum.SitkaAdmin })
         {
         }

--- a/Neptune.API/Services/ImpersonationService.cs
+++ b/Neptune.API/Services/ImpersonationService.cs
@@ -23,6 +23,23 @@ namespace Neptune.API.Services
             return impersonatedUser?.AsDto() ?? authenticatedUser;
         }
 
+        /// <summary>
+        /// Entity twin of <see cref="GetEffectiveUser"/> for the authorization pipeline (NPT-1104 rework):
+        /// authorization gates must evaluate the impersonated person — including their
+        /// StormwaterJurisdictionPeople assignments (People.GetByID includes them) — or impersonation can
+        /// never surface authorization failures (the UI wears the impersonated identity while every gate
+        /// passes as the admin). Production behavior is unchanged: impersonation no-ops there.
+        /// </summary>
+        public Person? GetEffectivePerson(NeptuneDbContext dbContext, Person? authenticatedUser)
+        {
+            if (environment.IsProduction() || authenticatedUser?.ImpersonatedPersonID == null)
+            {
+                return authenticatedUser;
+            }
+
+            return People.GetByID(dbContext, authenticatedUser.ImpersonatedPersonID.Value) ?? authenticatedUser;
+        }
+
         public async Task<PersonDto?> ImpersonateUserAsync(NeptuneDbContext dbContext, HttpContext httpContext, int targetPersonID)
         {
             // Use UserContext to resolve the authenticated user — handles both the standard

--- a/Neptune.API/Services/UserContext.cs
+++ b/Neptune.API/Services/UserContext.cs
@@ -29,9 +29,10 @@ namespace Neptune.API.Services
 
             // Impersonation: flip to the effective (impersonated) user if the authenticated
             // user has ImpersonatedPersonID set. Non-production only (the service no-ops in
-            // prod). BaseAuthorizationAttribute still uses GetUserFromHttpContext (raw Person)
-            // so role-based gates evaluate against the authenticated user, not the impersonated
-            // one — admins keep admin perms while impersonating.
+            // prod). NPT-1104 rework: BaseAuthorizationAttribute ALSO evaluates the effective
+            // user now (via ImpersonationService.GetEffectivePerson), so impersonation
+            // faithfully exercises authorization; only the impersonation start/stop features
+            // authorize against the raw authenticated admin.
             var impersonationService = httpContext.RequestServices.GetService(typeof(ImpersonationService)) as ImpersonationService;
             return impersonationService?.GetEffectiveUser(dbContext, dto) ?? dto;
         }

--- a/Neptune.Tests/ImpersonationAuthorizationTests.cs
+++ b/Neptune.Tests/ImpersonationAuthorizationTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;

--- a/Neptune.Tests/ImpersonationAuthorizationTests.cs
+++ b/Neptune.Tests/ImpersonationAuthorizationTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.API.Services;
+using Neptune.API.Services.Authorization;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1104 rework: authorization gates evaluate the EFFECTIVE (impersonated) user so that
+    /// impersonation faithfully exercises authorization — previously the UI wore the impersonated
+    /// identity while every gate passed as the authenticated admin, which is exactly how the
+    /// JurisdictionEditor 403 regression slipped past impersonation-based testing. These tests pin
+    /// the carve-outs and the environment short-circuits so the behavior can't silently drift.
+    /// </summary>
+    [TestClass]
+    public class ImpersonationAuthorizationTests
+    {
+        private static bool GetEvaluateAuthenticatedUserOnly(BaseAuthorizationAttribute attribute)
+        {
+            var property = typeof(BaseAuthorizationAttribute).GetProperty("EvaluateAuthenticatedUserOnly",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(property, "EvaluateAuthenticatedUserOnly property must exist on BaseAuthorizationAttribute.");
+            return (bool)property!.GetValue(attribute)!;
+        }
+
+        [TestMethod]
+        public void ImpersonationStartAndStopFeatures_EvaluateTheAuthenticatedUser()
+        {
+            // Start/stop must authorize the REAL admin even while wearing a low-privilege identity —
+            // otherwise an admin impersonating a Viewer could never stop impersonating.
+            Assert.IsTrue(GetEvaluateAuthenticatedUserOnly(new ImpersonateUserFeature()),
+                "ImpersonateUserFeature must evaluate the authenticated user.");
+            Assert.IsTrue(GetEvaluateAuthenticatedUserOnly(new StopImpersonationFeature()),
+                "StopImpersonationFeature must evaluate the authenticated user.");
+        }
+
+        [TestMethod]
+        public void RegularFeatures_EvaluateTheEffectiveUser()
+        {
+            // Representative sample of ordinary gates: all must run against the effective
+            // (impersonated) user so impersonation testing is faithful.
+            Assert.IsFalse(GetEvaluateAuthenticatedUserOnly(new TreatmentBMPEditFeature()),
+                "TreatmentBMPEditFeature must evaluate the effective (impersonated) user.");
+            Assert.IsFalse(GetEvaluateAuthenticatedUserOnly(new AdminFeature()),
+                "AdminFeature must evaluate the effective (impersonated) user.");
+            Assert.IsFalse(GetEvaluateAuthenticatedUserOnly(new UserViewFeature()),
+                "UserViewFeature must evaluate the effective (impersonated) user.");
+        }
+
+        [TestMethod]
+        public void GetEffectivePerson_InProduction_ReturnsAuthenticatedUser_WithoutTouchingTheDatabase()
+        {
+            var service = new ImpersonationService(new FakeWebHostEnvironment("Production"));
+            var authenticatedAdmin = new Person { PersonID = 1, RoleID = 2, ImpersonatedPersonID = 42 };
+
+            // dbContext is deliberately null: the production path must short-circuit before any DB access.
+            var effective = service.GetEffectivePerson(null!, authenticatedAdmin);
+
+            Assert.AreSame(authenticatedAdmin, effective, "Impersonation must no-op in production.");
+        }
+
+        [TestMethod]
+        public void GetEffectivePerson_NotImpersonating_ReturnsAuthenticatedUser_WithoutTouchingTheDatabase()
+        {
+            var service = new ImpersonationService(new FakeWebHostEnvironment("Development"));
+            var authenticatedAdmin = new Person { PersonID = 1, RoleID = 2, ImpersonatedPersonID = null };
+
+            var effective = service.GetEffectivePerson(null!, authenticatedAdmin);
+
+            Assert.AreSame(authenticatedAdmin, effective, "Without an ImpersonatedPersonID the authenticated user is the effective user.");
+        }
+
+        [TestMethod]
+        public void GetEffectivePerson_NullAuthenticatedUser_ReturnsNull()
+        {
+            var service = new ImpersonationService(new FakeWebHostEnvironment("Development"));
+            Assert.IsNull(service.GetEffectivePerson(null!, null));
+        }
+
+        // The impersonating (non-prod, ImpersonatedPersonID set) path loads the impersonated Person —
+        // with StormwaterJurisdictionPeople includes — via People.GetByID; exercised end-to-end in
+        // local verification (impersonated JE saving an out-of-jurisdiction BMP now 403s).
+
+        private sealed class FakeWebHostEnvironment(string environmentName) : IWebHostEnvironment
+        {
+            public string EnvironmentName { get; set; } = environmentName;
+            public string ApplicationName { get; set; } = "Neptune.Tests";
+            public string WebRootPath { get; set; } = string.Empty;
+            public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+            public string ContentRootPath { get; set; } = string.Empty;
+            public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        }
+    }
+}

--- a/Neptune.Web/src/app/app.routes.ts
+++ b/Neptune.Web/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { ManagerOnlyGuard } from "./shared/guards/unauthenticated-access/manager
 import { ManagerOrAdminOnlyGuard } from "./shared/guards/unauthenticated-access/manager-or-admin-only-guard";
 import { JurisdictionManagerOrEditorOnlyGuard } from "./shared/guards/unauthenticated-access/jurisdiction-manager-or-editor-only-guard.guard";
 import { UnsavedChangesGuard } from "./shared/guards/unsaved-changes.guard";
+import { TreatmentBmpEditAccessGuard } from "src/app/shared/guards/treatment-bmp-edit-access.guard";
 import { OCTAGrantReviewerOnlyGuard } from "./shared/guards/unauthenticated-access/octa-grant-reviewer-only.guard";
 import { AdminOnlyGuard } from "./shared/guards/unauthenticated-access/admin-only-guard";
 import { authGuardFn } from "@auth0/auth0-angular";
@@ -451,6 +452,7 @@ export const routes: Routes = [
                     import("./pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-update-basic-info/treatment-bmp-update-basic-info.component").then(
                         (m) => m.TreatmentBmpUpdateBasicInfoComponent
                     ),
+                canActivate: [TreatmentBmpEditAccessGuard],
                 canDeactivate: [UnsavedChangesGuard],
             },
             {
@@ -460,6 +462,7 @@ export const routes: Routes = [
                     import("./pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-update-images/treatment-bmp-update-images.component").then(
                         (m) => m.TreatmentBmpUpdateImagesComponent
                     ),
+                canActivate: [TreatmentBmpEditAccessGuard],
                 canDeactivate: [UnsavedChangesGuard],
             },
             {
@@ -469,6 +472,7 @@ export const routes: Routes = [
                     import("./pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-update-location/treatment-bmp-update-location.component").then(
                         (m) => m.TreatmentBmpUpdateLocationComponent
                     ),
+                canActivate: [TreatmentBmpEditAccessGuard],
                 canDeactivate: [UnsavedChangesGuard],
             },
             {
@@ -478,6 +482,7 @@ export const routes: Routes = [
                     import("./pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-update-custom-attributes/treatment-bmp-update-custom-attributes.component").then(
                         (m) => m.TreatmentBmpUpdateCustomAttributesComponent
                     ),
+                canActivate: [TreatmentBmpEditAccessGuard],
                 canDeactivate: [UnsavedChangesGuard],
             },
             {

--- a/Neptune.Web/src/app/shared/guards/treatment-bmp-edit-access.guard.ts
+++ b/Neptune.Web/src/app/shared/guards/treatment-bmp-edit-access.guard.ts
@@ -29,8 +29,11 @@ export class TreatmentBmpEditAccessGuard {
     ) {}
 
     canActivate(next: ActivatedRouteSnapshot): Observable<boolean> | boolean {
-        const treatmentBMPID = Number(next.paramMap.get("treatmentBMPID"));
-        if (!Number.isFinite(treatmentBMPID)) {
+        // Number(null) === 0, so check the raw param and require a positive integer ID —
+        // otherwise a missing/malformed param would fire a pointless API call for ID 0.
+        const rawTreatmentBMPID = next.paramMap.get("treatmentBMPID");
+        const treatmentBMPID = Number(rawTreatmentBMPID);
+        if (!rawTreatmentBMPID || !Number.isInteger(treatmentBMPID) || treatmentBMPID <= 0) {
             return true; // malformed URL: let routing/component handle it
         }
 

--- a/Neptune.Web/src/app/shared/guards/treatment-bmp-edit-access.guard.ts
+++ b/Neptune.Web/src/app/shared/guards/treatment-bmp-edit-access.guard.ts
@@ -1,0 +1,54 @@
+import { Injectable } from "@angular/core";
+import { ActivatedRouteSnapshot, Router } from "@angular/router";
+import { Observable, of } from "rxjs";
+import { catchError, map } from "rxjs/operators";
+import { TreatmentBMPService } from "src/app/shared/generated/api/treatment-bmp.service";
+import { AlertService } from "src/app/shared/services/alert.service";
+import { Alert } from "src/app/shared/models/alert";
+import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
+
+/**
+ * NPT-1104: the routed Treatment BMP editors (edit-basic-info / edit-location /
+ * edit-custom-attributes / edit-images) had no canActivate guard, so a user without edit
+ * rights (e.g. a JurisdictionEditor for a different jurisdiction, arriving via bookmark or
+ * direct URL — the detail page hides the buttons) could open the editor, fill in the form,
+ * and only discover on save that they lack permission. Check the server-computed
+ * CurrentPersonCanEdit up front and bounce back to the detail page with a clear alert.
+ *
+ * On an API error the guard lets navigation proceed — the server-side
+ * [TreatmentBMPEditFeature] gates remain the real enforcement on save.
+ */
+@Injectable({
+    providedIn: "root",
+})
+export class TreatmentBmpEditAccessGuard {
+    constructor(
+        private treatmentBMPService: TreatmentBMPService,
+        private router: Router,
+        private alertService: AlertService
+    ) {}
+
+    canActivate(next: ActivatedRouteSnapshot): Observable<boolean> | boolean {
+        const treatmentBMPID = Number(next.paramMap.get("treatmentBMPID"));
+        if (!Number.isFinite(treatmentBMPID)) {
+            return true; // malformed URL: let routing/component handle it
+        }
+
+        return this.treatmentBMPService.getByIDTreatmentBMP(treatmentBMPID).pipe(
+            map((treatmentBMP) => {
+                if (treatmentBMP?.CurrentPersonCanEdit) {
+                    return true;
+                }
+                // Post-navigation alert pattern: push after the redirect completes so the
+                // destination's AlertDisplayComponent renders it (matches returnUnauthorized).
+                this.router.navigate(["/treatment-bmps", treatmentBMPID]).then(() => {
+                    this.alertService.pushAlert(
+                        new Alert("You do not have permission to edit this Treatment BMP.", AlertContext.Warning)
+                    );
+                });
+                return false;
+            }),
+            catchError(() => of(true))
+        );
+    }
+}

--- a/Neptune.Web/src/app/shared/interceptors/httpErrorInterceptor.ts
+++ b/Neptune.Web/src/app/shared/interceptors/httpErrorInterceptor.ts
@@ -68,11 +68,19 @@ export class HttpErrorInterceptor implements HttpInterceptor {
                             });
                         }
                         if (error.status == 403) {
-                            this.router.navigateByUrl("/subscription-insufficient", { replaceUrl: false }).then((x) => {
-                                if (typeof error.error === "string") {
-                                    this.alertService.pushAlert(new Alert(error.error, AlertContext.Danger));
-                                }
-                            });
+                            // NPT-1104: a 403 on a mutation (save/delete) should not eject the user from
+                            // the page they are on — surface it inline like a validation failure instead.
+                            // Page-level data denials (GETs) keep the hard redirect.
+                            if (request.method !== "GET") {
+                                const message = typeof error.error === "string" && error.error ? error.error : "You are not authorized to perform this action.";
+                                this.alertService.pushAlert(new Alert(message, AlertContext.Danger));
+                            } else {
+                                this.router.navigateByUrl("/subscription-insufficient", { replaceUrl: false }).then((x) => {
+                                    if (typeof error.error === "string") {
+                                        this.alertService.pushAlert(new Alert(error.error, AlertContext.Danger));
+                                    }
+                                });
+                            }
                         }
                         if (error.status == 404) {
                             // Bare 404s from EntityNotFoundMiddleware have no response body, so


### PR DESCRIPTION
Rework for [NPT-1104](https://sitkatech.atlassian.net/browse/NPT-1104) (KE 7/9 red AC item: impersonated JE works, real JE login bounced to "not authorized").

## Why impersonation couldn't catch this — fixed

`BaseAuthorizationAttribute` evaluated the **authenticated** user while the UI/`CallingUser` wore the **impersonated** identity: an admin impersonating a JE rendered the JE's buttons but passed every API gate as admin. Authorization failures were structurally invisible under impersonation.

- Gates now evaluate the **effective (impersonated) user** via `ImpersonationService.GetEffectivePerson` (loads with the `StormwaterJurisdictionPeople` the jurisdiction checks need)
- `ImpersonateUserFeature`/`StopImpersonationFeature` override `EvaluateAuthenticatedUserOnly` — start/stop always authorize the real admin (you must be able to stop impersonating while wearing a Viewer identity)
- **Production behavior unchanged** — impersonation no-ops in prod
- 5 tests pin the carve-outs and environment short-circuits

## 403 UX

A 403 on a **mutation** now surfaces as an inline danger alert (like a validation failure) instead of hard-redirecting to `/subscription-insufficient` mid-workflow. GETs (page-level data denials) keep the redirect.

## Editor access guard

The four routed BMP editors had no `canActivate` — their loads are anonymous-allowed, so a non-assigned user via bookmark/direct URL could open an editor, fill the form, and only fail on save. New `TreatmentBmpEditAccessGuard` checks the server-computed `CurrentPersonCanEdit` up front and bounces to the detail page with a clear alert. Fails open on API errors; server-side gates remain the enforcement.

## The reported bounce itself

Traced every request from all six edit surfaces: an **assigned** JE/JM passes everything. The reported experience is producible by a role-changed-but-unassigned account (role ≠ jurisdiction assignment) and/or post-login returning to the manager-only /dashboard — retest steps + assignment-check SQL on the Jira card.

## Testing

- `dotnet build` clean; 5 new tests + existing 7 authorization tests green; SPA typechecks clean
- Verified locally by Ray: direct-URL editor access bounces correctly; impersonated JE saving an out-of-jurisdiction BMP gets the inline alert (previously silent success); stop-impersonation works; normal editing unaffected