### PR TITLE
NPT-1099: Add OVTA Areas reference layer to the OVTA Area map editor

### DIFF
--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.html
@@ -33,6 +33,12 @@
         } @else if (mapIsReady) {
         <land-use-block-layer [displayOnLoad]="true" [map]="map" [layerControl]="layerControl" [sortOrder]="20"></land-use-block-layer>
         } @if (mapIsReady) {
+        <ovta-areas-layer
+            [displayOnLoad]="true"
+            [map]="map"
+            [layerControl]="layerControl"
+            [sortOrder]="10"
+            [selectedJurisdictionID]="stormwaterJurisdictionID"></ovta-areas-layer>
         <transect-line-layer
             [displayOnLoad]="true"
             [map]="map"

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.html
@@ -38,7 +38,7 @@
             [map]="map"
             [layerControl]="layerControl"
             [sortOrder]="10"
-            [selectedJurisdictionID]="stormwaterJurisdictionID"></ovta-areas-layer>
+            [selectedJurisdictionID]="onlandVisualTrashAssessmentArea.StormwaterJurisdictionID"></ovta-areas-layer>
         <transect-line-layer
             [displayOnLoad]="true"
             [map]="map"

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-edit-location/trash-ovta-area-edit-location.component.ts
@@ -5,6 +5,7 @@ import { NeptuneMapComponent, NeptuneMapInitEvent } from "../../../../shared/com
 import * as L from "leaflet";
 import "@geoman-io/leaflet-geoman-free";
 import { LandUseBlockLayerComponent } from "../../../../shared/components/leaflet/layers/land-use-block-layer/land-use-block-layer.component";
+import { OvtaAreasLayerComponent } from "../../../../shared/components/leaflet/layers/ovta-areas-layer/ovta-areas-layer.component";
 import { SelectedLandUseBlockLayerComponent } from "../../../../shared/components/leaflet/layers/selected-land-use-block-layer/selected-land-use-block-layer.component";
 import { AsyncPipe } from "@angular/common";
 import { FormsModule } from "@angular/forms";
@@ -33,6 +34,7 @@ type EditMode = OvtaAreaSourceTypeEnum | "Draw";
         PageHeaderComponent,
         NeptuneMapComponent,
         LandUseBlockLayerComponent,
+        OvtaAreasLayerComponent,
         SelectedLandUseBlockLayerComponent,
         AsyncPipe,
         FormsModule,


### PR DESCRIPTION
## Context

When drawing/editing an OVTA Area's geometry, editors had no visual reference for neighboring OVTA Areas, making it easy to draw overlapping or misaligned boundaries. This adds a reference WMS layer of the jurisdiction's OVTA Areas to the map-based location editor for spatial context.

## Changes

Frontend-only — reuses the existing `ovta-areas-layer` component (no API/service/DB/codegen changes):

- Registered `OvtaAreasLayerComponent` in the `trash-ovta-area-edit-location` standalone component's imports.
- Added `<ovta-areas-layer [displayOnLoad]="true" [selectedJurisdictionID]="stormwaterJurisdictionID" …>` inside the unconditional `@if (mapIsReady)` block (alongside `transect-line-layer`), so the reference layer renders in **all three** edit modes (Draw, Land Use Blocks, Parcels).
- **On by default** (`[displayOnLoad]="true"`) per the requirement. Show/hide is provided automatically by the map's grouped layer-control checkbox (via `MapLayerBase`), and the Geoman vector edit layer is independent — toggling the reference layer never affects the editable geometry. `sortOrder=10` slots the reference areas beneath Land Use Blocks (20) / transect (30).

Note: the layer's jurisdiction input is `selectedJurisdictionID` (not `stormwaterJurisdictionID` like the sibling layers) — bound accordingly.

## Testing

- `npm run build-dev` clean (template compiles, bindings resolve).
- Verified in-browser: reference layer visible + checkbox checked on load; toggling hides/shows without affecting the editable geometry; persists across Draw / Land Use Blocks / Parcels; only the current jurisdiction's areas render.
