### PR TITLE
NPT-1104: Unblock JE/JM edit flows - relax reference-list gates

### DIFF
--- a/Neptune.API/Controllers/FundingSourceController.cs
+++ b/Neptune.API/Controllers/FundingSourceController.cs
@@ -20,7 +20,9 @@ namespace Neptune.API.Controllers
         : SitkaController<FundingSourceController>(dbContext, logger, neptuneConfiguration)
     {
         [HttpGet]
-        [AdminFeature]
+        // NPT-1104: reference list consumed by JE/JM-facing flows (BMP Edit Basics owner-org dropdown /
+        // funding-event modal / BMP create / project basics) - AdminFeature 403d those flows on open.
+        [JurisdictionEditFeature]
         public async Task<ActionResult<IEnumerable<FundingSourceDto>>> List()
         {
             var sources = await FundingSources.ListAsDtoAsync(DbContext);

--- a/Neptune.API/Controllers/OrganizationController.cs
+++ b/Neptune.API/Controllers/OrganizationController.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -17,7 +17,9 @@ public class OrganizationController(NeptuneDbContext dbContext, ILogger<Organiza
     : SitkaController<OrganizationController>(dbContext, logger, neptuneConfiguration)
 {
     [HttpGet]
-    [AdminFeature]
+    // NPT-1104: reference list consumed by JE/JM-facing flows (BMP Edit Basics owner-org dropdown /
+    // funding-event modal / BMP create / project basics) — AdminFeature 403'd those flows on open.
+    [JurisdictionEditFeature]
     public async Task<ActionResult<List<OrganizationDto>>> List()
     {
         var organizations = await Organizations.ListAsDtoAsync(DbContext);

--- a/Neptune.Tests/ReferenceListAuthorizationTests.cs
+++ b/Neptune.Tests/ReferenceListAuthorizationTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.API.Controllers;
+using Neptune.API.Services.Authorization;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1104 round 2: JE/JM-facing edit flows load reference lists on open (owner-organization
+    /// dropdown in Edit Basic Info, funding sources in the funding-event modal, BMP create, project
+    /// basics). Those list GETs were [AdminFeature], which 403'd JurisdictionEditors AND
+    /// JurisdictionManagers the moment they opened the editor — the round-1 audit covered the write
+    /// endpoints but missed the ancillary lookup loads. Pin the corrected gates so this regression
+    /// class can't silently return.
+    /// </summary>
+    [TestClass]
+    public class ReferenceListAuthorizationTests
+    {
+        private static MethodInfo GetListMethod(System.Type controllerType)
+        {
+            var method = controllerType.GetMethod("List", BindingFlags.Public | BindingFlags.Instance);
+            Assert.IsNotNull(method, $"Expected List() on {controllerType.Name}.");
+            return method!;
+        }
+
+        [TestMethod]
+        public void OrganizationList_IsReachableByJurisdictionEditorsAndManagers()
+        {
+            var method = GetListMethod(typeof(OrganizationController));
+            Assert.IsTrue(method.GetCustomAttributes(typeof(JurisdictionEditFeature), true).Any(),
+                "GET /organizations must be [JurisdictionEditFeature] — the BMP Edit Basic Info owner-organization dropdown, BMP create, and project basics all load it for JE/JM users.");
+            Assert.IsFalse(method.GetCustomAttributes(typeof(AdminFeature), true).Any(),
+                "GET /organizations must not be [AdminFeature] — that 403'd JE/JM edit flows on open.");
+        }
+
+        [TestMethod]
+        public void FundingSourceList_IsReachableByJurisdictionEditorsAndManagers()
+        {
+            var method = GetListMethod(typeof(FundingSourceController));
+            Assert.IsTrue(method.GetCustomAttributes(typeof(JurisdictionEditFeature), true).Any(),
+                "GET /funding-sources must be [JurisdictionEditFeature] — the funding-event modal loads it for JE/JM users.");
+            Assert.IsFalse(method.GetCustomAttributes(typeof(AdminFeature), true).Any(),
+                "GET /funding-sources must not be [AdminFeature] — that 403'd the JE/JM funding modal on open.");
+        }
+    }
+}


### PR DESCRIPTION
Round-2 rework (KE 1:50PM retest): 'Edit Basics and Edit Funding Sources is still insufficient permissions for JE and JM' while every other edit surface worked. Root cause: both surfaces load an [AdminFeature]-gated reference list on open - GET /organizations (owner-organization dropdown in Edit Basic Info) and GET /funding-sources (funding-event modal) - which 403'd both roles before they could do anything. The round-1 audit covered the write endpoints; these ancillary lookup loads were the miss.

Both List() endpoints move to [JurisdictionEditFeature] (Admin/SitkaAdmin/ JM/JE role check): least privilege that unblocks the flows; reference data only (names + IDs); every other endpoint on both controllers keeps its admin gate. Also repairs BMP create and planning project-basics, which load the same organization list and were broken identically for JE/JM.

Swept the remaining manager+-gated GETs for JE/JM-reachable consumers: HRU/LGU lists back admin utility pages with no JE-facing entry point; the county-gis refresh buttons are admin-disabled POSTs. No further gate changes needed.

2 reflection tests pin the corrected gates.