### PR TITLE
NPT-1109: Unblock JEs - WQMP documents, AI workflow, BMP search

### DIFF
--- a/Build/Scaffold.ps1
+++ b/Build/Scaffold.ps1
@@ -46,12 +46,17 @@ if ($path)
   "Generate POCOs"
   $args1 = "--db-server-name=" + $config.Server + " --db-name=" + $config.DatabaseName + " --generate-primary-key-objects=true --generate-enums-as-select-dropdown-options=true --code-namespace=" + $config.ApiEFModelsNamespace + " --api-efmodels-output-dir=" + $config.ApiEFModelExtensionMethodsPath + " --table-exclude-list=" + $config.TableExcludeList + " --enum-list=" + ($lookupTablesFiles.BaseName -join ",") + " --typescript-enums-output-dir=" + $config.TypescriptEnumsPath
 
+  # Launch via the signed `dotnet` host rather than the unsigned apphost .exe: ESA endpoint
+  # policy (2026-07, WDAC/Defender-level — the AppLocker channel logs nothing) started denying
+  # locally-built unsigned executables in user-writable paths with "Access is denied". The
+  # managed .dll runs fine under dotnet.exe, which is signed and lives in Program Files.
+  $dllPath = [System.IO.Path]::ChangeExtension("$PSScriptRoot\$path", ".dll")
   $pinfo = New-Object System.Diagnostics.ProcessStartInfo
-  $pinfo.FileName = "$PSScriptRoot\$path"
+  $pinfo.FileName = "dotnet"
   $pinfo.RedirectStandardError = $true
   $pinfo.RedirectStandardOutput = $true
   $pinfo.UseShellExecute = $false
-  $pinfo.Arguments = $args1
+  $pinfo.Arguments = '"' + $dllPath + '" ' + $args1
   $pinfo.WorkingDirectory = "$PSScriptRoot\"
   $p = New-Object System.Diagnostics.Process
   $p.StartInfo = $pinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,14 @@ Custom `BaseAuthorizationAttribute` (implements `IAuthorizationFilter`). Derived
 |---|---|
 | `SitkaAdminFeature` | SitkaAdmin |
 | `AdminFeature` | Admin, SitkaAdmin |
-| `JurisdictionEditFeature` | Admin, SitkaAdmin, JurisdictionManager, JurisdictionEditor (+ jurisdiction match) |
+| `JurisdictionManageFeature` | Admin, SitkaAdmin, JurisdictionManager (role check only — no jurisdiction match) |
+| `JurisdictionEditFeature` | Admin, SitkaAdmin, JurisdictionManager, JurisdictionEditor (role check only — no jurisdiction match) |
+| `TreatmentBMPEditFeature` | Same as JurisdictionEditFeature + jurisdiction match against the routed TreatmentBMP |
+| `WaterQualityManagementPlanEditFeature` | Same as JurisdictionEditFeature + jurisdiction match against the routed WQMP |
 | `UserViewFeature` | Any authenticated user |
 | `LoggedInUnclassifiedFeature` | Unassigned users |
+
+Note: the plain `Jurisdiction*Feature` attributes check **role only** — jurisdiction scoping must come from an entity-scoped attribute (the `*EditFeature` variants above, which resolve the route id and require `IsAssignedToStormwaterJurisdiction`) or an in-controller check against the caller's assigned jurisdictions.
 
 Roles: Admin(1), SitkaAdmin(2), JurisdictionManager(3), JurisdictionEditor(4), Unassigned(5), Viewer(6), ExternalViewer(7).
 

--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -151,8 +151,12 @@ namespace Neptune.API.Controllers
         // (FinalWQMP / AsBuiltDrawings / OMPlan / Other). Mirrors the BMP doc-by-BMP pattern but
         // lives on WaterQualityManagementPlanController so the existing GET .../documents list
         // endpoint keeps its current route.
+        // NPT-1109: document CRUD was [JurisdictionManageFeature] — Manager-only AND
+        // jurisdiction-blind. Documents are supporting-data editing per the JE/JM doctrine
+        // (CLAUDE.md), and the entity-scoped gate adds the per-WQMP jurisdiction match that
+        // was previously missing entirely.
         [HttpPost("{waterQualityManagementPlanID}/documents")]
