### PR TITLE
Document JurisdictionEditor vs JurisdictionManager permission boundary

### DIFF
--- a/.claude/skills/create-story/SKILL.md
+++ b/.claude/skills/create-story/SKILL.md
@@ -40,7 +40,7 @@ After you have the initial context (either from an existing card, the user's des
 - **Scope**: What specific behaviors or screens are involved? What is explicitly out of scope?
 - **Acceptance criteria**: What are the testable conditions for "done"? Walk through user flows and edge cases.
 - **Data model**: Are there new entities, fields, lookup tables, or relationships?
-- **Permissions/roles**: Does this feature have role-based access differences?
+- **Permissions/roles**: Does this feature have role-based access differences? If the feature involves any action gated to JurisdictionManager, flag it — JurisdictionEditors should have access to almost everything Managers can. The only Manager-only exceptions are (1) deleting primary records (WQMPs, BMPs, verifications) and (2) attestation/verification actions (marking BMPs verified, promoting WQMP status). If a draft requirement restricts Editors from anything outside those two categories, call it out and ask if that's intentional.
 - **UI/UX**: Any wireframes, Figma links, or specific UI patterns to follow? Which existing page/component is this most similar to?
 - **Dependencies**: Does this depend on or block other work?
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,12 @@ Custom `BaseAuthorizationAttribute` (implements `IAuthorizationFilter`). Derived
 
 Roles: Admin(1), SitkaAdmin(2), JurisdictionManager(3), JurisdictionEditor(4), Unassigned(5), Viewer(6), ExternalViewer(7).
 
+**JurisdictionEditor vs JurisdictionManager:** The two roles are nearly identical — both operate within their assigned jurisdiction. Editors should be able to do almost everything Managers can. The narrow exceptions where Manager-only (`[JurisdictionManageFeature]`) is correct:
+- **Deleting primary records** — WQMPs, BMPs, verifications
+- **Attestation/verification actions** — marking BMPs as verified, promoting a WQMP from Draft to Active
+
+Everything else — CRUD on supporting data (documents, attributes, delineations), creating WQMPs from PDF upload, running AI extraction, editing metadata — should use `[JurisdictionEditFeature]`. When an endpoint or UI gate is set to `[JurisdictionManageFeature]`, verify it falls into one of the above exceptions before assuming the restriction is correct.
+
 ### Background Jobs (Hangfire)
 
 Configured with SQL Server storage, 1 worker, 0 auto-retries. Dashboard at `/hangfire`. Key jobs:


### PR DESCRIPTION
Clarifies that Editors should have access to almost everything Managers can, with only two exceptions: deleting primary records and attestation/verification actions. Adds an active reminder to the create-story skill so future story cards are flagged when they incorrectly restrict Editors.