### PR TITLE
NPT-1105: Unblock QA release - drop rotted Apache Arrow apt repo from GDALAPI image

### DIFF
--- a/Neptune.GDALAPI/Dockerfile
+++ b/Neptune.GDALAPI/Dockerfile
@@ -7,7 +7,13 @@ EXPOSE 80
 # Install ASP.NET Core 10.0 runtime via Microsoft's dotnet-install script.
 # Avoids the dotnet/backports PPA (which requires reaching launchpad.net at build
 # time and was timing out from the QA build agent).
-RUN apt-get update && \
+# The base image ships the Apache Arrow apt repo (parquet support); its upstream
+# signing key rotated (NO_PUBKEY 9E922B2D60E9FD1C, 2026-07-10 QA build failure),
+# which fails ALL apt-get update runs. The arrow libs are already baked into the
+# image — we never apt-install from that repo — so drop its source entry rather
+# than chase the new key.
+RUN rm -f /etc/apt/sources.list.d/apache-arrow.sources /etc/apt/sources.list.d/*arrow*.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates && \
     rm -rf /var/lib/apt/lists/* && \
     wget -O /tmp/dotnet-install.sh https://dot.net/v1/dotnet-install.sh && \


### PR DESCRIPTION
The 2026-07-10 QA release failed in the `neptune_gdalapi` image build: the `osgeo/gdal:ubuntu-full-3.8.5` base ships the Apache Arrow apt repo (parquet support is baked into the image at *its* build time), and Arrow rotated the repo's signing key upstream (`NO_PUBKEY 9E922B2D60E9FD1C`). That fails **every** `apt-get update` in derived images before it reaches the Ubuntu archives we actually need for `wget`/`ca-certificates`.

## Fix

Remove the Arrow source entry before `apt-get update` — we never apt-install from that repo (the arrow libs are already in the image), so there's no reason to chase the new key:

```dockerfile
RUN rm -f /etc/apt/sources.list.d/apache-arrow.sources /etc/apt/sources.list.d/*arrow*.list &&     apt-get update && ...
```

## Verification

Local `docker build --no-cache --target base` completes: apt-get update clean (no GPG error), ASP.NET Core 10.0.9 runtime installed. Only `Neptune.GDALAPI/Dockerfile` uses the osgeo/gdal base — no other image affected.

Re-run the failed QA release after merge; this unblocks the #610 OverlayAPI memory-limit deploy.