### PR TITLE
NPT-1106: Make strict tool use compile - de-union schemas + $defs + per-category strict

### DIFF
--- a/Neptune.API/Services/AI/PromptTemplateService.cs
+++ b/Neptune.API/Services/AI/PromptTemplateService.cs
@@ -27,10 +27,15 @@ public sealed class PromptTemplateService : IPromptTemplateService
     // callers can still pass an explicit version to override for A/B testing.
     private static readonly Dictionary<PromptTemplate, string> ActiveVersion = new()
     {
-        [PromptTemplate.ExtractWqmpFields] = "v2",
-        [PromptTemplate.ExtractParcels] = "v2",
-        [PromptTemplate.ExtractQuickBMPs] = "v3",
-        [PromptTemplate.ExtractSourceControlBMPs] = "v3",
+        // NPT-1106 round 3: v3/v4 switch "not found" from null to sentinels ("" for strings,
+        // all-zero BoundingBox) — strict tool use caps union-typed schema params at 16 per
+        // request, and the nullable-everywhere schemas carried 132. WqmpExtractionService
+        // normalizes the sentinels back to nulls before storage, so the persisted
+        // ExtractionResultJson contract is unchanged.
+        [PromptTemplate.ExtractWqmpFields] = "v3",
+        [PromptTemplate.ExtractParcels] = "v3",
+        [PromptTemplate.ExtractQuickBMPs] = "v4",
+        [PromptTemplate.ExtractSourceControlBMPs] = "v4",
     };
 
     private readonly string _promptsDirectory;

--- a/Neptune.API/Services/AI/Prompts/ExtractParcels_v3.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractParcels_v3.md
@@ -1,0 +1,12 @@
+{{EvidenceInstructions}}
+
+<task>
+Extract all Parcels (APNs / Assessor Parcel Numbers) from the uploaded Water Quality Management Plan PDF (Orange County, CA). APNs commonly appear on the cover page, the title block, the project-description section, or in a parcel-listing table near the front of the document. Format is typically `XXX-XX-XXX` or `XXX-XXX-XX`.
+</task>
+
+When you cannot determine a value from the document, set the field's `Value`, `ExtractionEvidence`, and `DocumentSource` to empty strings (`""`) and set every `BoundingBox` number (`PageNumber`, `X`, `Y`, `Width`, `Height`) to 0. Do not infer.
+
+The schema for each emitted item:
+{{Schema}}
+
+Return a JSON object containing an `"items"` array (empty if no parcels are listed in this document).

