### PR TITLE
NPT-1105: Bump OverlayAPI memory limit 4Gi -> 8Gi

### DIFF
--- a/charts/neptune/values.yaml
+++ b/charts/neptune/values.yaml
@@ -293,7 +293,12 @@ overlayapi:
   nameOverride: ""
   fullnameOverride: ""
   namespace: h2o
-  # Sized from measured NPT-1105 NTS-port numbers: full TGU refresh peaks ~1.6-2.5 GiB working set.
+  # The 4Gi limit sized from pre-merge NPT-1105 benchmarks (~1.6-2.5 GiB peak) OOMKilled the pod
+  # (exit 137) ~7 min into the first QA-scale full TGU refresh on 2026-07-09 — QA data is heavier
+  # than the benchmark set, and working set scales with the parallel layer union's fan-out across
+  # every node core. 8Gi unblocks the soak; capture the Datadog peak-memory curve on the next
+  # nightly run to right-size, and consider bounding the union's degree of parallelism in code so
+  # memory is bounded regardless of node size.
   # No CPU limit on purpose: the parallel layer union deliberately saturates the node's cores for
   # the few minutes a full refresh runs.
   resources:
@@ -301,7 +306,7 @@ overlayapi:
       memory: "1Gi"
       cpu: "250m"
     limits:
-      memory: "4Gi"
+      memory: "8Gi"
   serviceAccount:
     # Specifies whether a service account should be created
     create: true


### PR DESCRIPTION
First QA-scale full TGU refresh (nightly 22:30, 7/9) **OOMKilled the overlayapi pod** — exit 137 at 22:37:52, exactly when `OverlayAPIService.GenerateTGUs` saw "response ended prematurely" and Hangfire job 165484 failed. Trash Module stayed at Last Calculated 7/8.

The 4Gi limit came from pre-merge benchmarks (~1.6–2.5 GiB peak, ~3:50 runtime); the QA run was still going at ~7 min when it hit the limit — QA data is heavier, and the parallel layer union's working set scales with the node's core count (CPU deliberately uncapped).

## Change

`overlayapi.resources.limits.memory`: 4Gi → 8Gi in `charts/neptune/values.yaml` (request unchanged at 1Gi).

## Verification / follow-up

- After deploy, re-trigger the TGU refresh from Hangfire and confirm completion; watch the Datadog memory curve (`DD_ENV: qa`, service `neptune-overlayapi`) to right-size the limit.
- Candidate code fix if 8Gi is still tight: bound the layer union's degree of parallelism so memory is bounded regardless of node size.