### PR TITLE
NPT-1105: Fix liveness-kill of OverlayAPI during full TGU refresh

### DIFF
--- a/Neptune.OverlayAPI/Services/Overlay/OverlayEngine.cs
+++ b/Neptune.OverlayAPI/Services/Overlay/OverlayEngine.cs
@@ -30,10 +30,10 @@ public static class OverlayEngine
 
     // Leave one core free for Kestrel. Unbounded Parallel.ForEach saturated every thread-pool
     // worker with long CPU-bound iterations for the entire multi-minute run, so the pod's
-    // health endpoints couldn't get a thread — the kubelet liveness probe timed out 8+ times
-    // in a row and SIGKILLed the container mid-refresh (QA nightly TGU, 2026-07-09 and -10;
-    // the API sees it as "response ended prematurely"). Costs ~1/8 of throughput on the QA
-    // nodes; keeps the pod responsive to probes and concurrent overlay calls.
+    // health endpoints couldn't get a thread — the kubelet liveness probe timed out repeatedly
+    // and SIGKILLed the container mid-refresh (QA nightly TGU, 2026-07-09 and -10; the API
+    // sees it as "response ended prematurely"). Costs ~1/8 of throughput on the QA nodes;
+    // keeps the pod responsive to probes and concurrent overlay calls.
     private static readonly ParallelOptions ParallelOpts = new()
     {
         MaxDegreeOfParallelism = Math.Max(1, Environment.ProcessorCount - 1),

--- a/Neptune.OverlayAPI/Services/Overlay/OverlayEngine.cs
+++ b/Neptune.OverlayAPI/Services/Overlay/OverlayEngine.cs
@@ -28,6 +28,17 @@ public static class OverlayEngine
         new PrecisionModel(), Neptune.Common.GeoSpatial.Proj4NetHelper.NAD_83_HARN_CA_ZONE_VI_SRID,
         PackedCoordinateSequenceFactory.DoubleFactory);
 
+    // Leave one core free for Kestrel. Unbounded Parallel.ForEach saturated every thread-pool
+    // worker with long CPU-bound iterations for the entire multi-minute run, so the pod's
+    // health endpoints couldn't get a thread — the kubelet liveness probe timed out 8+ times
+    // in a row and SIGKILLed the container mid-refresh (QA nightly TGU, 2026-07-09 and -10;
+    // the API sees it as "response ended prematurely"). Costs ~1/8 of throughput on the QA
+    // nodes; keeps the pod responsive to probes and concurrent overlay calls.
+    private static readonly ParallelOptions ParallelOpts = new()
+    {
+        MaxDegreeOfParallelism = Math.Max(1, Environment.ProcessorCount - 1),
+    };
+
     /// <summary>
     /// Make valid + buffer(0) + force polygonal/2D. Replaces the QGIS bufferSnapFix pipeline.
     /// Features whose geometry cleans to empty are dropped.
@@ -124,7 +135,7 @@ public static class OverlayEngine
         var results = new ConcurrentBag<OverlayFeature>();
         var bIntersectorGeometries = new ConcurrentDictionary<int, ConcurrentBag<Geometry>>();
 