--- a/Neptune.API/Services/AI/Prompts/ExtractQuickBMPs_v4.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractQuickBMPs_v4.md
@@ -1,0 +1,125 @@
+{{EvidenceInstructions}}
+
+<task>
+Extract all **Simplified Structural BMPs** (a.k.a. "Simple BMPs" or "QuickBMPs") that this Water Quality Management Plan (WQMP) describes — stormwater control measures that this specific Orange County, CA project has committed to. This is **not** the global Treatment BMP inventory; scope each extraction to the BMPs in this document for this site.
+</task>
+
+<where_to_look>
+The OC WQMP form has two stylistic regions for BMP listings. You must read both. **Section numbers below reflect the standard OC template** — older variants and non-standard documents may use different numbering or omit sections. **Anchor your reading on the content / intent of each section, not on the literal section number.** If you see a section described by content that fits one of the categories below, treat it as that category regardless of how it's numbered.
+
+**Pre-printed checkbox forms** — typically Sections IV.3.1 through IV.3.6 (sometimes also IV.3.8, IV.3.9). Recognize by structure: a fixed list of BMP names with an "Included?" column, where selection is signaled by a graphical mark (☑, ✓, X, filled circle, or similar) next to the name. There is often no underlying text saying "selected." A marked box is positive selection evidence on equal footing with a free-form table row. Skip blank / unchecked rows.
+
+What the checkbox sections typically cover, in standard OC order — match by intent, not number:
+
+- **Hydrologic Source Controls (HSCs):** site-design measures — permeable pavement, planter boxes, green roofs, etc. (typically IV.3.1)
+- **Infiltration BMPs:** basins, drywells, trenches (typically IV.3.2)
+- **Harvest-and-Use BMPs:** cisterns, rain barrels (typically IV.3.3)
+- **Biotreatment BMPs:** bioretention, biofilters, vegetated swales, and most proprietary biotreatment products (typically IV.3.4)
+- **Hydromodification Control BMPs:** flow-duration control tanks, underground detention, CMP detention pipes — these BMPs typically *do not* appear in the free-form table; they are selected here (typically IV.3.5)
+- **Source Control BMPs (operational/non-structural):** covered by a separate extraction — ignore for QuickBMPs (typically IV.3.6)
+
+**Free-form treatment-control tables** — typically Section IV.3.7. Recognize by structure: two-column "BMP Name | BMP Description" tables filled in by the engineer, often with vendor names, model numbers, and sizing. Extract one BMP per row.
+
+If a free-form table cross-references a checkbox section (e.g. *"See Proprietary Biotreatment BMP table above"*), follow the cross-reference and extract from the referenced content. If the same BMP appears in both a checkbox form and a free-form table, emit it **once** (de-dupe).
+
+Footnotes attached to a BMP table count as part of that table's content — extract BMPs mentioned only in a footnote (e.g. trash-capture pipe screens listed under a biotreatment table footnote).
+
+**Variant templates exist.** The "North OC Priority WQMP Template August 2011" omits the free-form treatment-control table and describes structural treatment BMPs directly in the Biotreatment section. Some other templates use entirely custom numbering or merge categories. In any layout, prioritize content semantics — *is this site committing to this BMP?* — over the document's organizational scheme.
+
+**Older "South-OC 2003" templates** use a flat S-code numbering (S1 – S20) that mixes Source Controls and Treatment Controls. **S-codes roughly S1 – S14 are Source Controls** (Site Design + Structural Source Controls — trash enclosures, fueling areas, vehicle wash, etc.) and are extracted by the SourceControlBMPs tool, **not by this one**. Skip them here. Only S-codes ≥ S15 (typically Inlet Trash Racks, Water Quality Inlets, Hydrodynamic Separators, and other treatment devices) are QuickBMPs and should be extracted here.
+
+**Non-standard or unrecognized BMPs.** If the document selects a BMP that doesn't fit any vendor alias or canonical category cleanly, extract it anyway: put the document's name verbatim in `QuickBMPName`, put your best canonical guess (or the document's own type label if it gave one) in `TreatmentBMPType`, and leave staff to remap during review. Do not skip a BMP because it doesn't fit the template — a missed BMP is worse than a mis-typed one.
+
+Other supporting evidence: BMP fact sheets / cut-sheets in WQMP appendices, sizing calculation pages, treatment train diagrams, Section V (Operation & Maintenance) narratives that enumerate the project's BMPs. These often disambiguate which checkboxes were marked when a scanned page is unclear.
+</where_to_look>
+
+<positive_selection_rule>
+Some WQMPs include catalog or reference tables listing BMP types that are **not** selected for this project — every row may be marked "N/A" or left blank. Do **not** extract these.
+
+Emit a BMP only when at least one of the following positive signals is present for that specific row/instance:
+
+- A checked / marked / X'd / filled box next to the BMP name in a Section IV.3.x form.
+- An explicit "Selected: Yes" / "Included" / "Provided" mark.
+- An assigned `% Site Treated`, drainage area assignment, or sizing calculation for this site.
+- A project-specific fact sheet, sizing page, or O&M narrative naming this BMP as installed on the project.
+
+If a row is marked "N/A", left blank, or appears in a generic reference appendix without any of the above, do **not** extract it.
+</positive_selection_rule>
+
+<vendor_aliases>
+Engineers commonly write vendor product names rather than the canonical `TreatmentBMPType`. Map vendor names to the canonical type when populating the `TreatmentBMPType` field — use a name from DomainContext's `TreatmentBMPTypes` list when available. Keep the vendor name in `QuickBMPName`.
+
+| Vendor name in document | Canonical `TreatmentBMPType` |
+|---|---|
+| Modular Wetlands / Modular Wetland System / MWS / MWS-L-* | Proprietary Biotreatment |
+| UrbanGreen Biofilter | Proprietary Biotreatment |
+| Filterra (any model, incl. Roofdrain System) | Proprietary Biotreatment |
+| Contech StormFilter | Proprietary Biotreatment |
+| Americast (vendor of Filterra) | Proprietary Biotreatment |
+| Bioclean Modular Connector / Connector Pipe Screen | Inlet and Pipe Screens |
+| Bioclean Grate Inlet Filter | Catch Basin / Inlet (unscreened) |
+| FloGard (catch basin filter insert) | Catch Basin / Inlet (unscreened) |
+| Kristar | Catch Basin / Inlet (unscreened) — verify in document |
+| CMP Underground Detention / corrugated metal pipe detention | Flow Duration Control Tank |
+| Stormwater Planter Box (with or without underdrains) | Bioinfiltration (bioretention with underdrain) |
+| Bioswale | Vegetated Swale |
+| Hydrodynamic Separator | Hydrodynamic Separator |
+
+<example>
+Document text:
+"1) 4x4 Filterra Roofdrain System: LAT: 33°38'51.42"; LONG: 117° 44'07.38""
+
+Correct extraction (vendor name in QuickBMPName, canonical type in TreatmentBMPType):
+
+```
+{
+  "QuickBMPName":     "4x4 Filterra Roofdrain System",
+  "TreatmentBMPType": "Proprietary Biotreatment"
+}
+```
+
+Wrong: leaving `TreatmentBMPType` as "Filterra Roof Drain System" (a vendor name — does not match any canonical `TreatmentBMPType` and will fail dropdown bind during staff review).
+</example>
+
+<example>
+Document mentions two distinct Bioclean products:
+
+- "Bioclean Modular Connector Pipe Screens" — trash-capture screens at storm-drain pipe inlets
+- "Bioclean Grate Inlet Filter" — filter insert that sits inside a catch basin grate
+
+Correct extraction (two separate items, different canonical types — same vendor, different BMP categories):
+
+```
+[
+  { "QuickBMPName": "Bioclean Modular Connector Pipe Screen", "TreatmentBMPType": "Inlet and Pipe Screens" },
+  { "QuickBMPName": "Bioclean Grate Inlet Filter",            "TreatmentBMPType": "Catch Basin / Inlet (unscreened)" }
+]
+```
+</example>
+</vendor_aliases>
+
+<output_fields>
+For each Simple BMP found, emit one object containing the following ExtractedValue fields:
+
+| Field | Guidance |
+|---|---|
+| `QuickBMPName` | The name as written in the WQMP (e.g. "Bioretention Area #1", "MWS DMA D1 (MWS-L-6-8 Unit A)", "4x4 Filterra Roofdrain System"). Keep vendor names, numbering, and DMA/subarea identifiers. If individual instances are distinguished by drainage area or model (e.g. MWS 1 in DA 1, MWS 2 in DA 2), emit one object per instance — these are distinct BMPs. |
+| `TreatmentBMPType` | Canonical BMP type/category. Apply the vendor-alias table above. Prefer a name from DomainContext's `TreatmentBMPTypes` list. |
+| `NumberOfIndividualBMPs` | Integer count of physical units this row represents. **Defer to nearby quantity language** ("two planter boxes", "three 4'x6' units", "the 4 MWSs and 2 bioswales") rather than guessing. Default to 1 only if the document gives no count signal at all. If a single BMP type covers multiple identical instances enumerable as one row (e.g. "10 catch basin inserts at the perimeter"), emit one object with `NumberOfIndividualBMPs=10`. |
+| `PercentOfSiteTreated` | Numeric percent (0–100) of the WQMP site this BMP treats. Often shown in BMP sizing tables or treatment train diagrams. |
+| `PercentCaptured` | Numeric percent (0–100) of the design storm captured/intercepted by this BMP. If given as a range ("80–90% capture"), emit the higher value. |
+| `PercentRetained` | Numeric percent (0–100) retained on-site (infiltrated, evapotranspired, harvested). Must be ≤ `PercentCaptured` — anything captured but not retained is treated and discharged. If the source document violates this constraint, still extract both verbatim — staff will reconcile during review. |
+| `QuickBMPNote` | Free-form note (≤200 chars) — sizing rationale, model number, drainage area assignment, or qualifiers like *"Supplemental Only. Not part of the Design Volume"*. |
+</output_fields>
+
+<edge_cases>
+- If the document discusses BMPs in the abstract — a list of "could be used" measures with no commitment to specific instances on this site — do not extract them.
+- A BMP qualified as "Supplemental Only" or "Not part of Design Volume" should still be extracted; surface the qualifier in `QuickBMPNote`.
+- If the same BMP is described in multiple sections (e.g. IV.3.4 and IV.3.7), emit it once.
+- **When uncertain about a value, set the field's `Value`, `ExtractionEvidence`, and `DocumentSource` to empty strings (`""`) and set every `BoundingBox` number (`PageNumber`, `X`, `Y`, `Width`, `Height`) to 0.** Do not infer plausible values from defaults, general knowledge, or other documents — the empty string is the correct answer when the document does not specify.
+</edge_cases>
+
+The schema for each emitted item:
+{{Schema}}
+
+Return a JSON object containing an `"items"` array (empty if no Simple BMPs are described in this document).

--- a/Neptune.API/Services/AI/Prompts/ExtractSourceControlBMPs_v4.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractSourceControlBMPs_v4.md
@@ -1,0 +1,118 @@
+{{EvidenceInstructions}}
+
+<task>
+Extract all **Source Control BMPs** that this Water Quality Management Plan (WQMP) describes — operational practices, site-design features, and structural elements that prevent pollutants from entering the storm-drain system. This is **not** the global Source Control inventory; scope each extraction to the practices this document commits to for this specific Orange County, CA site.
+</task>
+
+<where_to_look>
+OC WQMPs present Source Control BMPs in one or more of these layouts. Read all of them — they often appear in the same document.
+
+**Pre-printed checklist sections** — typically **Section IV.3.6** in the modern (2013+) OC Model WQMP template. Recognize by structure: three sub-tables (one per category) where each row is a fixed attribute name with an "Included? Yes / No / N/A" indicator and a "Conditions if Yes" note column. A marked Yes or No is positive evidence — extract every marked row from every category sub-table. Skip rows marked N/A or left blank.
+
+The checklist covers three categories, in standard order:
+
+- **Hydrologic Source Control and Site Design BMPs** — LID measures that reduce runoff at the source. Examples: Impervious Area Dispersion, Localized On-lot Infiltration, Street Trees, Harvest and Use Systems, Conserved Natural Areas, Buffer Zones for Natural Water Bodies, Minimized Impervious Areas, Maintained or Restored Natural Drainage Patterns, Distributed Permeable Pavement in Low Traffic Areas, Green Roof / Brown Roof, Absorbent Landscaping with Drought Tolerant Species.
+- **Applicable Routine Non-Structural Source Control BMPs** — operational / programmatic practices the owner/operator commits to. Examples: Education for Property Owners/Tenants/Occupants, Activity Restrictions, Landscape Management, BMP Maintenance, Title 22 CCR Compliance, Local Water Quality Permit Compliance, Spill Contingency Plan, Underground Storage Tank Compliance, Hazardous Materials Disclosure Compliance, Uniform Fire Code Implementation, Litter Control, Employee Training, Housekeeping of Loading Docks, Catch Basin Inspection, Street Sweeping Private Streets and Parking Lots, Retail Gasoline Outlets.
+- **Applicable Routine Structural Source Control BMPs** — fixed structures. Examples: Provide Storm Drain System Stenciling and Signage, Design Outdoor Hazardous Material Storage Areas, Design Trash Enclosures, Use Efficient Irrigation Systems and Landscape Design, Protect Slopes and Channels, Maintenance Bays, Vehicle Wash Areas, Outdoor Processing Areas, Equipment Wash Areas, Loading Dock Areas, Fueling Areas, Wash Water Controls for Food Preparation Areas, Community Car Wash Racks.
+
+**Older OC BMP Manual templates** (2003-era South-OC and similar) — Source Controls described by code letters in narrative form. Common code schemes across older templates:
+
+- **South-OC 2003 template** uses a flat **S-code** numbering (S1 through ~S20) that mixes Source Controls and Treatment Controls in the same list. **Low-numbered S-codes (roughly S1 – S14) are Source Controls** (Site Design + Structural Source Controls); high-numbered S-codes (≥ S15) are Treatment Controls and are NOT your responsibility — the QuickBMPs extraction handles those.
+
+  Known South-OC 2003 S-code mappings to DomainContext attributes:
+
+  - **S3. Common Area Runoff-Minimizing Landscape Design** → *Maintained or Restored Natural Drainage Patterns* (Site Design)
+  - **S6. Trash Container Areas** → *Design Trash Enclosures to Reduce Pollutant Introduction* (Structural)
+  - **S9. Concrete Fuel Dispensing Area** / **S10. Motor Fuel Dispensing Area Canopy** → *Fueling Areas* (Structural) — both codes describe parts of the same fueling-area BMP; emit once.
+  - **S11. Outdoor Material Storage Area** → *Design Outdoor Hazardous Material Storage Areas to Reduce Pollutant Introduction* (Structural)
+  - **S12. Vehicle Wash Area** → *Vehicle Wash Areas* (Structural)
+  - Any S-code below S15 with "landscape", "irrigation", "drainage", "trash", "fuel", "vehicle", "material storage", "hazardous", or "wash" in its title is almost certainly a Source Control and you should emit it.
+
+- **Other older templates** sometimes use letter-prefixed codes: **N1 – N16** for Routine Non-Structural Source Controls (e.g., "N1. Education for Property Owners and Tenants"; "N7. Catch Basin Inspection"); **SD-1 to SD-32** for Site Design BMPs (e.g., "SD-12. Efficient Irrigation"); **SC-10 to SC-44** for Structural Source Controls (e.g., "SC-15. Outdoor Material Storage Areas"; "SC-30. Fueling Areas"; "SC-32. Trash Storage Areas").
+
+When a code appears as a section heading with an implementation description (even one sentence), treat it as committed and extract `IsPresent: "Yes"`. Put the code in the `SourceControlBMPNote` for traceability if helpful, but map `SourceControlBMPAttribute.Value` to the matching DomainContext name — not to the code.
+
+**Narrative O&M / BMP sections** — some WQMPs lack any structured checklist or code list and only describe Source Controls inside an Operation & Maintenance, Best Management Practices, or Pollution Prevention narrative. Pull each practice the document describes as implemented on this site. Common narrative phrasings and the DomainContext attribute they map to:
+
+- "storm drain stenciling", "no-dumping markers", "drain marking" → **Provide Storm Drain System Stenciling and Signage**
+- "trash enclosure", "trash storage area", "roofed dumpster" → **Design Trash Enclosures to Reduce Pollutant Introduction**
+- "fueling area canopy", "fuel dispenser island", "spill containment at fuel pumps" → **Fueling Areas**
+- "vehicle wash area", "car wash bay" → **Vehicle Wash Areas**
+- "equipment wash area" → **Equipment Wash Areas**
+- "maintenance bay", "service bay containment" → **Maintenance Bays**
+- "loading dock containment" → **Loading Dock Areas**
+- "hazardous material storage", "chemical storage area" → **Design Outdoor Hazardous Material Storage Areas to Reduce Pollutant Introduction**
+- "underground storage tank", "UST" → **Underground Storage Tank Compliance**
+- "spill plan", "spill response", "spill kit" → **Spill Contingency Plan**
+- "employee training", "operator training" → **Employee Training**
+- "tenant education", "property owner pamphlet" → **Education for Property Owners, Tenants and Occupants**
+- "catch basin inspection", "drainage facility inspection" → **Catch Basin Inspection**
+- "street sweeping", "parking lot sweeping" → **Street Sweeping Private Streets and Parking Lots**
+- "efficient irrigation", "drip irrigation", "smart controller" → **Use Efficient Irrigation Systems and Landscape Design**
+- "retail gasoline outlet practices", "Chevron / Shell / 76 / Mobil service station SOPs" → **Retail Gasoline Outlets**
+- "hazardous materials business plan", "HMDC" → **Hazardous Materials Disclosure Compliance**
+- "Uniform Fire Code compliance", "UFC" → **Uniform Fire Code Implementation**
+- "Title 22 hazardous waste compliance" → **Title 22 CCR Compliance**
+- "drought-tolerant landscaping", "absorbent soil amendments" → **Absorbent Landscaping with Drought Tolerant Species**
+
+For each extracted item, set `SourceControlBMPAttribute.Value` to the matching DomainContext attribute name (see DomainContext's grouped `SourceControlBMPAttributes`) when a close conceptual match exists. If no match, emit the document's wording verbatim — staff will remap during review.
+</where_to_look>
+
+<positive_selection_rule>
+Emit a Source Control BMP when at least one positive signal is present:
+
+- A checked / Yes-marked row in a Section IV.3.6 checklist.
+- An explicitly No-marked row (extract as `IsPresent: "No"`).
+- A BMP code (N1, SD-x, SC-x) appearing as a section heading or list entry with an implementation description.
+- A narrative paragraph in an O&M / BMP / Pollution Prevention section describing implementation of a practice that maps to a DomainContext attribute.
+
+Do **not** emit when:
+
+- The row is marked N/A or left blank.
+- The document references a practice only as "could apply" without committing to it.
+- The mention appears only in a generic glossary or appendix without project-specific commitment.
+
+**Be permissive on narrative-style matches.** A missed Source Control is worse than a mismapped one — staff reviews and corrects every extraction. If a document describes a practice that fits a DomainContext attribute even loosely, extract it.
+</positive_selection_rule>
+
+<example>
+Modern checklist row (Section IV.3.6.a): "Localized On-lot Infiltration … [✓] Yes  [ ] No  [ ] N/A     Conditions if Yes: Bioretention area at SW corner". Emit one item with `SourceControlBMPAttribute.Value = "Localized On-lot Infiltration"`, `IsPresent.Value = "Yes"`, `SourceControlBMPNote.Value = "Bioretention area at SW corner"`.
+</example>
+
+<example>
+Modern checklist row marked No: "Street Trees … [ ] Yes  [✓] No  [ ] N/A". Emit one item with `SourceControlBMPAttribute.Value = "Street Trees"`, `IsPresent.Value = "No"`, `SourceControlBMPNote.Value = ""`.
+</example>
+
+<example>
+Older BMP-code style: "N1. Education for Property Owners and Tenants. Tenants will receive a stormwater pollution prevention pamphlet at lease signing." Emit one item with `SourceControlBMPAttribute.Value = "Education for Property Owners, Tenants and Occupants"`, `IsPresent.Value = "Yes"`, `SourceControlBMPNote.Value = "Pamphlet at lease signing"`.
+</example>
+
+<example>
+Older BMP-code style: "SC-32. Trash Storage Areas. Trash enclosure to be roofed with side walls on three sides." Emit one item with `SourceControlBMPAttribute.Value = "Design Trash Enclosures to Reduce Pollutant Introduction"`, `IsPresent.Value = "Yes"`, `SourceControlBMPNote.Value = "Roofed with side walls on three sides"`.
+</example>
+
+<example>
+Narrative O&M paragraph: "Storm drain inlets on the property are stenciled with 'No Dumping — Flows to Ocean'." Emit one item with `SourceControlBMPAttribute.Value = "Provide Storm Drain System Stenciling and Signage"`, `IsPresent.Value = "Yes"`, `SourceControlBMPNote.Value = "'No Dumping - Flows to Ocean' stencils"`. (Likewise: "Catch basins inspected monthly during the rainy season" → `Catch Basin Inspection`; "Spill kits at fueling islands" → `Spill Contingency Plan`; "Underground storage tanks inspected per CUPA" → `Underground Storage Tank Compliance`.)
+</example>
+
+<output_fields>
+For each Source Control BMP found, emit one object containing the following ExtractedValue fields:
+
+| Field | Guidance |
+|---|---|
+| `SourceControlBMPAttribute` | The attribute name. Prefer a name from DomainContext's grouped `SourceControlBMPAttributes` when a close conceptual match exists; otherwise emit the document's wording verbatim. |
+| `IsPresent` | `"Yes"` if the document indicates the attribute is implemented / applicable / checked / committed-to. `"No"` if the document explicitly indicates the attribute is NOT implemented / NOT applicable / unchecked. Empty string (`""`) only when the document mentions the attribute but is genuinely silent on its presence. |
+| `SourceControlBMPNote` | Free-form note (≤200 chars) — the document's "Conditions if Yes" entry, a brief description, sizing detail, or any qualifier. Empty string (`""`) if there is no note. |
+</output_fields>
+
+<edge_cases>
+- The same attribute mentioned in multiple sections → emit once.
+- BMP codes like "N7" or "SC-32" should NOT appear in `SourceControlBMPAttribute.Value` — map them to the DomainContext attribute name. Codes can appear in the note if helpful.
+- When a field's `Value` is an empty string, also set `ExtractionEvidence` and `DocumentSource` to empty strings and every `BoundingBox` number (`PageNumber`, `X`, `Y`, `Width`, `Height`) to 0.
+- If a BMP only appears in a generic glossary or template appendix without project-specific commitment, do not extract.
+</edge_cases>
+
+The schema for each emitted item:
+{{Schema}}
+
+Return a JSON object containing an `"items"` array (empty only if no Source Control BMP discussion is present anywhere in the document).

--- a/Neptune.API/Services/AI/Prompts/ExtractWqmpFields_v3.md
+++ b/Neptune.API/Services/AI/Prompts/ExtractWqmpFields_v3.md
@@ -1,0 +1,12 @@
+{{EvidenceInstructions}}
+
+<task>
+Extract root-level WQMP attributes from the uploaded Water Quality Management Plan PDF (Orange County, CA). For fields whose value should match a controlled vocabulary — `Jurisdiction`, `HydrologicSubarea`, `WaterQualityManagementPlanLandUse`, `WaterQualityManagementPlanPriority`, `WaterQualityManagementPlanStatus`, `WaterQualityManagementPlanDevelopmentType`, `WaterQualityManagementPlanPermitTerm`, `TrashCaptureStatusType`, `HydromodificationAppliesType` — match the document's text to the corresponding list in DomainContext when a close match exists.
+</task>
+
+When you cannot determine a field from the document, set its `Value`, `ExtractionEvidence`, and `DocumentSource` to empty strings (`""`) and set every `BoundingBox` number (`PageNumber`, `X`, `Y`, `Width`, `Height`) to 0. Do not infer plausible values from defaults, general knowledge, or related fields — the empty string is the correct answer when the document does not specify.
+
+The schema:
+{{Schema}}
+
+Return a single JSON object matching the schema.

--- a/Neptune.API/Services/AI/WqmpExtractionService.cs
+++ b/Neptune.API/Services/AI/WqmpExtractionService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Anthropic;
@@ -71,14 +72,18 @@ public class WqmpExtractionService
 
         var domainContext = await BuildDomainContext();
 
+        // NPT-1106 round 3: "not found" is expressed with sentinels ("" for the three strings,
+        // all-zero BoundingBox) instead of nulls — strict tool use caps union-typed schema
+        // parameters at 16 per request, and nullable-everywhere schemas carried 132.
+        // NormalizeNotFoundSentinels converts the sentinels back to nulls post-receive, so the
+        // stored ExtractionResultJson contract is unchanged.
         var evidenceInstructions =
             $"SchemaVersion: {SchemaVersion}. Use ONLY the provided WQMP PDF. Each attribute object MUST match ExtractedValueSchema. " +
-            "Value = raw extracted string or null; ExtractionEvidence = source snippet (preceding sentence, target sentence, following sentence OR nearby table text); DocumentSource = page reference (e.g. 'Page 12'). " +
+            "Value = raw extracted string, or empty string \"\" when not found; ExtractionEvidence = source snippet (preceding sentence, target sentence, following sentence OR nearby table text); DocumentSource = page reference (e.g. 'Page 12'). " +
             "BoundingBox = {PageNumber, X, Y, Width, Height} locating the evidence on the page. X/Y/Width/Height are 0-1 fractions of page size where (0,0) is top-left and (1,1) is bottom-right. " +
-            "ALWAYS emit BoundingBox whenever Value is not null. The rectangle should tightly cover the ACTUAL TEXT of ExtractionEvidence — measure from the top of the character baselines to the bottom, and from the first character to the last. Do NOT center the box on surrounding whitespace, adjacent paragraphs, or 'the general area'; point directly at the text characters themselves. " +
+            "ALWAYS emit a real BoundingBox whenever Value is non-empty. The rectangle should tightly cover the ACTUAL TEXT of ExtractionEvidence — measure from the top of the character baselines to the bottom, and from the first character to the last. Do NOT center the box on surrounding whitespace, adjacent paragraphs, or 'the general area'; point directly at the text characters themselves. " +
             "For scanned/rasterized pages, look at the page image and estimate from the ink positions. Use a typical line height of ~0.02–0.04 (2–4% of page height) for a single-line field value; taller for multi-line evidence. " +
-            "Only set BoundingBox to null if Value is also null (field not found in the document). " +
-            "If not found, set Value, ExtractionEvidence, DocumentSource, BoundingBox to null. Do not add or rename properties.\n" +
+            "If a field is not found in the document: set Value, ExtractionEvidence, and DocumentSource to empty strings and set every BoundingBox number (PageNumber, X, Y, Width, Height) to 0. Do not add or rename properties.\n" +
             $"ExtractedValueSchema: {ExtractedValueSchema.Value}";
 
         // Build all 4 tools upfront — identical across all parallel calls so the tools-level cache is shared.
@@ -200,6 +205,12 @@ public class WqmpExtractionService
                 }
                 else
                 {
+                    // NPT-1106 round 3: the strict schemas express "not found" as sentinels
+                    // ("" strings / all-zero BoundingBox) to stay under the 16-union strict
+                    // compilation cap. Convert them back to nulls here so the stored
+                    // ExtractionResultJson keeps the original null-based contract the SPA
+                    // review wizard and the approve endpoint consume.
+                    output = NormalizeNotFoundSentinels(output);
                     _logger.LogInformation("Finished extraction category: {Category} in {ElapsedMs}ms ({OutputChars} chars, cached={CachedTokens})",
                         key, catSw.ElapsedMilliseconds, output.Length, cachedTokens);
                 }
@@ -433,10 +444,18 @@ public class WqmpExtractionService
             // double-encoded string with unescaped quotes / trailing commas that no regex
             // cleanup could reliably repair. Strict requires additionalProperties:false +
             // required on every object INCLUDING the root, so the schema JSON is passed to
-            // InputSchema wholesale via the raw-data constructor — the previous
-            // Properties/Required-only initializer silently dropped the root-level
-            // additionalProperties:false.
-            Strict = true,
+            // InputSchema wholesale via the raw-data constructor.
+            //
+            // Strict is per-category: the API compiles EVERY strict tool in the request into a
+            // grammar and rejects the request when the combined grammar is too large ("The
+            // compiled grammar is too large"). All four tools ride in every request so the
+            // prompt-cache prefix (tools -> system -> the large PDF) stays identical across the
+            // four parallel category calls — flipping Strict per call would split that cache
+            // four ways. Instead the WQMP tool (22 of the 33 ExtractedValue objects — the bulk
+            // of the grammar) stays non-strict: its single-object output has never exhibited
+            // the corruption class, which lives in the array categories' `items` handling
+            // (SourceControlBMPs above all — see NPT-1054). The three array tools stay strict.
+            Strict = categoryKey != "WQMP",
             InputSchema = new(parsed ?? new Dictionary<string, JsonElement>()),
         };
     }
