### PR TITLE
NPT-1106: Strict tool use on extraction + round-2 Review rework (BMP saved-status, SC 'No' rows)

### DIFF
--- a/Neptune.API/Services/AI/WqmpExtractionService.cs
+++ b/Neptune.API/Services/AI/WqmpExtractionService.cs
@@ -427,16 +427,17 @@ public class WqmpExtractionService
         {
             Name = $"emit_{categoryKey.ToLower()}_extraction",
             Description = $"Emit the extracted {categoryKey} fields as structured JSON matching the required schema.",
-            InputSchema = new()
-            {
-                Properties = parsed?.Where(kvp => kvp.Key == "properties")
-                    .SelectMany(kvp => kvp.Value.EnumerateObject())
-                    .ToDictionary(prop => prop.Name, prop => JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<object>(prop.Value.GetRawText())))
-                    ?? new Dictionary<string, JsonElement>(),
-                Required = parsed != null && parsed.TryGetValue("required", out var req)
-                    ? JsonSerializer.Deserialize<List<string>>(req.GetRawText()) ?? []
-                    : [],
-            },
+            // NPT-1106: strict tool use (GA, no beta header) — the API validates the tool input
+            // against the schema server-side, guaranteeing well-formed JSON that matches it
+            // exactly. Kills the recurring UnwrapItems failure class: `items` emitted as a
+            // double-encoded string with unescaped quotes / trailing commas that no regex
+            // cleanup could reliably repair. Strict requires additionalProperties:false +
+            // required on every object INCLUDING the root, so the schema JSON is passed to
+            // InputSchema wholesale via the raw-data constructor — the previous
+            // Properties/Required-only initializer silently dropped the root-level
+            // additionalProperties:false.
+            Strict = true,
+            InputSchema = new(parsed ?? new Dictionary<string, JsonElement>()),
         };
     }
 

--- a/Neptune.EFModels/Entities/SourceControlBMPs.cs
+++ b/Neptune.EFModels/Entities/SourceControlBMPs.cs
@@ -20,10 +20,16 @@ public static class SourceControlBMPs
     public static async Task<List<SourceControlBMPDto>> ListByWaterQualityManagementPlanIDAsDtoAsync(
         NeptuneDbContext dbContext, int waterQualityManagementPlanID)
     {
+        // NPT-1106 round 2: return every persisted row, including IsPresent=false with no note.
+        // MergeAsync stores explicit "No" answers, but this list used to filter them out —
+        // so the AI-review Step 5 compared a saved "No" against an apparently-empty record
+        // ("Pending Save" forever), and the SC editor prefilled those rows as unset (a
+        // subsequent replace-all save then deleted the persisted "No" via MergeDelete).
+        // Display surfaces that only want affirmative rows (WQMP detail panel, verification
+        // workflow) filter client-side.
         var dtos = await dbContext.SourceControlBMPs
             .AsNoTracking()
             .Where(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID)
-            .Where(x => x.SourceControlBMPNote != null || x.IsPresent == true)
             .OrderBy(x => x.SourceControlBMPAttributeID)
             .Select(SourceControlBMPProjections.AsDto)
             .ToListAsync();

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse } from "@angular/common/http";
 import { Router, RouterLink } from "@angular/router";
 import { DatePipe, AsyncPipe, CommonModule } from "@angular/common";
 import { BehaviorSubject, Observable, of } from "rxjs";
-import { finalize, shareReplay, switchMap, tap } from "rxjs/operators";
+import { finalize, map, shareReplay, switchMap, tap } from "rxjs/operators";
 import { DialogService } from "@ngneat/dialog";
 import { ColDef } from "ag-grid-community";
 import * as L from "leaflet";
