### PR TITLE
NPT-1109: Fix Kathleen's AI extraction nits (area decimals, rejection persistence, Final WQMP doc)

### DIFF
--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -739,9 +739,14 @@ namespace Neptune.API.Controllers
         public async Task<ActionResult<WaterQualityManagementPlanExtractionResultDto>> RunExtraction(
             [FromRoute] int waterQualityManagementPlanID)
         {
-            // Primary document for the WQMP — uploaded in Step 1 (UploadDocument).
-            var document = WaterQualityManagementPlanDocuments.ListByWaterQualityManagementPlanID(DbContext, waterQualityManagementPlanID)
-                .FirstOrDefault();
+            // Primary document for the WQMP. Step 1 (UploadDocument) tags the initial upload as
+            // FinalWQMP, but a WQMP can accumulate other doc types (as-builts, O&M plans). NPT-1109
+            // (Kathleen): extract from the Final WQMP when one exists; otherwise fall back to the
+            // first document (list is ordered by DisplayName) so a WQMP whose docs were re-typed
+            // still extracts rather than erroring.
+            var documents = WaterQualityManagementPlanDocuments.ListByWaterQualityManagementPlanID(DbContext, waterQualityManagementPlanID);
+            var document = documents.FirstOrDefault(x => x.WaterQualityManagementPlanDocumentTypeID == (int)WaterQualityManagementPlanDocumentTypeEnum.FinalWQMP)
+                ?? documents.FirstOrDefault();
             if (document == null)
             {
                 return BadRequest(new { message = "No uploaded document found for this WQMP. Upload a PDF before running extraction." });

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -57,6 +57,10 @@ export interface ExtractedField {
     step: number;
     acceptedValue?: string | null;
     state: "pending" | "accepted" | "edited" | "rejected";
+    // NPT-1109: set once a rejection has been committed by a section save. Keeps the field
+    // rejected (so the AI value isn't re-offered) while telling hasUnsavedChanges it's clean —
+    // a bare "rejected" state counts as dirty and would strand the UnsavedChangesGuard.
+    rejectionSaved?: boolean;
     fieldType?: FormFieldType;
     selectOptions?: SelectDropdownOption[];
     // ngx-mask pattern to apply in the form-field (e.g. "(000) 000-0000"). Optional.
@@ -190,6 +194,8 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
         return this.fields().some((f) => {
             if (f.state === "pending") return false;
             if (f.isUserEntered && f.state === "accepted") return false;
+            // NPT-1109: a rejection already committed by a save is settled, not pending work.
+            if (f.state === "rejected" && f.rejectionSaved) return false;
             return true;
         }) || this.rejectedBmpIndices().size > 0;
     });
@@ -1144,6 +1150,8 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     onFieldRejected(field: ExtractedField): void {
         field.state = "rejected";
         field.acceptedValue = null;
+        // NPT-1109: a brand-new rejection is unsaved work until the section Save commits it.
+        field.rejectionSaved = false;
         if (field.key === "TrashCaptureStatusType") this.syncTrashCaptureEffectivenessReadOnly();
         this.fields.update((f) => [...f]);
     }
@@ -1676,16 +1684,23 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
         // "pending" here re-offered the AI value as a fresh suggestion (initialValue is
         // acceptedValue ?? value, and reject nulls acceptedValue) — so returning to the step made
         // the rejection vanish and the next save would re-write the value the reviewer rejected.
-        this.fields.update((current) => current.map((f) => (keyset.has(f.key) && f.state !== "rejected")
-            ? { ...f, state: "pending" as const }
-            : f));
+        // Keep the rejected state but flag it saved so hasUnsavedChanges stops counting it dirty.
+        this.fields.update((current) => current.map((f) => {
+            if (!keyset.has(f.key)) return f;
+            return f.state === "rejected"
+                ? { ...f, rejectionSaved: true }
+                : { ...f, state: "pending" as const, rejectionSaved: false };
+        }));
     }
 
     private markParcelFieldsClean(): void {
         // NPT-1109: preserve rejected parcels for the same reason as markSectionFieldsClean.
-        this.fields.update((current) => current.map((f) => (f.key.startsWith(this.PARCEL_KEY_PREFIX) && f.state !== "rejected")
-            ? { ...f, state: "pending" as const }
-            : f));
+        this.fields.update((current) => current.map((f) => {
+            if (!f.key.startsWith(this.PARCEL_KEY_PREFIX)) return f;
+            return f.state === "rejected"
+                ? { ...f, rejectionSaved: true }
+                : { ...f, state: "pending" as const, rejectionSaved: false };
+        }));
     }
 
     private markBmpFieldsClean(): void {
@@ -1960,10 +1975,12 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
             // decimals. Round to 2 decimals up front so the auto-filled value matches what the
             // column stores — otherwise the save persists the rounded value while the wizard's
             // displayValue keeps the 4-decimal string, and the Review summary reads "Pending save"
-            // forever (getSaveStatus is a pure displayValue === wqmpRecordValue diff).
+            // forever (getSaveStatus is a pure displayValue === wqmpRecordValue diff). Canonicalize
+            // via String(number) rather than toFixed(2) so the shape matches the record column,
+            // which comes back as String(raw) ("1.2", not "1.20") — toFixed would re-strand the row.
             if (rawValue != null && rawValue !== "") {
                 const parsed = parseFloat(rawValue);
-                if (!isNaN(parsed)) value = parsed.toFixed(2);
+                if (!isNaN(parsed)) value = String(Math.round(parsed * 100) / 100);
             }
         } else if (key === "TrashCaptureEffectiveness") {
             // AI extraction doesn't produce this; it's a manual percentage the user enters when

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -1546,8 +1546,9 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                 } else {
                     const parsed = parseFloat(v);
                     // NPT-1109: guard the decimal(6,2) column — round even if a 4-decimal value
-                    // slips past makeField's rounding (e.g. a manually typed entry).
-                    if (!isNaN(parsed)) dto.RecordedWQMPAreaInAcres = Math.round(parsed * 100) / 100;
+                    // slips past makeField's rounding (e.g. a manually typed entry). toFixed(2)
+                    // gives predictable half-up rounding vs. Math.round's float-multiply edge cases.
+                    if (!isNaN(parsed)) dto.RecordedWQMPAreaInAcres = Number(parsed.toFixed(2));
                 }
                 continue;
             }
