### PR TITLE
NPT-1105: Free agent disk space before the Build API docker job

### DIFF
--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -105,6 +105,20 @@ stages:
     - checkout: self
       fetchDepth: 0
 
+    # This job builds three images (api, externalapi, gdalapi — the osgeo-based gdalapi alone is
+    # ~1.5GB) and the Defender scan then extracts their layers, pushing the hosted agent's small
+    # / disk past 95%. Reclaim space up front by removing preinstalled toolsets this job never
+    # uses (same fix as psinfo's build). NPT-1107 (gdalapi image rebase) will shrink the worst
+    # offender at the source.
+    - bash: |
+        echo "Disk before cleanup:"; df -h /
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /opt/ghc /usr/local/.ghcup || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        docker builder prune -af || true
+        echo "Disk after cleanup:"; df -h /
+      displayName: 'Free up agent disk space'
+
     - task: AzureKeyVault@2
       inputs:
         azureSubscription: "$(azureSubscription)"


### PR DESCRIPTION
The hosted agent warns **"Free disk space on / is lower than 5%; Currently used: 95.13%"** during Build API → Defender scan of `neptune/gdalapi`. The job builds three images (the osgeo-based gdalapi alone is ~1.5GB) and the Defender scan extracts their layers on top, cresting the agent's small `/` disk.

## Change

Add the same up-front cleanup step psinfo's pipeline uses, immediately after checkout in the BuildAPI job: remove preinstalled toolsets the job never touches (Android SDK, GHC, CodeQL — ~15GB combined) and `docker builder prune`, with `df -h /` logged before/after so the reclaim is visible in the build log.

## Notes

- Targeted at BuildAPI only (where the warning fires); BuildWeb/BuildOverlayApi build single small images. Easy to replicate if they ever warn.
- NPT-1107 (gdalapi image rebase off `osgeo/gdal:ubuntu-full`) shrinks the worst offender at the source; this keeps builds comfortable in the meantime.
- Verification: next pipeline run's "Free up agent disk space" step shows the before/after df output, and the low-disk warning should be gone.