@@ -279,6 +279,9 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
         });
 
         this.sourceControlBMPs$ = this.wqmpService.listSourceControlBMPsWaterQualityManagementPlan(this.waterQualityManagementPlanID).pipe(
+            // NPT-1106 round 2: the endpoint now returns explicit "No" rows too (the AI-review
+            // Step 5 needs them); this panel keeps its affirmative-only display.
+            map((bmps) => bmps.filter((b) => b.IsPresent === true || (b.SourceControlBMPNote ?? "").trim().length > 0)),
             tap((bmps) => {
                 const grouped = this.groupByPipe.transform(bmps, "SourceControlBMPAttributeCategoryName");
                 this.sourceControlBMPsByCategory = Object.entries(grouped).map(([category, items]) => ({

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/review-summary/review-summary.component.ts
@@ -47,7 +47,10 @@ export class ReviewSummaryComponent {
     @Input() locationFields: ExtractedField[] = [];
     @Input() basicsFields: ExtractedField[] = [];
     @Input() parcelFields: ExtractedField[] = [];
-    @Input() bmpGroups: { bmpIndex: number; displayName: string | null; fields: ExtractedField[]; isRejected: boolean }[] = [];
+    // NPT-1106 round 2: wqmpRecordValue carries the persisted QuickBMP name (matched by the
+    // backend merge's name key) so BMP rows can reach "Saved" — it was previously hard-coded
+    // null in toRow, which made getSaveStatus() return "pending" for every BMP forever.
+    @Input() bmpGroups: { bmpIndex: number; displayName: string | null; fields: ExtractedField[]; isRejected: boolean; wqmpRecordValue: string | null }[] = [];
     // NPT-1054: flat list of Source Control BMP rows. origin mirrors Step 4's row classifier
     // (getSourceControlRowOrigin) so the AI pill only shows when the displayed value actually
     // came from the AI — not when the user accepted a value that was already on the record.
@@ -126,8 +129,10 @@ export class ReviewSummaryComponent {
                 return {
                     label: `BMP #${g.bmpIndex + 1}`,
                     displayValue: g.isRejected ? "(rejected)" : display,
-                    // BMP rows don't map to a single WQMP-record column — leave blank.
-                    wqmpRecordValue: null,
+                    // NPT-1106 round 2: persisted-QuickBMP match from the parent. A saved BMP
+                    // now compares equal and shows "Saved"; unmatched (unsaved / renamed) rows
+                    // keep the empty record value and show "Pending save".
+                    wqmpRecordValue: g.wqmpRecordValue,
                     state,
                     origin: "ai",
                 };

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -18,6 +18,7 @@ import { WaterQualityManagementPlanExtractionResultDto } from "src/app/shared/ge
 import { WaterQualityManagementPlanDto } from "src/app/shared/generated/model/water-quality-management-plan-dto";
 import { WaterQualityManagementPlanUpsertDto } from "src/app/shared/generated/model/water-quality-management-plan-upsert-dto";
 import { QuickBMPUpsertDto } from "src/app/shared/generated/model/quick-bmp-upsert-dto";
+import { QuickBMPDto } from "src/app/shared/generated/model/quick-bmp-dto";
 import { QuickBMPMergeSkipDto } from "src/app/shared/generated/model/quick-bmp-merge-skip-dto";
 import { WaterQualityManagementPlanSectionSaveResponseDto } from "src/app/shared/generated/model/water-quality-management-plan-section-save-response-dto";
 import { EvidenceBoundingBox, FieldCardComponent, SourceNavigation } from "src/app/pages/wqmps/wqmp-detail/wqmp-review/field-card/field-card.component";
@@ -123,6 +124,13 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     // schedules change detection in this zoneless app — the Step 5 summary getter reads it,
     // and a bare field mutation inside .subscribe() wouldn't repaint until the next click.
     private existingSourceControlByAttributeID = signal(new Map<number, SourceControlBMPDto>());
+    // NPT-1106 round 2: QuickBMPs currently persisted on the WQMP record, keyed by trimmed
+    // QuickBMPName (the same match key the backend merge uses). Drives the "WQMP Record"
+    // column for the Step 5 BMP rows — those rows previously hard-coded wqmpRecordValue to
+    // null, so getSaveStatus() could never return "saved" and every BMP showed "Pending save"
+    // even after a successful section save. Signal for the same zoneless-repaint reason as
+    // existingSourceControlByAttributeID above.
+    private existingQuickBmpNamesByKey = signal(new Map<string, string>());
     public readonly BMP_FIELD_KEYS = [
         "QuickBMPName",
         "TreatmentBMPType",
@@ -328,8 +336,14 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 existingSourceControl: this.wqmpService.listSourceControlBMPsWaterQualityManagementPlan(this.waterQualityManagementPlanID).pipe(
                     catchError(() => of([] as SourceControlBMPDto[]))
                 ),
+                // NPT-1106 round 2: previously-saved QuickBMPs feed the Step 5 Review's
+                // "WQMP Record" column for BMP rows, same as existingSourceControl does for
+                // Source Control rows.
+                existingQuickBmps: this.wqmpService.listQuickBMPsWaterQualityManagementPlan(this.waterQualityManagementPlanID).pipe(
+                    catchError(() => of([] as QuickBMPDto[]))
+                ),
             })),
-            tap(({ extractionResult, wqmp, existingSourceControl }) => {
+            tap(({ extractionResult, wqmp, existingSourceControl, existingQuickBmps }) => {
                 this.currentResult.set(extractionResult);
                 this.liveWqmp.set(wqmp);
                 this.existingSourceControlByAttributeID.set(new Map(
@@ -337,6 +351,7 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                         .filter((e) => e?.SourceControlBMPAttributeID != null)
                         .map((e) => [e.SourceControlBMPAttributeID!, e] as const)
                 ));
+                this.existingQuickBmpNamesByKey.set(WqmpReviewComponent.buildQuickBmpNameMap(existingQuickBmps));
                 if (extractionResult?.ExtractionResultJson) {
                     this.parseExtractionResult(extractionResult.ExtractionResultJson);
                 } else {
@@ -479,7 +494,7 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     get summaryParcelFields(): ExtractedField[] {
         return this.fields().filter((f) => f.key.startsWith(this.PARCEL_KEY_PREFIX));
     }
-    get summaryBmpGroups(): { bmpIndex: number; displayName: string | null; fields: ExtractedField[]; isRejected: boolean }[] {
+    get summaryBmpGroups(): { bmpIndex: number; displayName: string | null; fields: ExtractedField[]; isRejected: boolean; wqmpRecordValue: string | null }[] {
         // Same grouping logic as bmpGroupsForCurrentStep but without the step==3 gate
         // (the summary view runs on Step 4).
         const groups = new Map<number, ExtractedField[]>();
@@ -494,12 +509,20 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
             groups.get(bmpIndex)!.push(field);
         }
         const rejected = this.rejectedBmpIndices();
+        // NPT-1106 round 2: surface the persisted QuickBMP (matched by name — the backend
+        // merge's key) as the row's WQMP Record value so getSaveStatus() can flip the row
+        // to "Saved" once the section save lands. Previously always null → always pending.
+        const persistedNames = this.existingQuickBmpNamesByKey();
         return Array.from(groups.entries())
             .sort(([a], [b]) => a - b)
             .map(([bmpIndex, fields]) => {
                 const nameField = fields.find((f) => f.key.endsWith("-QuickBMPName"));
                 const displayName = (nameField?.acceptedValue ?? nameField?.value) ?? null;
-                return { bmpIndex, displayName, fields, isRejected: rejected.has(bmpIndex) };
+                // Echo the workflow's own string on a trimmed-name match (not the persisted
+                // spelling) so the summary's strict displayValue === wqmpRecordValue equality
+                // can't fail on whitespace-only differences.
+                const wqmpRecordValue = displayName && persistedNames.has(displayName.trim()) ? displayName : null;
+                return { bmpIndex, displayName, fields, isRejected: rejected.has(bmpIndex), wqmpRecordValue };
             });
     }
     /**
@@ -1299,6 +1322,7 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 this.warnAboutSkippedBMPs(response?.SkippedBMPs);
                 this.markBmpFieldsClean();
                 this.refreshLiveWqmp();
+                this.refreshExistingQuickBmps();
             },
             error: (err: HttpErrorResponse) => this.handleSectionSaveError(err, "BMPs"),
         });
@@ -1364,6 +1388,28 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 this.refreshExistingSourceControl();
             },
             error: (err: HttpErrorResponse) => this.handleSectionSaveError(err, "Source Control BMPs"),
+        });
+    }
+
+    // NPT-1106 round 2: key by trimmed name, echo the persisted name — the backend merge
+    // matches QuickBMPs by exact QuickBMPName, so the trim only forgives whitespace the
+    // review form may carry around an otherwise-identical name.
+    private static buildQuickBmpNameMap(quickBmps: QuickBMPDto[] | null | undefined): Map<string, string> {
+        return new Map(
+            (quickBmps ?? [])
+                .filter((b) => (b?.QuickBMPName ?? "").trim().length > 0)
+                .map((b) => [b.QuickBMPName!.trim(), b.QuickBMPName!] as const)
+        );
+    }
+
+    // NPT-1106 round 2: same shape as refreshExistingSourceControl below — after a BMPs
+    // section save, rebuild the persisted-QuickBMP name map so the Step 5 rows flip to
+    // "Saved" against the freshly persisted records.
+    private refreshExistingQuickBmps(): void {
+        this.wqmpService.listQuickBMPsWaterQualityManagementPlan(this.waterQualityManagementPlanID).pipe(
+            catchError(() => of([] as QuickBMPDto[])),
+        ).subscribe((quickBmps) => {
+            this.existingQuickBmpNamesByKey.set(WqmpReviewComponent.buildQuickBmpNameMap(quickBmps));
         });
     }
 

--- a/Neptune.Web/src/app/shared/services/wqmp-verification-workflow.service.ts
+++ b/Neptune.Web/src/app/shared/services/wqmp-verification-workflow.service.ts
@@ -204,7 +204,13 @@ export class WqmpVerificationWorkflowService {
                     };
                 }));
 
-                this.sourceControlRows.set(sourceControlBMPs.map((bmp: any) => {
+                // NPT-1106 round 2: the list endpoint now returns explicit "No" rows (needed by
+                // the AI-review Step 5); the verification checklist keeps its affirmative-only
+                // scope — verifiers assess controls that are on the record, not absent ones.
+                const affirmativeSourceControlBMPs = sourceControlBMPs.filter(
+                    (bmp: any) => bmp.IsPresent === true || ((bmp.SourceControlBMPNote ?? "") as string).trim().length > 0
+                );
+                this.sourceControlRows.set(affirmativeSourceControlBMPs.map((bmp: any) => {
                     const existing = verify?.SourceControlBMPs?.find((v: any) => v.SourceControlBMPID === bmp.SourceControlBMPID);
                     return {
                         sourceControlBMPID: bmp.SourceControlBMPID,


### PR DESCRIPTION
Two NPT-1106 fixes, one per commit.

## Commit 1 — Strict tool use on WQMP extraction (backend)

Extraction intermittently failed with `JsonReaderException: 'N' is invalid after a value` in `UnwrapItems` — Claude emitting `items` as a JSON-encoded **string** whose escaping comes back corrupted on long outputs. Regex cleanup can't repair unescaped inner quotes, and the one-shot retry sometimes reproduces it.

**Fix:** strict tool use (GA, no beta header) on all four category tools in `WqmpExtractionService` — the API validates tool input server-side against the schema, guaranteeing well-formed JSON that matches it exactly. `InputSchema` is now built from the full schema JSON via the SDK raw-data constructor (strict requires `additionalProperties: false` on the **root** object too; the old `Properties`/`Required`-only initializer silently dropped it). `UnwrapItems` repair/retry stays as defense in depth. First call per schema pays a one-time compilation cost (cached 24h).

## Commit 2 — Round-2 Review rework (KE 7/9 retest red items)

**Treatment BMPs** ("unsaved changes warning immediately after saving some BMPs"): Step 5 BMP rows could **never** show "Saved" — the summary hard-coded `wqmpRecordValue: null`, and `getSaveStatus()` returns "pending" whenever the workflow value is non-empty and the record value is empty. The wizard now fetches the WQMP's persisted QuickBMPs (initial load + after every BMPs save; signal-backed for zoneless repaint, mirroring the SC pattern), matches each summary row by name — the backend merge's own key — and echoes the workflow's string on a trimmed match so strict equality can't fail on whitespace.

**Source Controls** (manual "No" + save → still "Pending save"): the "No" **was persisting** (`MergeAsync` stores `IsPresent = false`), but `ListByWaterQualityManagementPlanIDAsDtoAsync` filtered out `IsPresent == false` rows with no note, so the refreshed comparison map never saw it. The same filter also made the SC **editor** prefill saved "No" rows as unset — and since the merge has a delete pass, re-saving from the editor silently **deleted** persisted "No" answers (latent data-loss bug). The list endpoint now returns every persisted row; the WQMP detail panel and verification workflow filter client-side to keep their affirmative-only display.

No endpoint-shape changes — no codegen needed.

## Retest

1. Extraction → edit + save each section → Step 5: BMP rows show "Saved" with the name in the WQMP Record column.
2. SC: manually click "No" (no note) → save → row shows "No / No / Saved"; revisit the wizard and confirm the "No" prefills.
3. Confirm the WQMP detail SC panel and a verification workflow run look unchanged (affirmative rows only).
4. Re-run an AI extraction end-to-end to exercise strict tool use (watch for any 400 naming a schema construct on the first call).