-        Parallel.ForEach(layerA, a =>
+        Parallel.ForEach(layerA, ParallelOpts, a =>
         {
             var prepared = PreparedGeometryFactory.Prepare(a.Geometry);
             var hits = new List<int>();
@@ -189,7 +200,7 @@ public static class OverlayEngine
     {
         var prepared = PreparedGeometryFactory.Prepare(clipBoundary);
         var results = new ConcurrentBag<OverlayFeature>();
-        Parallel.ForEach(layer, feature =>
+        Parallel.ForEach(layer, ParallelOpts, feature =>
         {
             if (!prepared.Intersects(feature.Geometry)) return;
             if (prepared.Contains(feature.Geometry))

--- a/charts/neptune/charts/neptune-overlayapi/templates/deployment.yaml
+++ b/charts/neptune/charts/neptune-overlayapi/templates/deployment.yaml
@@ -49,8 +49,13 @@ spec:
               protocol: TCP
           # Deliberately lenient probes: the parallel NTS union saturates the pod's cores for the few
           # minutes a full overlay refresh runs, so slow probe responses are expected mid-run.
-          # failureThreshold 8 x 15s = ~2 min of consecutive failures before a restart — a liveness restart
-          # kills the in-flight refresh, so we only want it for a genuinely wedged pod.
+          # The original 8 x 15s (~2 min) tolerance was NOT lenient enough — the 7/9 and 7/10 QA
+          # nightly TGU refreshes starved Kestrel for the whole ~8-min run and kubelet SIGKILLed the
+          # pod mid-job (the API saw "response ended prematurely"). OverlayEngine now caps its
+          # parallelism at cores-1 so probes should answer; this 40 x 15s (~10 min) threshold is
+          # belt-and-braces so a saturated-but-healthy run can never be mistaken for a wedged pod.
+          # The cost: a genuinely wedged pod takes up to 10 min to restart — acceptable for an
+          # internal batch service.
           livenessProbe:
             httpGet:
               path: /
@@ -58,7 +63,7 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 10
-            failureThreshold: 8
+            failureThreshold: 40
           readinessProbe:
             httpGet:
               path: /

--- a/charts/neptune/values.yaml
+++ b/charts/neptune/values.yaml
@@ -293,18 +293,18 @@ overlayapi:
   nameOverride: ""
   fullnameOverride: ""
   namespace: h2o
-  # The 4Gi limit sized from pre-merge NPT-1105 benchmarks (~1.6-2.5 GiB peak) OOMKilled the pod
-  # (exit 137) ~7 min into the first QA-scale full TGU refresh on 2026-07-09 — QA data is heavier
-  # than the benchmark set, and working set scales with the parallel layer union's fan-out across
-  # every node core. 8Gi unblocks the soak; capture the Datadog peak-memory curve on the next
-  # nightly run to right-size, and consider bounding the union's degree of parallelism in code so
-  # memory is bounded regardless of node size.
-  # No CPU limit on purpose: the parallel layer union deliberately saturates the node's cores for
-  # the few minutes a full refresh runs.
+  # 2026-07-10 postmortem: the 7/9 and 7/10 exit-137 kills were the kubelet LIVENESS probe (thread
+  # pool starved by the then-unbounded parallel union — see OverlayEngine.ParallelOpts), not OOM;
+  # observed memory peak was well under 1Gi on the full QA TGU refresh. Keeping the 8Gi limit as
+  # headroom anyway. CPU request raised 250m -> 2000m: with no CPU limit the pod bursts to ~6.4
+  # cores on the 8-core QA nodes, and a 250m request gave it almost no CFS share under node
+  # contention (daytime delta solves would crawl) and understated scheduling needs.
+  # No CPU limit on purpose: the parallel layer union deliberately saturates cores-1 for the few
+  # minutes a full refresh runs.
   resources:
     requests:
       memory: "1Gi"
-      cpu: "250m"
+      cpu: "2000m"
     limits:
       memory: "8Gi"
   serviceAccount:


### PR DESCRIPTION
## Postmortem correction

The 7/9 and 7/10 QA nightly TGU failures (exit 137, API sees `response ended prematurely`) were **not OOM** — kubelet events show `Killing: Container overlayapi failed liveness probe`. The unbounded `Parallel.ForEach` in `OverlayEngine` saturated every thread-pool worker with long CPU-bound geometry ops for the entire ~8-minute run, so Kestrel couldn't get a thread to answer the probe (`timeout awaiting headers` ×13), and kubelet SIGKILLed the container mid-job. Memory peaked well under 1Gi both nights; #610's 4Gi→8Gi bump treated the wrong suspect (kept as headroom).

## Three layers

1. **Root cause — `OverlayEngine.cs`:** shared `ParallelOptions` capping `MaxDegreeOfParallelism` at `ProcessorCount − 1` on both `Parallel.ForEach` sites, leaving a core for Kestrel so probes and concurrent overlay calls stay serviceable. ~1/8 throughput cost on the 8-core QA nodes. All 16 `OverlayEngineTests` pass — scheduling change only, identical results.
2. **Belt-and-braces — liveness probe:** `failureThreshold` 8 → 40 (~10 min), so tolerance exceeds a full refresh and a saturated-but-healthy run can't be mistaken for a wedged pod. A genuinely wedged pod now takes up to 10 min to recycle — acceptable for an internal batch service.
3. **Honest scheduling — `values.yaml`:** CPU request 250m → 2000m (pod bursts to ~6.4 cores; 250m gave it almost no CFS share under node contention). Comment updated from the OOM theory to the actual postmortem.

Note: the first commit accidentally rewrote OverlayEngine.cs line endings (LF); the second commit restores CRLF — the **Files changed** view shows the true ~30-line net diff.

## Verification after deploy

Re-trigger "TGU Refresh" from Hangfire: job completes, pod stays `1/1 Ready` throughout the run (no Unhealthy events, restart count stays 0), Trash Module Last Calculated flips to today.