@@ -1704,9 +1705,17 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     }
 
     private markBmpFieldsClean(): void {
-        this.fields.update((current) => current.map((f) => f.key.startsWith(this.BMP_KEY_PREFIX)
-            ? { ...f, state: "pending" as const }
-            : f));
+        // NPT-1109: preserve per-field BMP attribute rejections after a save for the same reason
+        // as markSectionFieldsClean — buildQuickBMPsForSave blanks rejected attributes (valueOf
+        // returns null), so resetting them to "pending" would re-offer the AI value in the card
+        // and re-write it on the next save. Card-level rejections (rejectedBmpIndices) are cleared
+        // as before: a dropped BMP isn't created, so there's no per-field value to keep rejected.
+        this.fields.update((current) => current.map((f) => {
+            if (!f.key.startsWith(this.BMP_KEY_PREFIX)) return f;
+            return f.state === "rejected"
+                ? { ...f, rejectionSaved: true }
+                : { ...f, state: "pending" as const, rejectionSaved: false };
+        }));
         this.rejectedBmpIndices.set(new Set());
     }
 
@@ -1975,12 +1984,13 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
             // decimals. Round to 2 decimals up front so the auto-filled value matches what the
             // column stores — otherwise the save persists the rounded value while the wizard's
             // displayValue keeps the 4-decimal string, and the Review summary reads "Pending save"
-            // forever (getSaveStatus is a pure displayValue === wqmpRecordValue diff). Canonicalize
-            // via String(number) rather than toFixed(2) so the shape matches the record column,
-            // which comes back as String(raw) ("1.2", not "1.20") — toFixed would re-strand the row.
+            // forever (getSaveStatus is a pure displayValue === wqmpRecordValue diff). Round with
+            // toFixed(2) for predictable half-up behavior, then coerce back through Number(...) so
+            // the string shape matches the record column — which comes back as String(raw) ("1.2",
+            // not "1.20"). String(Number(...)) drops the trailing zero toFixed would otherwise add.
             if (rawValue != null && rawValue !== "") {
                 const parsed = parseFloat(rawValue);
-                if (!isNaN(parsed)) value = String(Math.round(parsed * 100) / 100);
+                if (!isNaN(parsed)) value = String(Number(parsed.toFixed(2)));
             }
         } else if (key === "TrashCaptureEffectiveness") {
             // AI extraction doesn't produce this; it's a manual percentage the user enters when

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-review/wqmp-review.component.ts
@@ -1537,7 +1537,9 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
                     dto.RecordedWQMPAreaInAcres = null;
                 } else {
                     const parsed = parseFloat(v);
-                    if (!isNaN(parsed)) dto.RecordedWQMPAreaInAcres = parsed;
+                    // NPT-1109: guard the decimal(6,2) column — round even if a 4-decimal value
+                    // slips past makeField's rounding (e.g. a manually typed entry).
+                    if (!isNaN(parsed)) dto.RecordedWQMPAreaInAcres = Math.round(parsed * 100) / 100;
                 }
                 continue;
             }