-        [JurisdictionManageFeature]
+        [WaterQualityManagementPlanEditFeature]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         public async Task<ActionResult<WaterQualityManagementPlanDocumentDto>> CreateDocument(
             [FromRoute] int waterQualityManagementPlanID,
@@ -181,7 +185,7 @@ namespace Neptune.API.Controllers
 
         // File is optional — when present we delete the old blob and swap the FileResource.
         [HttpPut("{waterQualityManagementPlanID}/documents/{waterQualityManagementPlanDocumentID}")]
-        [JurisdictionManageFeature]
+        [WaterQualityManagementPlanEditFeature]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         [EntityNotFound(typeof(WaterQualityManagementPlanDocument), "waterQualityManagementPlanDocumentID")]
         public async Task<ActionResult<WaterQualityManagementPlanDocumentDto>> UpdateDocument(
@@ -230,7 +234,7 @@ namespace Neptune.API.Controllers
         }
 
         [HttpDelete("{waterQualityManagementPlanID}/documents/{waterQualityManagementPlanDocumentID}")]
-        [JurisdictionManageFeature]
+        [WaterQualityManagementPlanEditFeature]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         [EntityNotFound(typeof(WaterQualityManagementPlanDocument), "waterQualityManagementPlanDocumentID")]
         public async Task<IActionResult> DeleteDocument(
@@ -609,12 +613,13 @@ namespace Neptune.API.Controllers
             return Ok(response);
         }
 
-        // NPT-984: Create-via-AI is a Manager-level entry point. Previously [AdminFeature]
-        // (Admin + SitkaAdmin only) which locked out Jurisdiction Managers even though they
-        // own WQMP records for their jurisdictions. Editors stay excluded — creating a new
-        // WQMP record is an attestation action above performing field work on an existing one.
+        // NPT-984 opened this to JurisdictionManagers (was [AdminFeature]); NPT-1109 opens it
+        // to JurisdictionEditors — per the JE/JM doctrine (CLAUDE.md), creating a WQMP from a
+        // PDF is data entry, not an attestation action (promoting Draft->Active is the
+        // attestation). No route id here, so the plain role gate applies; the in-body
+        // jurisdiction check below scopes the request to the caller's assigned jurisdictions.
         [HttpPost("upload")]
-        [JurisdictionManageFeature]
+        [JurisdictionEditFeature]
         [Consumes("multipart/form-data")]
         [RequestSizeLimit(200 * 1024 * 1024)]
         [RequestFormLimits(MultipartBodyLengthLimit = 200 * 1024 * 1024)]
@@ -654,9 +659,10 @@ namespace Neptune.API.Controllers
             }
 
             // NPT-984: defense-in-depth — even though the frontend modal only offers the
-            // user's manageable jurisdictions, validate the requested jurisdiction is in
-            // the caller's manageable set. Admin / SitkaAdmin see all jurisdictions; a
-            // JurisdictionManager is restricted to their assigned set.
+            // user's assigned jurisdictions, validate the requested jurisdiction is in
+            // the caller's set. Admin / SitkaAdmin see all jurisdictions; a
+            // JurisdictionManager or JurisdictionEditor is restricted to their assigned set
+            // (the helper is role-agnostic below admin).
             var currentPerson = People.GetByID(DbContext, CallingUser.PersonID);
             var manageableJurisdictionIDs = StormwaterJurisdictionPeople
                 .ListViewableStormwaterJurisdictionIDsByPersonForWQMPs(DbContext, currentPerson)
@@ -724,12 +730,11 @@ namespace Neptune.API.Controllers
             });
         }
 
-        // NPT-984: Run AI extraction — Manager-level. The Manager created the WQMP via the
-        // upload flow (also [JurisdictionManageFeature]); they need to run extractions on
-        // their own WQMPs. Was [AdminFeature] which left JMs unable to use the wizard they
-        // just opened.
+        // NPT-1109: Editor and up, jurisdiction-matched to the routed WQMP (was
+        // [JurisdictionManageFeature] via NPT-984, [AdminFeature] before that). Whoever can
+        // edit the WQMP can run extractions on it.
         [HttpPost("{waterQualityManagementPlanID}/extract")]
-        [JurisdictionManageFeature]
+        [WaterQualityManagementPlanEditFeature]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         public async Task<ActionResult<WaterQualityManagementPlanExtractionResultDto>> RunExtraction(
             [FromRoute] int waterQualityManagementPlanID)
@@ -839,10 +844,10 @@ namespace Neptune.API.Controllers
             return rawMessage;
         }
 
-        // NPT-984: Manager-level — the review wizard loads this on mount to show the AI's
-        // suggestions; JMs need access to review their own WQMPs.
+        // NPT-1109: Editor and up, jurisdiction-matched — the review wizard loads this on
+        // mount to show the AI's suggestions (was Manager-only via NPT-984).
         [HttpGet("{waterQualityManagementPlanID}/extraction-result")]
-        [JurisdictionManageFeature]
+        [WaterQualityManagementPlanEditFeature]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         public async Task<ActionResult<WaterQualityManagementPlanExtractionResultDto>> GetExtractionResult(
             [FromRoute] int waterQualityManagementPlanID)