@@ -480,15 +499,78 @@ public class WqmpExtractionService
         try { using var _ = JsonDocument.Parse(candidate); return true; } catch { return false; }
     }
 
+    // NPT-1106 round 3: the strict tool schemas can't use nullable/union types (Anthropic caps
+    // union-typed parameters at 16 per request; nullable-everywhere carried 132), so "not
+    // found" arrives as sentinels: empty strings for Value/ExtractionEvidence/DocumentSource
+    // and an all-zero BoundingBox (PageNumber 0). This walks the category output and restores
+    // the null-based contract every downstream consumer (SPA review wizard, approve endpoint,
+    // stored ExtractionResultJson) was built against. Defensive: any parse hiccup returns the
+    // input unchanged — the caller already validated it as JSON.
+    public static string NormalizeNotFoundSentinels(string json)
+    {
+        try
+        {
+            var root = JsonNode.Parse(json);
+            if (root == null) return json;
+            NormalizeNode(root);
+            return root.ToJsonString();
+        }
+        catch (Exception)
+        {
+            return json;
+        }
+    }
+
+    private static void NormalizeNode(JsonNode node)
+    {
+        switch (node)
+        {
+            case JsonObject obj when obj.ContainsKey("Value") && obj.ContainsKey("BoundingBox"):
+                // ExtractedValue shape — apply the sentinel conversions and stop descending.
+                foreach (var key in new[] { "Value", "ExtractionEvidence", "DocumentSource" })
+                {
+                    if (obj[key] is JsonValue v && v.TryGetValue<string>(out var s) && string.IsNullOrWhiteSpace(s))
+                    {
+                        obj[key] = null;
+                    }
+                }
+                if (obj["BoundingBox"] is JsonObject boundingBox
+                    && boundingBox["PageNumber"] is JsonValue pageNumber
+                    && pageNumber.TryGetValue<double>(out var page) && page < 1)
+                {
+                    obj["BoundingBox"] = null;
+                }
+                break;
+            case JsonObject obj:
+                foreach (var property in obj.ToList())
+                {
+                    if (property.Value != null) NormalizeNode(property.Value);
+                }
+                break;
+            case JsonArray array:
+                foreach (var item in array.ToList())
+                {
+                    if (item != null) NormalizeNode(item);
+                }
+                break;
+        }
+    }
+
+    // NPT-1106 round 3: no union types anywhere in these schemas. Strict tool use compiles
+    // schemas into grammars server-side and caps union-typed parameters (type arrays / anyOf)
+    // at 16 per request; the previous nullable-everywhere shape carried 132 across the four
+    // tools and every extraction 400'd. "Not found" is now an empty string ("") for the three
+    // strings and an all-zero BoundingBox — NormalizeNotFoundSentinels restores nulls
+    // post-receive so downstream consumers see the original contract.
     private static object ExtractedValueProp(string description) => new
     {
         type = "object",
         description,
         properties = new
         {
-            Value = new { type = new[] { "string", "null" }, description = "Raw extracted value or null." },
-            ExtractionEvidence = new { type = new[] { "string", "null" }, description = "Source snippet or null." },
-            DocumentSource = new { type = new[] { "string", "null" }, description = "Page reference or null." },
+            Value = new { type = "string", description = "Raw extracted value; empty string when not found." },
+            ExtractionEvidence = new { type = "string", description = "Source snippet; empty string when not found." },
+            DocumentSource = new { type = "string", description = "Page reference; empty string when not found." },
             BoundingBox = BoundingBoxProp()
         },
         required = new[] { "Value", "ExtractionEvidence", "DocumentSource", "BoundingBox" },
@@ -496,16 +578,16 @@ public class WqmpExtractionService
     };
 
     // Spatial hint for the evidence region on the page. Normalized 0-1 fractions relative
