### PR TITLE
NPT-1110: Unify upload size limits at 400 MB (fix 30 MB request-body rejection)

### DIFF
--- a/Neptune.API/Controllers/DelineationGeometryController.cs
+++ b/Neptune.API/Controllers/DelineationGeometryController.cs
@@ -30,7 +30,7 @@ namespace Neptune.API.Controllers
     {
         [HttpPost("upload")]
         [JurisdictionEditFeature]
-        [RequestFormLimits(MultipartBodyLengthLimit = 524288000)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
         [Consumes("multipart/form-data")]
         public async Task<ActionResult<DelineationGdbUploadValidationDto>> Upload([FromForm] DelineationGdbUploadFormDto form)
         {

--- a/Neptune.API/Controllers/FieldVisit/FieldVisitController.cs
+++ b/Neptune.API/Controllers/FieldVisit/FieldVisitController.cs
@@ -125,8 +125,8 @@ public class FieldVisitController(NeptuneDbContext dbContext, ILogger<FieldVisit
 
     [HttpPost("bulk-upload-trash-screen")]
     [JurisdictionEditFeature]
-    [RequestSizeLimit(100_000_000)]
-    [RequestFormLimits(MultipartBodyLengthLimit = 100_000_000)]
+    [RequestSizeLimit(400 * 1024 * 1024)]
+    [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
     [Consumes("multipart/form-data")]
     public async Task<ActionResult<TrashScreenFieldVisitUploadResultDto>> BulkUploadTrashScreen([FromForm] TrashScreenFieldVisitUploadFormDto form)
     {

--- a/Neptune.API/Controllers/LandUseBlockController.cs
+++ b/Neptune.API/Controllers/LandUseBlockController.cs
@@ -50,8 +50,8 @@ public class LandUseBlockController(
 
     [HttpPost("upload-gdb")]
     [JurisdictionEditFeature]
-    [RequestSizeLimit(524_288_000)]
-    [RequestFormLimits(MultipartBodyLengthLimit = 524_288_000)]
+    [RequestSizeLimit(400 * 1024 * 1024)]
+    [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
     [Consumes("multipart/form-data")]
     public async Task<ActionResult<LandUseBlockGdbUploadResultDto>> UploadGdb([FromForm] LandUseBlockGdbUploadFormDto form)
     {

--- a/Neptune.API/Controllers/OnlandVisualTrashAssessmentAreaController.cs
+++ b/Neptune.API/Controllers/OnlandVisualTrashAssessmentAreaController.cs
@@ -187,7 +187,7 @@ public class OnlandVisualTrashAssessmentAreaController(
 
     [HttpPost("gdb-upload")]
     [JurisdictionEditFeature]
-    [RequestFormLimits(MultipartBodyLengthLimit = 524288000)]
+    [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
     [Consumes("multipart/form-data")]
     public async Task<ActionResult<OvtaAreaGdbStagingReportDto>> GdbUpload([FromForm] OvtaAreaGdbUploadFormDto form)
     {

--- a/Neptune.API/Controllers/OnlandVisualTrashAssessmentController.cs
+++ b/Neptune.API/Controllers/OnlandVisualTrashAssessmentController.cs
@@ -202,8 +202,8 @@ public class OnlandVisualTrashAssessmentController(
 
     [HttpPost("bulk-upload")]
     [JurisdictionEditFeature]
-    [RequestSizeLimit(100_000_000)]
-    [RequestFormLimits(MultipartBodyLengthLimit = 100_000_000)]
+    [RequestSizeLimit(400 * 1024 * 1024)]
+    [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
     [Consumes("multipart/form-data")]
     public async Task<ActionResult<OvtaBulkUploadResultDto>> BulkUpload([FromForm] OvtaBulkUploadFormDto form)
     {

--- a/Neptune.API/Controllers/Project/ProjectController.cs
+++ b/Neptune.API/Controllers/Project/ProjectController.cs
@@ -123,8 +123,8 @@ namespace Neptune.API.Controllers
 
         [HttpPost("{projectID}/attachments")]
         [EntityNotFound(typeof(Project), "projectID")]
-        [RequestSizeLimit(30 * 1024 * 1024)]
-        [RequestFormLimits(MultipartBodyLengthLimit = 30 * 1024 * 1024), ProducesResponseType(StatusCodes.Status413RequestEntityTooLarge)]
+        [RequestSizeLimit(400 * 1024 * 1024)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024), ProducesResponseType(StatusCodes.Status413RequestEntityTooLarge)]
         [JurisdictionEditFeature]
         public async Task<ActionResult<ProjectDocumentDto>> AddAttachment([FromRoute] int projectID, [FromForm] ProjectDocumentUpsertDto projectDocumentUpsertDto)
         {

--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -486,8 +486,8 @@ public class TreatmentBMPController(
 
     [HttpPost("bulk-upload")]
     [AdminFeature]
-    [RequestSizeLimit(100_000_000)]
-    [RequestFormLimits(MultipartBodyLengthLimit = 100_000_000)]
+    [RequestSizeLimit(400 * 1024 * 1024)]
+    [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
     [Consumes("multipart/form-data")]
     public async Task<ActionResult<TreatmentBMPCsvUploadResultDto>> BulkUpload([FromForm] TreatmentBMPCsvUploadFormDto form)
     {

--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -157,6 +157,9 @@ namespace Neptune.API.Controllers
         // was previously missing entirely.
         [HttpPost("{waterQualityManagementPlanID}/documents")]
         [WaterQualityManagementPlanEditFeature]
+        [Consumes("multipart/form-data")]
+        [RequestSizeLimit(400 * 1024 * 1024)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         public async Task<ActionResult<WaterQualityManagementPlanDocumentDto>> CreateDocument(
             [FromRoute] int waterQualityManagementPlanID,
@@ -186,6 +189,9 @@ namespace Neptune.API.Controllers
         // File is optional — when present we delete the old blob and swap the FileResource.
         [HttpPut("{waterQualityManagementPlanID}/documents/{waterQualityManagementPlanDocumentID}")]
         [WaterQualityManagementPlanEditFeature]
+        [Consumes("multipart/form-data")]
+        [RequestSizeLimit(400 * 1024 * 1024)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         [EntityNotFound(typeof(WaterQualityManagementPlanDocument), "waterQualityManagementPlanDocumentID")]
         public async Task<ActionResult<WaterQualityManagementPlanDocumentDto>> UpdateDocument(
@@ -345,8 +351,8 @@ namespace Neptune.API.Controllers
         [HttpPost("{waterQualityManagementPlanID}/verifications/{waterQualityManagementPlanVerifyID}/supporting-documentation")]
         [JurisdictionEditFeature]
         [Consumes("multipart/form-data")]
-        [RequestSizeLimit(500 * 1024 * 1024)]
-        [RequestFormLimits(MultipartBodyLengthLimit = 500 * 1024 * 1024)]
+        [RequestSizeLimit(400 * 1024 * 1024)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
         [EntityNotFound(typeof(WaterQualityManagementPlan), "waterQualityManagementPlanID")]
         [EntityNotFound(typeof(WaterQualityManagementPlanVerify), "waterQualityManagementPlanVerifyID")]
         public async Task<ActionResult<WaterQualityManagementPlanVerifyDetailDto>> UploadVerificationSupportingDocumentation(
@@ -621,8 +627,8 @@ namespace Neptune.API.Controllers
         [HttpPost("upload")]
         [JurisdictionEditFeature]
         [Consumes("multipart/form-data")]
-        [RequestSizeLimit(200 * 1024 * 1024)]
-        [RequestFormLimits(MultipartBodyLengthLimit = 200 * 1024 * 1024)]
+        [RequestSizeLimit(400 * 1024 * 1024)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
         public async Task<ActionResult<WqmpUploadResultDto>> UploadDocument(
             IFormFile file, [FromForm] int stormwaterJurisdictionID, [FromForm] string wqmpName, [FromForm] bool overwrite = false)
         {
@@ -1040,8 +1046,8 @@ namespace Neptune.API.Controllers
 
         [HttpPost("bulk-upload-xlsx")]
         [JurisdictionEditFeature]
-        [RequestSizeLimit(100_000_000)]
-        [RequestFormLimits(MultipartBodyLengthLimit = 100_000_000)]
+        [RequestSizeLimit(400 * 1024 * 1024)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
         [Consumes("multipart/form-data")]
         public async Task<ActionResult<WqmpBulkUploadResultDto>> BulkUploadXlsx([FromForm] WQMPBulkUploadFormDto form)
         {
@@ -1083,8 +1089,8 @@ namespace Neptune.API.Controllers
 
         [HttpPost("upload-simplified-bmps")]
         [JurisdictionEditFeature]
-        [RequestSizeLimit(100_000_000)]
-        [RequestFormLimits(MultipartBodyLengthLimit = 100_000_000)]
+        [RequestSizeLimit(400 * 1024 * 1024)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
         [Consumes("multipart/form-data")]
         public async Task<ActionResult<WqmpBulkUploadResultDto>> UploadSimplifiedBMPs([FromForm] WQMPBulkUploadFormDto form)
         {
@@ -1126,8 +1132,8 @@ namespace Neptune.API.Controllers
 
         [HttpPost("upload-boundary-from-apns")]
         [JurisdictionEditFeature]
-        [RequestSizeLimit(100_000_000)]
-        [RequestFormLimits(MultipartBodyLengthLimit = 100_000_000)]
+        [RequestSizeLimit(400 * 1024 * 1024)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
         [Consumes("multipart/form-data")]
         public async Task<ActionResult<WQMPBoundaryUploadResultDto>> UploadBoundaryFromAPNs([FromForm] WQMPBulkUploadFormDto form)
         {

--- a/Neptune.API/Models/ProjectDocumentUpsertDto.cs
+++ b/Neptune.API/Models/ProjectDocumentUpsertDto.cs
@@ -27,8 +27,8 @@ namespace Neptune.Models.DataTransferObjects
             if (extension == null || !acceptableExtensions.Contains(extension.ToLower()))
                 yield return new ValidationResult("File extension is not valid", new[] { "FileResource" });
 
-            if (size > 30 * 1024 * 1024)
-                yield return new ValidationResult("File size is greater than 30MB", new[] { "FileResource" });
+            if (size > 400 * 1024 * 1024)
+                yield return new ValidationResult("File size is greater than 400MB", new[] { "FileResource" });
         }
     }
 }

--- a/Neptune.API/Services/NeptuneConfiguration.cs
+++ b/Neptune.API/Services/NeptuneConfiguration.cs
@@ -37,7 +37,7 @@ public class NeptuneConfiguration : NeptuneJobConfiguration
     /// 99%+ of real-world scanned WQMPs with headroom). Override per environment if
     /// needed.
     /// </summary>
-    public long MaxExtractablePdfSizeBytes { get; set; } = 200L * 1024 * 1024;
+    public long MaxExtractablePdfSizeBytes { get; set; } = 400L * 1024 * 1024;
     public string Auth0Domain { get; set; }
     public string Auth0ClientID { get; set; }
 }

--- a/Neptune.API/Startup.cs
+++ b/Neptune.API/Startup.cs
@@ -4,7 +4,9 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -50,6 +52,17 @@ namespace Neptune.API
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            // Kestrel's default MaxRequestBodySize is 30,000,000 bytes (~28.6 MB). Legitimate
+            // uploads — WQMP PDFs bound for AI extraction, GIS files, land use blocks — are
+            // larger, so raise the global transport cap. A per-endpoint [RequestFormLimits] is
+            // NOT enough on its own: it only lifts the multipart form-length limit, not Kestrel's
+            // body cap, so without this an oversized upload fails with "Request body too large.
+            // The max request body size is 30000000 bytes." before the endpoint's form is read.
+            // Per-endpoint [RequestSizeLimit] still narrows this where a smaller cap is wanted.
+            const long maxUploadBytes = 400L * 1024 * 1024; // 400 MB — unified WQMP PDF/upload ceiling
+            services.Configure<KestrelServerOptions>(options => options.Limits.MaxRequestBodySize = maxUploadBytes);
+            services.Configure<FormOptions>(options => options.MultipartBodyLengthLimit = maxUploadBytes);
+
             services.AddControllers(options =>
                 {
                     options.SuppressImplicitRequiredAttributeForNonNullableReferenceTypes = true;

--- a/Neptune.EFModels/Entities/FileResources.cs
+++ b/Neptune.EFModels/Entities/FileResources.cs
@@ -26,13 +26,13 @@ public class FileResources
             });
         }
 
-        const double maxFileSize = 500d * 1024d * 1024d;
+        const double maxFileSize = 400d * 1024d * 1024d;
         if (inputFile.Length > maxFileSize)
         {
             errors.Add(new ErrorMessage
             {
                 Type = "File Resource",
-                Message = "File size cannot exceed 500MB."
+                Message = "File size cannot exceed 400MB."
             });
         }
 

--- a/Neptune.Web/src/app/pages/planning-module/project-workflow/project-attachments/project-attachments.component.html
+++ b/Neptune.Web/src/app/pages/planning-module/project-workflow/project-attachments/project-attachments.component.html
@@ -32,7 +32,7 @@
                                     </button>
                                 </label>
                             </div>
-                            <em>Allowed extensions: pdf, zip, doc, docx, xls, xlsx, jpg, png. Max file size: 30 MB.</em>
+                            <em>Allowed extensions: pdf, zip, doc, docx, xls, xlsx, jpg, png. Max file size: 400 MB.</em>
                             <i class="fas fa-file-open"></i>
                         </div>
                         <div class="field mt-3">

--- a/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-document-modal/wqmp-document-modal.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmp-detail/wqmp-document-modal/wqmp-document-modal.component.html
@@ -19,6 +19,10 @@
                 Current file: <strong>{{ ref.data.document.FileResource.OriginalBaseFilename }}</strong>
             </p>
         }
+        <p class="copy copy-3 system-text mt-1">
+            PDFs used for AI extraction and chat must be <strong>100 pages or fewer</strong> and
+            <strong>400 MB or smaller</strong>. Larger documents upload fine but can't be AI-processed.
+        </p>
 
         <form-field
             size="md"

--- a/Neptune.Web/src/app/shared/components/forms/form-field/form-field.component.html
+++ b/Neptune.Web/src/app/shared/components/forms/form-field/form-field.component.html
@@ -152,7 +152,7 @@
                 </div>
                 <div class="copy copy-3 pt-2">
                     <em>
-                        Maximum total file size should not exceed 500MB. Accepted extensions:
+                        Maximum total file size should not exceed 400MB. Accepted extensions:
                         <strong>{{ uploadFileAccepts }}</strong>
                     </em>
                 </div>

--- a/Neptune.Web/src/app/shared/constants/pdf-extraction-limits.ts
+++ b/Neptune.Web/src/app/shared/constants/pdf-extraction-limits.ts
@@ -4,7 +4,7 @@
 // Update here if any of the limits change; all UI surfaces will follow.
 
 export const PDF_EXTRACTION_MAX_PAGES = 100;
-export const PDF_EXTRACTION_MAX_SIZE_MB = 200;
+export const PDF_EXTRACTION_MAX_SIZE_MB = 400;
 
 /**
  * Verbose bullet list — used in the Create-from-PDF upload modal where


### PR DESCRIPTION
## What & why

Fixes the production error uploading WQMP PDFs over ~30 MB:

> Failed to read the request form. Request body too large. The max request body size is 30000000 bytes.

That `30000000` is Kestrel's **default** `MaxRequestBodySize`, which was never overridden globally. The failing WQMP document endpoints (`CreateDocument` / `UpdateDocument`) also had no `[RequestSizeLimit]` — and `[RequestFormLimits]` alone only raises the multipart form limit, **not** Kestrel's transport cap, so several endpoints were silently stuck at 30 MB. Limits were also inconsistent app-wide (30 / ~95 / 200 / 500 MB) across endpoints, validators, config, and UI.

This unifies every upload surface at **400 MB**, which stays under Anthropic's Files API ceiling (500 MB / 100 pages) — the path WQMP PDFs take for AI extraction/chat via `AnthropicFileService`.

## Changes

- **`Startup.cs`** — global Kestrel `MaxRequestBodySize` + `FormOptions.MultipartBodyLengthLimit` = 400 MB (the real fix; no endpoint silently caps at 30 MB now)
- **Endpoints → 400 MB** — WQMP create/update/upload/verification/3× bulk; OVTA assessment + area GDB; TreatmentBMP; FieldVisit; LandUseBlock GDB; Delineation; Project attachments
- **Server-side validators → 400 MB** (value + message) — `ProjectDocumentUpsertDto.Validate`, `FileResources.ValidateFileUpload`
- **Config** — `NeptuneConfiguration.MaxExtractablePdfSizeBytes` 200 → 400 MB
- **Front-end** — shared `form-field` note, `pdf-extraction-limits.ts`, `wqmp-document-modal` (adds 100-page note), `project-attachments` text
- **Intentionally unchanged** — OVTA `observation-photo` stays 30 MB (field photos); `Neptune.ExternalAPI` / `Neptune.OverlayAPI` are separate hosts

## Testing notes

- Upload a >30 MB (e.g. ~50 MB) WQMP document — succeeds (previously 30 MB error)
- Upload >400 MB — rejected with a 400 MB message
- Run AI extraction on a valid scanned WQMP PDF (≤400 MB / ≤100 pages)
- Spot-check a Project attachment and one GIS upload

Ticket: NPT-1110