--- a/Neptune.API/Services/Authorization/RegionalSubbasinRevisionRequestDownloadFeature.cs
+++ b/Neptune.API/Services/Authorization/RegionalSubbasinRevisionRequestDownloadFeature.cs
@@ -24,8 +24,15 @@ namespace Neptune.API.Services.Authorization
                 return;
             }
 
-            var revisionRequest = RegionalSubbasinRevisionRequests.GetByID(dbContext, regionalSubbasinRevisionRequestID);
-            var treatmentBMP = TreatmentBMPs.GetByIDForFeatureContextCheck(dbContext, revisionRequest.TreatmentBMPID);
+            // Null-tolerant fetches: authorization filters run before EntityNotFoundAttribute,
+            // so a throwing lookup surfaces a bogus route id as a 500 instead of a 404.
+            var revisionRequest = RegionalSubbasinRevisionRequests.GetByIDForFeatureContextCheck(dbContext, regionalSubbasinRevisionRequestID);
+            var treatmentBMP = revisionRequest == null ? null : TreatmentBMPs.GetByIDForFeatureContextCheck(dbContext, revisionRequest.TreatmentBMPID);
+            if (revisionRequest == null || treatmentBMP == null)
+            {
+                context.Result = new NotFoundResult();
+                return;
+            }
 
             if (user.RoleID == Role.JurisdictionManager.RoleID && user.IsAssignedToStormwaterJurisdiction(treatmentBMP.StormwaterJurisdictionID))
             {

--- a/Neptune.API/Services/Authorization/RegionalSubbasinRevisionRequestViewFeature.cs
+++ b/Neptune.API/Services/Authorization/RegionalSubbasinRevisionRequestViewFeature.cs
@@ -13,8 +13,15 @@ namespace Neptune.API.Services.Authorization
                 return;
             }
 