@@ -1670,13 +1672,18 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
     // though the save persisted. Resetting state alone keeps hasUnsavedChanges correct.
     private markSectionFieldsClean(sectionKeys: string[]): void {
         const keyset = new Set(sectionKeys);
-        this.fields.update((current) => current.map((f) => keyset.has(f.key)
+        // NPT-1109 (Kathleen): a rejected field must STAY rejected after a save. Resetting it to
+        // "pending" here re-offered the AI value as a fresh suggestion (initialValue is
+        // acceptedValue ?? value, and reject nulls acceptedValue) — so returning to the step made
+        // the rejection vanish and the next save would re-write the value the reviewer rejected.
+        this.fields.update((current) => current.map((f) => (keyset.has(f.key) && f.state !== "rejected")
             ? { ...f, state: "pending" as const }
             : f));
     }
 
     private markParcelFieldsClean(): void {
-        this.fields.update((current) => current.map((f) => f.key.startsWith(this.PARCEL_KEY_PREFIX)
+        // NPT-1109: preserve rejected parcels for the same reason as markSectionFieldsClean.
+        this.fields.update((current) => current.map((f) => (f.key.startsWith(this.PARCEL_KEY_PREFIX) && f.state !== "rejected")
             ? { ...f, state: "pending" as const }
             : f));
     }
@@ -1949,6 +1956,15 @@ export class WqmpReviewComponent implements OnInit, IDeactivateComponent {
             }
         } else if (key === "RecordedWQMPAreaInAcres") {
             fieldType = FormFieldType.Number;
+            // NPT-1109 (Kathleen): the DB column is decimal(6,2), but the AI can extract 4+
+            // decimals. Round to 2 decimals up front so the auto-filled value matches what the
+            // column stores — otherwise the save persists the rounded value while the wizard's
+            // displayValue keeps the 4-decimal string, and the Review summary reads "Pending save"
+            // forever (getSaveStatus is a pure displayValue === wqmpRecordValue diff).
+            if (rawValue != null && rawValue !== "") {
+                const parsed = parseFloat(rawValue);
+                if (!isNaN(parsed)) value = parsed.toFixed(2);
+            }
         } else if (key === "TrashCaptureEffectiveness") {
             // AI extraction doesn't produce this; it's a manual percentage the user enters when
             // TrashCaptureStatus = Partial. The post-build pass in parseExtractionResult marks


### PR DESCRIPTION
@
## NPT-1109 rework — Kathleen's AI Nits

The three original bugs (JurisdictionEditor document upload perms, AI review workflow perms, BMP search) all passed retest. This addresses the three follow-up defects Kathleen found in the WQMP AI extraction/review workflow.

### Nit 1 — WQMP Area stuck on "Pending save"
The AI extracts 4+ decimal places, but `RecordedWQMPAreaInAcres` is `decimal(6,2)`. The save persisted the SQL-rounded 2-decimal value, but the review wizard kept the 4-decimal string as its `displayValue`, so `getSaveStatus` (a pure `displayValue === wqmpRecordValue` diff) read "Pending save" forever.
- Round to 2 decimals at auto-fill in `makeField()` so the displayed value matches what the column stores.
- Defense-in-depth round in `buildSectionUpsertDto()` for manually typed entries.

### Nit 2 — Field rejection not persisting (Phone Number)
Rejecting a field then saving reset it back to `pending` in `markSectionFieldsClean()`; since reject nulls `acceptedValue`, the field re-rendered `acceptedValue ?? value` = the original AI suggestion — so the rejection vanished on returning to the step, and the next save would re-write the rejected value.
- Preserve `state === "rejected"` through `markSectionFieldsClean()` and `markParcelFieldsClean()`. Scope is in-session (survives step navigation + saves), consistent with the extraction flow having no server-side per-field state (NPT-1051).

### Nit 3 — Multi-document extraction picked the wrong doc
`RunExtraction` selected `.FirstOrDefault()` (first alphabetically by DisplayName) with no type filter, so a non-primary doc could be sent to the AI.
- Prefer the `FinalWQMP` document when present; fall back to the first document when none is typed Final WQMP.

## Testing
- Backend builds clean (0 errors). No codegen / no DB changes (Nit 3 changes internal selection logic only).
- Verified in browser: 4-decimal area now auto-fills 2 decimals and saves without a stuck "Pending save"; rejected Phone survives navigation back to Basics; multi-doc WQMP extracts from the Final WQMP doc.
@