### PR TITLE
NPT-1104: Relax the WQMP display-dtos gate - round-2 sweep miss

### DIFF
--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -74,7 +74,9 @@ namespace Neptune.API.Controllers
         }
 
         [HttpGet("display-dtos")]
-        [AdminFeature]
+        // NPT-1104: reference list consumed by JE/JM-facing flows (BMP Edit Basics WQMP dropdown /
+        // BMP create) — AdminFeature 403'd those flows on open.
+        [JurisdictionEditFeature]
         public async Task<ActionResult<List<WaterQualityManagementPlanDisplayDto>>> ListAsDisplayDtos()
         {
             var plans = await WaterQualityManagementPlans.ListAsDisplayDtoAsync(DbContext);

--- a/Neptune.Tests/ReferenceListAuthorizationTests.cs
+++ b/Neptune.Tests/ReferenceListAuthorizationTests.cs
@@ -43,5 +43,17 @@ namespace Neptune.Tests
             Assert.IsFalse(method.GetCustomAttributes(typeof(AdminFeature), true).Any(),
                 "GET /funding-sources must not be [AdminFeature] — that 403'd the JE/JM funding modal on open.");
         }
+
+        [TestMethod]
+        public void WaterQualityManagementPlanDisplayDtos_IsReachableByJurisdictionEditorsAndManagers()
+        {
+            var method = typeof(WaterQualityManagementPlanController)
+                .GetMethod("ListAsDisplayDtos", BindingFlags.Public | BindingFlags.Instance);
+            Assert.IsNotNull(method, "Expected ListAsDisplayDtos() on WaterQualityManagementPlanController.");
+            Assert.IsTrue(method!.GetCustomAttributes(typeof(JurisdictionEditFeature), true).Any(),
+                "GET /water-quality-management-plans/display-dtos must be [JurisdictionEditFeature] — the BMP Edit Basic Info WQMP dropdown and BMP create load it for JE/JM users.");
+            Assert.IsFalse(method.GetCustomAttributes(typeof(AdminFeature), true).Any(),
+                "GET /water-quality-management-plans/display-dtos must not be [AdminFeature] — that 403'd the JE/JM Edit Basics flow on open.");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Round-3 rework: a JurisdictionManager still hit **Insufficient Permissions** opening Edit Basics on a BMP in their own jurisdiction.

**Root cause:** Edit Basic Info loads a *third* reference list on open — `GET /water-quality-management-plans/display-dtos` for the WQMP dropdown — and it was still `[AdminFeature]`. The HTTP error interceptor hard-redirects on any GET 403, so JE/JM users were ejected before the editor rendered. BMP create loads the same list and was broken identically. The round-2 sweep missed it because the component invokes it as a multiline chained call, which the single-line grep didn't match.

## Changes

- `WaterQualityManagementPlanController.ListAsDisplayDtos()` moves `[AdminFeature]` → `[JurisdictionEditFeature]`, matching the round-2 organization/funding-source changes. Display DTOs are names + IDs only; every other endpoint on the controller keeps its gate.
- Third reflection test in `ReferenceListAuthorizationTests` pins the corrected gate.

## Verification

- Re-swept every lookup the JE/JM-reachable BMP editors load (BMP types, jurisdictions, custom attribute types, upstream-BMP list, funding source groups) — all `[AllowAnonymous]`, `[UserViewFeature]`, or already `[JurisdictionEditFeature]`. This was the only remaining offender.
- Build clean; all 3 `ReferenceListAuthorizationTests` pass.