-            var revisionRequest = RegionalSubbasinRevisionRequests.GetByID(dbContext, regionalSubbasinRevisionRequestID);
-            var treatmentBMP = TreatmentBMPs.GetByIDForFeatureContextCheck(dbContext, revisionRequest.TreatmentBMPID);
+            // Null-tolerant fetches: authorization filters run before EntityNotFoundAttribute,
+            // so a throwing lookup surfaces a bogus route id as a 500 instead of a 404.
+            var revisionRequest = RegionalSubbasinRevisionRequests.GetByIDForFeatureContextCheck(dbContext, regionalSubbasinRevisionRequestID);
+            var treatmentBMP = revisionRequest == null ? null : TreatmentBMPs.GetByIDForFeatureContextCheck(dbContext, revisionRequest.TreatmentBMPID);
+            if (revisionRequest == null || treatmentBMP == null)
+            {
+                context.Result = new NotFoundResult();
+                return;
+            }
 
             if (user == null || user.IsAnonymousOrUnassigned())
             {

--- a/Neptune.API/Services/Authorization/TreatmentBMPEditFeature.cs
+++ b/Neptune.API/Services/Authorization/TreatmentBMPEditFeature.cs
@@ -15,6 +15,15 @@ namespace Neptune.API.Services.Authorization
 
             var treatmentBMP = TreatmentBMPs.GetByIDForFeatureContextCheck(dbContext, treatmentBMPID);
 
+            // Authorization filters run before EntityNotFoundAttribute — translate a
+            // nonexistent BMP into the 404 that attribute would have produced, rather than
+            // throwing (which surfaced as a 500).
+            if (treatmentBMP == null)
+            {
+                context.Result = new NotFoundResult();
+                return;
+            }
+
             if (user == null || user.IsAnonymousOrUnassigned())
             {
                 context.Result = new ForbidResult();

--- a/Neptune.API/Services/Authorization/TreatmentBMPViewFeature.cs
+++ b/Neptune.API/Services/Authorization/TreatmentBMPViewFeature.cs
@@ -17,8 +17,16 @@ namespace Neptune.API.Services.Authorization
                 return;
             }
 
-            // Assume entity existence is handled by EntityNotFoundAttribute
             var treatmentBMP = TreatmentBMPs.GetByIDForFeatureContextCheck(dbContext, treatmentBMPID);
+
+            // Authorization filters run before EntityNotFoundAttribute — translate a
+            // nonexistent BMP into the 404 that attribute would have produced, rather than
+            // throwing (which surfaced as a 500).
+            if (treatmentBMP == null)
+            {
+                context.Result = new NotFoundResult();
+                return;
+            }
 
             if (user.IsAnonymousOrUnassigned() &&
                 treatmentBMP.StormwaterJurisdiction.StormwaterJurisdictionPublicBMPVisibilityTypeID ==

--- a/Neptune.API/Services/Authorization/WaterQualityManagementPlanEditFeature.cs
+++ b/Neptune.API/Services/Authorization/WaterQualityManagementPlanEditFeature.cs
@@ -24,6 +24,15 @@ namespace Neptune.API.Services.Authorization
 
             var waterQualityManagementPlan = WaterQualityManagementPlans.GetByIDForFeatureContextCheck(dbContext, waterQualityManagementPlanID);
 
+            // Authorization filters run before EntityNotFoundAttribute — translate a
+            // nonexistent WQMP into the 404 that attribute would have produced, rather
+            // than throwing (which would 500).
+            if (waterQualityManagementPlan == null)
+            {
+                context.Result = new NotFoundResult();
+                return;
+            }
+
             if (user == null || user.IsAnonymousOrUnassigned())
             {
                 context.Result = new ForbidResult();

--- a/Neptune.API/Services/Authorization/WaterQualityManagementPlanEditFeature.cs
+++ b/Neptune.API/Services/Authorization/WaterQualityManagementPlanEditFeature.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.API.Services.Authorization
+{
+    /// <summary>
+    /// NPT-1109: entity-scoped edit gate for WQMP-routed endpoints — role check
+    /// (Editor and up) plus a jurisdiction match against the routed WQMP. Mirrors
+    /// <see cref="TreatmentBMPEditFeature"/>. Replaces [JurisdictionManageFeature] on the
+    /// document CRUD and AI-extraction endpoints, which was (a) Manager-only, blocking
+    /// JurisdictionEditors from supporting-data CRUD the JE/JM doctrine says they should
+    /// have, and (b) jurisdiction-blind, letting any Manager modify any jurisdiction's
+    /// WQMP documents.
+    /// </summary>
+    public class WaterQualityManagementPlanEditFeature() : BaseAuthorizationAttribute([RoleEnum.SitkaAdmin, RoleEnum.Admin, RoleEnum.JurisdictionManager, RoleEnum.JurisdictionEditor])
+    {
+        protected override void OnAuthorizationCore(AuthorizationFilterContext context, NeptuneDbContext dbContext, Person? user)
+        {
+            if (!context.RouteData.Values.TryGetValue("waterQualityManagementPlanID", out var idObj) || !int.TryParse(idObj?.ToString(), out var waterQualityManagementPlanID))
+            {
+                return;
+            }
+
+            var waterQualityManagementPlan = WaterQualityManagementPlans.GetByIDForFeatureContextCheck(dbContext, waterQualityManagementPlanID);
+
+            if (user == null || user.IsAnonymousOrUnassigned())
+            {
+                context.Result = new ForbidResult();
+                return;
+            }
+
+            if (!user.IsAssignedToStormwaterJurisdiction(waterQualityManagementPlan.StormwaterJurisdictionID))
+            {
+                context.Result = new ForbidResult();
+            }
+        }
+    }
+}

--- a/Neptune.EFModels/Entities/RegionalSubbasinRevisionRequests.cs
+++ b/Neptune.EFModels/Entities/RegionalSubbasinRevisionRequests.cs
@@ -39,6 +39,17 @@ public static class RegionalSubbasinRevisionRequests
         return regionalSubbasinRevisionRequest;
     }
 
+    // NPT-1109 (Copilot follow-up): authorization-filter fetch — returns null rather than
+    // throwing for a nonexistent ID, since authorization filters run BEFORE
+    // EntityNotFoundAttribute and a throw surfaces a bogus route id as a 500 instead of a
+    // 404. Fetches only the row (the feature attributes need just TreatmentBMPID).
+    public static RegionalSubbasinRevisionRequest? GetByIDForFeatureContextCheck(NeptuneDbContext dbContext, int regionalSubbasinRevisionRequestID)
+    {
+        return dbContext.RegionalSubbasinRevisionRequests
+            .AsNoTracking()
+            .SingleOrDefault(x => x.RegionalSubbasinRevisionRequestID == regionalSubbasinRevisionRequestID);
+    }
+
     public static List<RegionalSubbasinRevisionRequestDto> ListAsDto(NeptuneDbContext dbContext, Person currentPerson)
     {
         var jurisdictionIDs = currentPerson.IsAdministrator()

--- a/Neptune.EFModels/Entities/TreatmentBMPs.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPs.cs
@@ -698,17 +698,17 @@ public static class TreatmentBMPs
         }).ToList();
     }
 