-    // to the page's own width/height, top-left origin. Claude should emit this whenever
-    // Value is non-null — a rough estimate is more useful than null. Only null when the
-    // field wasn't found in the document.
+    // to the page's own width/height, top-left origin. Claude should emit a real box whenever
+    // Value is non-empty — a rough estimate is more useful than none. All-zero (PageNumber 0)
+    // is the not-found sentinel; NormalizeNotFoundSentinels converts it back to null.
     private static object BoundingBoxProp() => new
     {
-        type = new[] { "object", "null" },
-        description = "Required {PageNumber, X, Y, Width, Height} locating the evidence on its page. X/Y/Width/Height are 0-1 fractions of page size (top-left origin). Null only when Value is null.",
+        type = "object",
+        description = "Required {PageNumber, X, Y, Width, Height} locating the evidence on its page. X/Y/Width/Height are 0-1 fractions of page size (top-left origin). Set every number to 0 only when Value is empty (field not found).",
         properties = new
         {
-            PageNumber = new { type = "integer", description = "1-based page index." },
+            PageNumber = new { type = "integer", description = "1-based page index; 0 when the field was not found." },
             X = new { type = "number", description = "Left edge, fraction of page width." },
             Y = new { type = "number", description = "Top edge, fraction of page height." },
             Width = new { type = "number", description = "Width, fraction of page width." },
@@ -525,9 +607,9 @@ public class WqmpExtractionService
             description = "ExtractedValue schema. Attribute with evidence.",
             properties = new
             {
-                Value = new { type = new[] { "string", "null" }, description = "Raw extracted value or null." },
-                ExtractionEvidence = new { type = new[] { "string", "null" }, description = "Snippet: preceding, target, following sentence OR nearby table text." },
-                DocumentSource = new { type = new[] { "string", "null" }, description = "Page reference (e.g. 'Page 12')." },
+                Value = new { type = "string", description = "Raw extracted value; empty string when not found." },
+                ExtractionEvidence = new { type = "string", description = "Snippet: preceding, target, following sentence OR nearby table text; empty string when not found." },
+                DocumentSource = new { type = "string", description = "Page reference (e.g. 'Page 12'); empty string when not found." },
                 BoundingBox = BoundingBoxProp()
             },
             required = new[] { "Value", "ExtractionEvidence", "DocumentSource", "BoundingBox" },
@@ -574,27 +656,45 @@ public class WqmpExtractionService
         return JsonSerializer.Serialize(schema);
     }
 
+    // NPT-1106 round 3: the array-category schemas define ExtractedValue ONCE in $defs and
+    // $ref it per field. Strict grammar compilation counts every inlined object — the three
+    // array tools inlined (11 ExtractedValues) exceeded the "compiled grammar is too large"
+    // cap (QuickBMPs' 7 alone did), while the identical shapes with $refs compile fine
+    // (verified against the live API). Per-field guidance rides as a sibling `description`
+    // next to each $ref, which the strict validator accepts.
     private static string WrapAsArraySchema(string description, object itemSchema)
     {
-        var schema = new
+        var schema = new Dictionary<string, object>
         {
-            type = "object",
-            description,
-            properties = new Dictionary<string, object>
+            ["type"] = "object",
+            ["description"] = description,
+            ["$defs"] = new Dictionary<string, object>
+            {
+                ["ExtractedValue"] = ExtractedValueProp("Attribute with evidence.")
+            },
+            ["properties"] = new Dictionary<string, object>
             {
                 ["items"] = new { type = "array", items = itemSchema }
             },
-            required = new[] { "items" },
-            additionalProperties = false
+            ["required"] = new[] { "items" },
+            ["additionalProperties"] = false
         };
         return JsonSerializer.Serialize(schema);
     }
+
+    // Field property for array-category item schemas: a $ref to the shared ExtractedValue
+    // definition plus the per-field guidance as a sibling description.
+    private static Dictionary<string, object> ExtractedValueRef(string description) => new()
+    {
+        ["$ref"] = "#/$defs/ExtractedValue",
+        ["description"] = description
+    };
 
     private static object BuildParcelItemSchema()
     {
         var properties = new Dictionary<string, object>
         {
-            ["ParcelNumber"] = ExtractedValueProp("APN (e.g. XXX-XX-XXX or XXX-XXX-XX)")
+            ["ParcelNumber"] = ExtractedValueRef("APN (e.g. XXX-XX-XXX or XXX-XXX-XX)")
         };
         return new
         {
@@ -616,13 +716,13 @@ public class WqmpExtractionService
     {
         var properties = new Dictionary<string, object>
         {
-            ["QuickBMPName"] = ExtractedValueProp("Simple BMP name as written in the document."),
-            ["TreatmentBMPType"] = ExtractedValueProp("BMP type/classification name; should match a TreatmentBMPType from DomainContext when possible."),
-            ["NumberOfIndividualBMPs"] = ExtractedValueProp("Count of individual physical BMP units this row represents (default 1 if not stated)."),
-            ["PercentOfSiteTreated"] = ExtractedValueProp("% of the WQMP site this BMP treats (0-100)."),
-            ["PercentCaptured"] = ExtractedValueProp("% of design storm captured by this BMP (0-100)."),
-            ["PercentRetained"] = ExtractedValueProp("% of design storm retained on-site (0-100; must be <= PercentCaptured)."),
-            ["QuickBMPNote"] = ExtractedValueProp("Free-form note about this BMP (≤200 chars).")
+            ["QuickBMPName"] = ExtractedValueRef("Simple BMP name as written in the document."),
+            ["TreatmentBMPType"] = ExtractedValueRef("BMP type/classification name; should match a TreatmentBMPType from DomainContext when possible."),
+            ["NumberOfIndividualBMPs"] = ExtractedValueRef("Count of individual physical BMP units this row represents (default 1 if not stated)."),
+            ["PercentOfSiteTreated"] = ExtractedValueRef("% of the WQMP site this BMP treats (0-100)."),
+            ["PercentCaptured"] = ExtractedValueRef("% of design storm captured by this BMP (0-100)."),
+            ["PercentRetained"] = ExtractedValueRef("% of design storm retained on-site (0-100; must be <= PercentCaptured)."),
+            ["QuickBMPNote"] = ExtractedValueRef("Free-form note about this BMP (≤200 chars).")
         };
         return new
         {
@@ -640,9 +740,9 @@ public class WqmpExtractionService
     {
         var properties = new Dictionary<string, object>
         {
-            ["SourceControlBMPAttribute"] = ExtractedValueProp("Source control attribute name."),
-            ["IsPresent"] = ExtractedValueProp("Indicates presence (Yes/No)."),
-            ["SourceControlBMPNote"] = ExtractedValueProp("Attribute notes.")
+            ["SourceControlBMPAttribute"] = ExtractedValueRef("Source control attribute name."),
+            ["IsPresent"] = ExtractedValueRef("Indicates presence (Yes/No)."),
+            ["SourceControlBMPNote"] = ExtractedValueRef("Attribute notes.")
         };
         return new
         {

--- a/Neptune.Tests/WqmpExtractionSentinelTests.cs
+++ b/Neptune.Tests/WqmpExtractionSentinelTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.API.Services.AI;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1106 round 3: strict tool use caps union-typed schema parameters at 16 per request,
+    /// so the extraction schemas express "not found" as sentinels (empty strings, all-zero
+    /// BoundingBox) instead of nulls. NormalizeNotFoundSentinels must restore the null-based
+    /// contract the SPA review wizard and approve endpoint consume — pin that translation.
+    /// </summary>
+    [TestClass]
+    public class WqmpExtractionSentinelTests
+    {
+        [TestMethod]
+        public void NotFoundSentinels_BecomeNulls()
+        {
+            const string input = """
+                {"WaterQualityManagementPlanName":{"Value":"","ExtractionEvidence":"","DocumentSource":"","BoundingBox":{"PageNumber":0,"X":0,"Y":0,"Width":0,"Height":0}}}
+                """;
+
+            var normalized = WqmpExtractionService.NormalizeNotFoundSentinels(input);
+            using var doc = JsonDocument.Parse(normalized);
+            var field = doc.RootElement.GetProperty("WaterQualityManagementPlanName");
+
+            Assert.AreEqual(JsonValueKind.Null, field.GetProperty("Value").ValueKind);
+            Assert.AreEqual(JsonValueKind.Null, field.GetProperty("ExtractionEvidence").ValueKind);
+            Assert.AreEqual(JsonValueKind.Null, field.GetProperty("DocumentSource").ValueKind);
+            Assert.AreEqual(JsonValueKind.Null, field.GetProperty("BoundingBox").ValueKind);
+        }
+
+        [TestMethod]
+        public void FoundValues_PassThroughUnchanged()
+        {
+            const string input = """
+                {"Jurisdiction":{"Value":"City of Brea","ExtractionEvidence":"the City of Brea shall...","DocumentSource":"Page 3","BoundingBox":{"PageNumber":3,"X":0.1,"Y":0.2,"Width":0.5,"Height":0.03}}}
+                """;
+
+            var normalized = WqmpExtractionService.NormalizeNotFoundSentinels(input);
+            using var doc = JsonDocument.Parse(normalized);
+            var field = doc.RootElement.GetProperty("Jurisdiction");
+
+            Assert.AreEqual("City of Brea", field.GetProperty("Value").GetString());
+            Assert.AreEqual("Page 3", field.GetProperty("DocumentSource").GetString());
+            Assert.AreEqual(3, field.GetProperty("BoundingBox").GetProperty("PageNumber").GetInt32());
+        }
+
+        [TestMethod]
+        public void MixedFields_NormalizeIndependently_IncludingInsideArrays()
+        {
+            // Array-category shape: { "items": [ { <ExtractedValue fields> }, ... ] } — the
+            // SourceControlBMPs "No with no note" case must keep IsPresent and null the note.
+            const string input = """
+                {"items":[{"SourceControlBMPAttribute":{"Value":"Street Trees","ExtractionEvidence":"checklist row","DocumentSource":"Page 9","BoundingBox":{"PageNumber":9,"X":0.1,"Y":0.5,"Width":0.3,"Height":0.02}},"IsPresent":{"Value":"No","ExtractionEvidence":"[x] No","DocumentSource":"Page 9","BoundingBox":{"PageNumber":9,"X":0.6,"Y":0.5,"Width":0.1,"Height":0.02}},"SourceControlBMPNote":{"Value":"","ExtractionEvidence":"","DocumentSource":"","BoundingBox":{"PageNumber":0,"X":0,"Y":0,"Width":0,"Height":0}}}]}
+                """;
+
+            var normalized = WqmpExtractionService.NormalizeNotFoundSentinels(input);
+            using var doc = JsonDocument.Parse(normalized);
+            var item = doc.RootElement.GetProperty("items")[0];
+
+            Assert.AreEqual("No", item.GetProperty("IsPresent").GetProperty("Value").GetString(),
+                "an explicit 'No' answer must survive normalization untouched");
+            Assert.AreEqual(JsonValueKind.Null, item.GetProperty("SourceControlBMPNote").GetProperty("Value").ValueKind);
+            Assert.AreEqual(JsonValueKind.Null, item.GetProperty("SourceControlBMPNote").GetProperty("BoundingBox").ValueKind);
+            Assert.AreEqual(9, item.GetProperty("IsPresent").GetProperty("BoundingBox").GetProperty("PageNumber").GetInt32());
+        }
+
+        [TestMethod]
+        public void NonExtractedValueObjects_AreLeftAlone()
+        {
+            const string input = """{"SchemaVersion":"3","Notes":"","Count":0}""";
+            var normalized = WqmpExtractionService.NormalizeNotFoundSentinels(input);
+            using var doc = JsonDocument.Parse(normalized);
+
+            Assert.AreEqual("", doc.RootElement.GetProperty("Notes").GetString(),
+                "empty strings outside the ExtractedValue shape must not be nulled");
+        }
+
+        // The Anthropic strict-schema compiler enforces two hard caps this suite pins the
+        // schemas against: max 16 union-typed parameters per request (type arrays / anyOf),
+        // and a total compiled-grammar size that inlined ExtractedValue objects exceeded —
+        // the array-category schemas must use a single $defs/ExtractedValue definition with
+        // $ref fields (verified compilable against the live API; inlined equivalents 400).
+        private static string BuildSchema(string builderName)
+        {
+            var method = typeof(WqmpExtractionService).GetMethod(builderName,
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            Assert.IsNotNull(method, $"Expected private static {builderName}() on WqmpExtractionService.");
+            return (string)method!.Invoke(null, null)!;
+        }
+
+        [DataTestMethod]
+        [DataRow("BuildParcelSchemaJson")]
+        [DataRow("BuildQuickBmpSchemaJson")]
+        [DataRow("BuildSourceControlBmpSchemaJson")]
+        public void ArrayCategorySchemas_UseSharedExtractedValueDefinition(string builderName)
+        {
+            var json = BuildSchema(builderName);
+            using var doc = JsonDocument.Parse(json);
+
+            Assert.IsTrue(doc.RootElement.GetProperty("$defs").TryGetProperty("ExtractedValue", out _),
+                $"{builderName}: array-category schemas must define ExtractedValue once in $defs — inlining it per field exceeds the strict grammar-size cap.");
+            Assert.IsTrue(json.Contains("\"$ref\":\"#/$defs/ExtractedValue\""),
+                $"{builderName}: item fields must $ref the shared definition.");
+        }
+
+        [DataTestMethod]
+        [DataRow("BuildWqmpSchemaJson")]
+        [DataRow("BuildParcelSchemaJson")]
+        [DataRow("BuildQuickBmpSchemaJson")]
+        [DataRow("BuildSourceControlBmpSchemaJson")]
+        public void CategorySchemas_ContainNoUnionTypes(string builderName)
+        {
+            var json = BuildSchema(builderName);
+
+            Assert.IsFalse(json.Contains("\"type\":["),
+                $"{builderName}: union types (type arrays) are capped at 16 per strict request — 'not found' must use sentinels, not nullables.");
+            Assert.IsFalse(json.Contains("anyOf"),
+                $"{builderName}: anyOf counts against the same strict union cap.");
+        }
+    }
+}


### PR DESCRIPTION
Round 3: #609's `Strict = true` never actually ran — the first live extraction hit **two** Anthropic strict-schema compiler guardrails in sequence.

## Guardrail 1 — union-type cap (`limit: 16` per request)

The nullable-everywhere schemas (`type: [string, null]` ×3 + nullable BoundingBox per ExtractedValue; 33 ExtractedValues across the four tools) carried **132** union-typed parameters.

**Fix:** zero union types anywhere. "Not found" is a sentinel — empty string for the three text fields, all-zero BoundingBox (`PageNumber: 0`). New prompt versions (`ExtractWqmpFields_v3`, `ExtractParcels_v3`, `ExtractQuickBMPs_v4`, `ExtractSourceControlBMPs_v4`) instruct the convention, and a `NormalizeNotFoundSentinels` pass converts sentinels back to nulls post-receive — the stored `ExtractionResultJson` keeps the exact null-based contract the SPA review wizard and approve endpoint consume. **No downstream changes.**

## Guardrail 2 — compiled grammar size

The compiler inlines repeated object schemas: even the three array tools' 11 ExtractedValues exceeded the cap (QuickBMPs' 7 alone did). Verified against the live API with schema-only probe requests:

| Variant | Result |
|---|---|
| 3 array tools strict, inlined | 400 grammar too large |
| Same shapes with `$defs`/`$ref` | ✅ compiles |
| All 4 strict, even with refs | 400 — hard ceiling |
| `$ref` + sibling `description` | ✅ accepted |

**Fix:** array-category schemas define `ExtractedValue` once in `$defs` and `$ref` it per field (per-field guidance rides as sibling descriptions). `Strict` is per-category: the **three array tools stay strict** — every observed corruption (the malformed-`items` class, SourceControl above all) lived there — while the WQMP tool (22 of the 33 ExtractedValues, never corrupted; falls back to the existing repair path) is non-strict. The tool list stays byte-identical across the four parallel calls, so the prompt-cache prefix (tools → system → PDF) still shares.

## Tests

11 unit tests in `WqmpExtractionSentinelTests`: sentinel→null normalization (including the SC "explicit No with empty note" case and non-ExtractedValue empty strings left untouched), the `$defs`/`$ref` shape pinned on all three array schemas, and zero-union-types pinned on all four schemas — neither guardrail class can silently regress.

## Verification

Live extraction on a real PDF completes end-to-end (Ray); review wizard renders correct "(not set)" fields, confirming the sentinel→null round trip. First call per schema pays the one-time strict compilation (cached 24h).