-    public static TreatmentBMP GetByIDForFeatureContextCheck(NeptuneDbContext dbContext, int treatmentBMPID)
+    // NPT-1109 (Copilot follow-up): returns null rather than throwing for a nonexistent ID —
+    // authorization filters run BEFORE EntityNotFoundAttribute, so a throw here surfaced a
+    // bogus route id as a 500 instead of a 404. The calling feature attributes translate
+    // null into NotFoundResult themselves.
+    public static TreatmentBMP? GetByIDForFeatureContextCheck(NeptuneDbContext dbContext, int treatmentBMPID)
     {
-        var treatmentBMP = dbContext.TreatmentBMPs
+        return dbContext.TreatmentBMPs
             .Include(x => x.StormwaterJurisdiction)
             .ThenInclude(x => x.Organization)
             .AsNoTracking()
             .SingleOrDefault(x => x.TreatmentBMPID == treatmentBMPID);
-
-        Check.RequireNotNull(treatmentBMP, $"TreatmentBMP with ID {treatmentBMPID} not found!");
-
-        return treatmentBMP;
     }
 
     public static List<TreatmentBMP> ListByWaterQualityManagementPlanIDWithChangeTracking(

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlans.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlans.cs
@@ -44,15 +44,15 @@ public static partial class WaterQualityManagementPlans
     // NPT-1109: authorization-filter fetch for WaterQualityManagementPlanEditFeature. The
     // jurisdiction check only needs the row's StormwaterJurisdictionID, so skip GetImpl's
     // heavy include graph (parcels, BMPs + delineations) that GetByID drags in — this runs
-    // on every request to a WQMP-scoped endpoint. Mirrors TreatmentBMPs.GetByIDForFeatureContextCheck.
-    public static WaterQualityManagementPlan GetByIDForFeatureContextCheck(NeptuneDbContext dbContext, int waterQualityManagementPlanID)
+    // on every request to a WQMP-scoped endpoint. Returns null (rather than throwing) for a
+    // nonexistent ID: authorization filters run BEFORE EntityNotFoundAttribute, so a throw
+    // here would surface a bogus route id as a 500 instead of the intended 404 — the
+    // attribute translates null into NotFoundResult itself.
+    public static WaterQualityManagementPlan? GetByIDForFeatureContextCheck(NeptuneDbContext dbContext, int waterQualityManagementPlanID)
     {
-        var waterQualityManagementPlan = dbContext.WaterQualityManagementPlans
+        return dbContext.WaterQualityManagementPlans
             .AsNoTracking()
             .SingleOrDefault(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID);
-        Check.RequireNotNull(waterQualityManagementPlan,
-            $"WaterQualityManagementPlan with ID {waterQualityManagementPlanID} not found!");
-        return waterQualityManagementPlan;
     }
 
 

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlans.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlans.cs
@@ -41,6 +41,20 @@ public static partial class WaterQualityManagementPlans
         return waterQualityManagementPlan;
     }
 
+    // NPT-1109: authorization-filter fetch for WaterQualityManagementPlanEditFeature. The
+    // jurisdiction check only needs the row's StormwaterJurisdictionID, so skip GetImpl's
+    // heavy include graph (parcels, BMPs + delineations) that GetByID drags in — this runs
+    // on every request to a WQMP-scoped endpoint. Mirrors TreatmentBMPs.GetByIDForFeatureContextCheck.
+    public static WaterQualityManagementPlan GetByIDForFeatureContextCheck(NeptuneDbContext dbContext, int waterQualityManagementPlanID)
+    {
+        var waterQualityManagementPlan = dbContext.WaterQualityManagementPlans
+            .AsNoTracking()
+            .SingleOrDefault(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID);
+        Check.RequireNotNull(waterQualityManagementPlan,
+            $"WaterQualityManagementPlan with ID {waterQualityManagementPlanID} not found!");
+        return waterQualityManagementPlan;
+    }
+
 
     public static async Task<List<WaterQualityManagementPlanDto>> ListAsDtoAsync(NeptuneDbContext dbContext)
     {

--- a/Neptune.Tests/WqmpEndpointAuthorizationTests.cs
+++ b/Neptune.Tests/WqmpEndpointAuthorizationTests.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.API.Controllers;
+using Neptune.API.Services.Authorization;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1109: JurisdictionEditors were blocked from WQMP document CRUD and the AI
+    /// extraction workflow — six endpoints carried [JurisdictionManageFeature], which is both
+    /// Manager-only and jurisdiction-blind. The five WQMP-routed endpoints moved to the
+    /// entity-scoped [WaterQualityManagementPlanEditFeature] (role check + jurisdiction match
+    /// against the routed WQMP, mirroring TreatmentBMPEditFeature); the route-less upload
+    /// endpoint moved to [JurisdictionEditFeature] (its in-body jurisdiction check scopes it).
+    /// Pin the corrected gates so this regression class can't silently return — same rationale
+    /// as ReferenceListAuthorizationTests.
+    /// </summary>
+    [TestClass]
+    public class WqmpEndpointAuthorizationTests
+    {
+        private static MethodInfo GetControllerMethod(string methodName)
+        {
+            var method = typeof(WaterQualityManagementPlanController).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            Assert.IsNotNull(method, $"Expected {methodName}() on WaterQualityManagementPlanController.");
+            return method!;
+        }
+
+        private static void AssertWqmpEditGated(string methodName, string reason)
+        {
+            var method = GetControllerMethod(methodName);
+            Assert.IsTrue(method.GetCustomAttributes(typeof(WaterQualityManagementPlanEditFeature), true).Any(),
+                $"{methodName} must be [WaterQualityManagementPlanEditFeature] — {reason}");
+            Assert.IsFalse(method.GetCustomAttributes(typeof(JurisdictionManageFeature), true).Any(),
+                $"{methodName} must not be [JurisdictionManageFeature] — that excluded JurisdictionEditors and was jurisdiction-blind.");
+        }
+
+        [TestMethod]
+        public void CreateDocument_IsWqmpEditGated() =>
+            AssertWqmpEditGated("CreateDocument", "JEs upload documents on WQMPs in their jurisdiction (NPT-1109 AC 1-2).");
+
+        [TestMethod]
+        public void UpdateDocument_IsWqmpEditGated() =>
+            AssertWqmpEditGated("UpdateDocument", "JEs edit document metadata on WQMPs in their jurisdiction (NPT-1109 AC 3).");
+
+        [TestMethod]
+        public void DeleteDocument_IsWqmpEditGated() =>
+            AssertWqmpEditGated("DeleteDocument", "JEs delete documents on WQMPs in their jurisdiction (NPT-1109 AC 4).");
+
+        [TestMethod]
+        public void RunExtraction_IsWqmpEditGated() =>
+            AssertWqmpEditGated("RunExtraction", "JEs run AI extraction on WQMPs in their jurisdiction (NPT-1109 Bug 2).");
+
+        [TestMethod]
+        public void GetExtractionResult_IsWqmpEditGated() =>
+            AssertWqmpEditGated("GetExtractionResult", "the review wizard loads this on mount; JEs need it (NPT-1109 Bug 2).");
+
+        [TestMethod]
+        public void UploadDocument_IsJurisdictionEditGated()
+        {
+            var method = GetControllerMethod("UploadDocument");
+            Assert.IsTrue(method.GetCustomAttributes(typeof(JurisdictionEditFeature), true).Any(),
+                "POST /upload must be [JurisdictionEditFeature] — JEs create WQMPs from PDF (NPT-1109 Bug 2); the endpoint has no WQMP route id, and its in-body check scopes the requested jurisdiction to the caller's assigned set.");
+            Assert.IsFalse(method.GetCustomAttributes(typeof(JurisdictionManageFeature), true).Any(),
+                "POST /upload must not be [JurisdictionManageFeature] — that excluded JurisdictionEditors from the AI wizard entry point.");
+        }
+
+        [TestMethod]
+        public void WaterQualityManagementPlanEditFeature_GrantsJurisdictionEditor()
+        {
+            // grantedRoles is a primary-constructor parameter captured on BaseAuthorizationAttribute;
+            // locate its compiler-generated backing field by type rather than by (unstable) name.
+            var attribute = new WaterQualityManagementPlanEditFeature();
+            var rolesField = typeof(BaseAuthorizationAttribute)
+                .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
+                .Single(f => typeof(IEnumerable<RoleEnum>).IsAssignableFrom(f.FieldType));
+            var grantedRoles = ((IEnumerable<RoleEnum>)rolesField.GetValue(attribute)!).ToList();
+
+            CollectionAssert.AreEquivalent(
+                new List<RoleEnum> { RoleEnum.SitkaAdmin, RoleEnum.Admin, RoleEnum.JurisdictionManager, RoleEnum.JurisdictionEditor },
+                grantedRoles,
+                "WaterQualityManagementPlanEditFeature must grant exactly Editor-and-up — JurisdictionEditor inclusion is the point of NPT-1109.");
+        }
+    }
+}

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-treatment-bmps-modal/edit-treatment-bmps-modal.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-treatment-bmps-modal/edit-treatment-bmps-modal.component.html
@@ -11,11 +11,17 @@
         <div style="display: flex; gap: 0.5rem; align-items: flex-end; margin-bottom: 1rem">
             <div style="flex: 1 1 0; min-width: 0; overflow: hidden">
                 <label class="field-label">Add BMPs</label>
+                <!-- NPT-1109: bindLabel + searchFn are load-bearing. Without bindLabel,
+                     ng-select searches String(item) === "[object Object]" and every term
+                     returns zero results; the searchFn extends matching to the type name
+                     since the option template renders "Name (Type)". -->
                 <ng-select
                     [items]="availableBMPs"
+                    bindLabel="TreatmentBMPName"
                     bindValue="TreatmentBMPID"
                     [(ngModel)]="pickerBMPID"
                     [searchable]="true"
+                    [searchFn]="searchBMPs"
                     [clearable]="true"
                     appendTo="body"
                     placeholder="Search for a BMP...">

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-treatment-bmps-modal/edit-treatment-bmps-modal.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/edit-treatment-bmps-modal/edit-treatment-bmps-modal.component.ts
@@ -25,6 +25,13 @@ export class EditTreatmentBMPsModalComponent implements OnInit {
     public availableBMPs$: Observable<TreatmentBMPMinimalDto[]>;
     public pickerBMPID: number | null = null;
 
+    // NPT-1109: ng-select custom search matching what the option template renders —
+    // "TreatmentBMPName (TreatmentBMPTypeName)" — case-insensitive substring, so hyphenated
+    // names like "YOL-TC-WQ 003-1", partial terms, and type-name searches all work.
+    // Class-field arrow keeps `this`-free semantics and a stable reference across CD passes.
+    public searchBMPs = (term: string, item: TreatmentBMPMinimalDto): boolean =>
+        `${item.TreatmentBMPName ?? ""} ${item.TreatmentBMPTypeName ?? ""}`.toLowerCase().includes(term.toLowerCase());
+
     ngOnInit(): void {
         this.alertService.clearAlerts();
         const currentBMPIDs = new Set(this.ref.data?.currentBMPIDs ?? []);

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.html
@@ -395,7 +395,9 @@
             <div class="card g-col-12">
                 <div class="card-header">
                     <span class="card-title">Documents</span>
-                    @if (currentPersonCanManage) {
+                    <!-- NPT-1109: Editors and up — document CRUD is supporting-data editing; backend
+                         is [WaterQualityManagementPlanEditFeature] (was Manager-only). -->
+                    @if (currentPersonCanEdit) {
                         <button class="btn btn-primary btn-sm" (click)="openDocumentUploadModal()">
                             <i class="fa fa-plus"></i> Upload Document
                         </button>
@@ -420,7 +422,7 @@
                                                         <i class="fa fa-download"></i>
                                                     </a>
                                                 }
-                                                @if (currentPersonCanManage) {
+                                                @if (currentPersonCanEdit) {
                                                     <button type="button" class="btn btn-sm btn-primary-outline btn-icon" (click)="openDocumentEditModal(doc)" title="Edit document" aria-label="Edit document">
                                                         <i class="fa fa-pencil"></i>
                                                     </button>

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-detail.component.ts
@@ -129,10 +129,6 @@ export class WqmpDetailComponent implements OnInit, OnChanges {
     // (the JE/JM Begin-button bug from NPT-995's first round).
     currentUser: PersonDto;
 
-    public get currentPersonCanManage(): boolean {
-        return this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission();
-    }
-
     public get currentPersonCanEdit(): boolean {
         return this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission();
     }

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -399,9 +399,10 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     }
 
     runExtraction(): void {
-        // NPT-984: backend endpoint is [JurisdictionManageFeature], same as the upload flow
-        // that landed the user here. No frontend role gate — the wizard route itself is
-        // only reachable via paths that already require manage permission.
+        // NPT-1109: backend endpoint is [WaterQualityManagementPlanEditFeature] — Editor and
+        // up, jurisdiction-matched to this WQMP. No frontend role gate here: the wizard's
+        // entry points (Create from PDF on the list page, Review AI Extraction on the detail
+        // page) are both currentPersonCanEdit-gated, and the API enforces the rest.
         this.isExtracting.set(true);
         this.alertService.clearAlerts();
         this.wqmpService.runExtractionWaterQualityManagementPlan(this.waterQualityManagementPlanID)

--- a/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
@@ -3,11 +3,11 @@
         NPT-1051: Create from PDF promoted to a primary action — AI extraction is the
         expected entry point for new WQMPs going forward. The new WQMP lands in Draft
         status; the reviewer wizard auto-opens for transcription review.
-        NPT-984: Manager-only gate — backend upload endpoint is [JurisdictionManageFeature].
-        Editors keep access to the Actions dropdown (Add WQMP + bulk uploads) but cannot
-        kick off the AI workflow.
+        NPT-1109: Editors and up — backend upload endpoint is [JurisdictionEditFeature]
+        (was Manager-only under NPT-984); creating a WQMP from PDF is data entry, not an
+        attestation action.
     -->
-    @if (currentPersonCanManage$ | async) {
+    @if (currentPersonCanEdit$ | async) {
         <button type="button" class="btn btn-primary" style="margin-right: 0.5rem" (click)="openCreateFromPdfModal()">
             <i class="fa fa-magic"></i> Create from PDF
         </button>

--- a/Neptune.Web/src/app/pages/wqmps/wqmps.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmps.component.ts
@@ -47,10 +47,6 @@ export class WqmpsComponent {
     public mapIsReady = false;
     public wqmpJurisdictionIDs: number[];
     public currentPersonCanEdit$: Observable<boolean>;
-    // NPT-984: Create-from-PDF (the AI workflow entry point) is Manager-level — the backend
-    // upload endpoint is gated on [JurisdictionManageFeature]. Editor-level users see the
-    // rest of the Actions menu (Add WQMP, Bulk Uploads via the Data Hub) but not Create from PDF.
-    public currentPersonCanManage$: Observable<boolean>;
     private wqmps: WaterQualityManagementPlanGridDto[] = [];
     private reload$ = new BehaviorSubject<void>(undefined);
     private static NO_BOUNDARY_ALERT = "WqmpNoBoundary";
@@ -93,9 +89,6 @@ export class WqmpsComponent {
 
         this.currentPersonCanEdit$ = currentUser$.pipe(
             map(() => this.authenticationService.doesCurrentUserHaveJurisdictionEditPermission())
-        );
-        this.currentPersonCanManage$ = currentUser$.pipe(
-            map(() => this.authenticationService.doesCurrentUserHaveJurisdictionManagePermission())
         );
 
         this.wqmps$ = this.reload$.pipe(switchMap(() => this.loadWqmps$()));


### PR DESCRIPTION
Three bugs blocking Dana Point's JurisdictionEditors from the WQMP data-entry workflow (reported by Alison while onboarding an intern). Plus one drive-by build-tooling fix in a separate commit.

## Bug 1 + 2 — Document CRUD and AI workflow permissions

Six endpoints were `[JurisdictionManageFeature]` — **Manager-only and jurisdiction-blind**. The plain `Jurisdiction*Feature` attributes check role only, and the document/extraction endpoints had *no jurisdiction check at all* — any Manager could modify any jurisdiction's WQMP documents.

- New entity-scoped **`WaterQualityManagementPlanEditFeature`** (mirrors `TreatmentBMPEditFeature` from NPT-1104): Editor-and-up roles **plus** a jurisdiction match against the routed WQMP, backed by a new lightweight `WaterQualityManagementPlans.GetByIDForFeatureContextCheck` (no include graph). Gates the five WQMP-routed endpoints: document create/update/delete, `extract`, `extraction-result`.
- `POST /upload` (no route id) → plain `[JurisdictionEditFeature]`; its existing in-body check (`ListViewableStormwaterJurisdictionIDsByPersonForWQMPs`, verified role-agnostic) scopes the requested jurisdiction.
- **Behavior change to note in QA:** cross-jurisdiction Managers are now also 403'd on documents/extraction outside their assignment — that latent hole is what made AC 5 impossible before.
- SPA gates follow: Upload Document + document edit/delete buttons and the list page's "Create from PDF" move `currentPersonCanManage` → `currentPersonCanEdit`; orphaned `canManage` members removed; stale NPT-984 comments rewritten.

## Bug 3 — BMP search returned nothing, ever

The Edit Treatment BMPs ng-select had no `bindLabel`, so typing searched against `String(item)` = `[object Object]`. Added `bindLabel` + a `searchFn` matching "Name (Type)" case-insensitively — hyphenated names ("YOL-TC-WQ 003-1"), partials, and any casing now work (ACs 7–10).

## Tests / docs

- 7 reflection tests in `WqmpEndpointAuthorizationTests` pin the six corrected gates + the new attribute's role set (all 22 authorization tests pass).
- CLAUDE.md authorization table updated: added `JurisdictionManageFeature` + both entity-scoped attributes; corrected the inaccurate "(+ jurisdiction match)" claim on plain `JurisdictionEditFeature`.
- Doctrine reverse-mismatches (`promote`, verification DELETE are Edit-gated but the new JE/JM doctrine says Manager-only) flagged on the card for Kathleen — deliberately **not** changed here.
- AC section for the AI workflow (ACs 11–14) appended to the card; implementation notes posted there.

## Separate commit — Scaffold.ps1

Endpoint policy rolled out this week denies launching locally-built unsigned exes ("Access is denied" on `EFCorePOCOGenerator.exe`); the script now runs the generator via the signed `dotnet` host with the .dll. Identical behavior, policy-proof.

No codegen needed (no route/DTO changes). Browser-verified by Ray (JE impersonation: documents, wizard, 403s, BMP search).