### PR TITLE
NPT-1111: Move Assessments — allow partial selection on the OVTA Area detail page

### DIFF
--- a/Neptune.API/Controllers/OnlandVisualTrashAssessmentAreaController.cs
+++ b/Neptune.API/Controllers/OnlandVisualTrashAssessmentAreaController.cs
@@ -134,6 +134,12 @@ public class OnlandVisualTrashAssessmentAreaController(
             return BadRequest("A target OVTA Area must be specified.");
         }
 
+        var assessmentIDsToMove = dto.OnlandVisualTrashAssessmentIDs?.Distinct().ToList() ?? new List<int>();
+        if (!assessmentIDsToMove.Any())
+        {
+            return BadRequest("At least one assessment must be selected to move.");
+        }
+
         if (onlandVisualTrashAssessmentAreaID == dto.TargetOnlandVisualTrashAssessmentAreaID)
         {
             return BadRequest("Cannot move an OVTA Area's assessments to itself.");
@@ -157,15 +163,19 @@ public class OnlandVisualTrashAssessmentAreaController(
             return Forbid();
         }
 
-        var hasInProgressAssessment = DbContext.OnlandVisualTrashAssessments.Any(x =>
-            x.OnlandVisualTrashAssessmentAreaID == onlandVisualTrashAssessmentAreaID &&
-            x.OnlandVisualTrashAssessmentStatusID != (int)OnlandVisualTrashAssessmentStatusEnum.Complete);
-        if (hasInProgressAssessment)
+        // Every selected assessment must be a completed assessment belonging to the source area.
+        // In-progress assessments are not movable (disabled checkbox client-side; enforced here too).
+        var selectableCompletedAssessmentIDs = DbContext.OnlandVisualTrashAssessments.AsNoTracking()
+            .Where(x => x.OnlandVisualTrashAssessmentAreaID == onlandVisualTrashAssessmentAreaID &&
+                        x.OnlandVisualTrashAssessmentStatusID == (int)OnlandVisualTrashAssessmentStatusEnum.Complete)
+            .Select(x => x.OnlandVisualTrashAssessmentID)
+            .ToHashSet();
+        if (!assessmentIDsToMove.All(id => selectableCompletedAssessmentIDs.Contains(id)))
         {
-            return BadRequest("Cannot move assessments: the source OVTA Area has assessments still in progress. Finish or delete those assessments first.");
+            return BadRequest("Every selected assessment must be a completed assessment belonging to the source OVTA Area.");
         }
 
-        await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(DbContext, onlandVisualTrashAssessmentAreaID, dto.TargetOnlandVisualTrashAssessmentAreaID);
+        await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(DbContext, onlandVisualTrashAssessmentAreaID, dto.TargetOnlandVisualTrashAssessmentAreaID, assessmentIDsToMove);
 
         return Ok();
     }

--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -17723,6 +17723,14 @@
           "TargetOnlandVisualTrashAssessmentAreaID": {
             "type": "integer",
             "format": "int32"
+          },
+          "OnlandVisualTrashAssessmentIDs": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentAreas.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentAreas.cs
@@ -164,10 +164,13 @@ public static class OnlandVisualTrashAssessmentAreas
         return null;
     }
 
-    public static async Task MoveAssessmentsAsync(NeptuneDbContext dbContext, int sourceOnlandVisualTrashAssessmentAreaID, int targetOnlandVisualTrashAssessmentAreaID)
+    public static async Task MoveAssessmentsAsync(NeptuneDbContext dbContext, int sourceOnlandVisualTrashAssessmentAreaID, int targetOnlandVisualTrashAssessmentAreaID, IEnumerable<int> onlandVisualTrashAssessmentIDs)
     {
         Check.Require(sourceOnlandVisualTrashAssessmentAreaID != targetOnlandVisualTrashAssessmentAreaID,
             "Cannot move an OVTA Area's assessments to itself.");
+
+        var assessmentIDsToMove = onlandVisualTrashAssessmentIDs?.Distinct().ToList() ?? new List<int>();
+        Check.Require(assessmentIDsToMove.Any(), "No assessments were selected to move.");
 
         var sourceArea = GetByIDWithChangeTracking(dbContext, sourceOnlandVisualTrashAssessmentAreaID);
         var targetArea = GetByIDWithChangeTracking(dbContext, targetOnlandVisualTrashAssessmentAreaID);
@@ -175,37 +178,52 @@ public static class OnlandVisualTrashAssessmentAreas
         Check.Require(sourceArea.StormwaterJurisdictionID == targetArea.StormwaterJurisdictionID,
             "Source and target OVTA Areas must belong to the same Jurisdiction.");
 
-        var hasInProgressAssessment = sourceArea.OnlandVisualTrashAssessments
-            .Any(x => x.OnlandVisualTrashAssessmentStatusID != (int)OnlandVisualTrashAssessmentStatusEnum.Complete);
-        Check.Require(!hasInProgressAssessment,
-            "Cannot move assessments: the source OVTA Area has assessments still in progress. Finish or delete those assessments first.");
+        // Every selected assessment must be a completed assessment belonging to the source area.
+        // In-progress assessments are never movable (they render with a disabled checkbox client-side;
+        // this enforces it server-side). Replaces the former blanket "source has no in-progress" guard,
+        // which would have blocked every partial move whenever the source held an in-progress assessment.
+        var movableSourceAssessmentIDs = sourceArea.OnlandVisualTrashAssessments
+            .Where(x => x.OnlandVisualTrashAssessmentStatusID == (int)OnlandVisualTrashAssessmentStatusEnum.Complete)
+            .Select(x => x.OnlandVisualTrashAssessmentID)
+            .ToHashSet();
+        Check.Require(assessmentIDsToMove.All(id => movableSourceAssessmentIDs.Contains(id)),
+            "Cannot move assessments: every selected assessment must be a completed assessment belonging to the source OVTA Area.");
 
         await dbContext.OnlandVisualTrashAssessments
-            .Where(x => x.OnlandVisualTrashAssessmentAreaID == sourceOnlandVisualTrashAssessmentAreaID)
+            .Where(x => x.OnlandVisualTrashAssessmentAreaID == sourceOnlandVisualTrashAssessmentAreaID
+                        && assessmentIDsToMove.Contains(x.OnlandVisualTrashAssessmentID))
             .ExecuteUpdateAsync(s => s
                 .SetProperty(a => a.OnlandVisualTrashAssessmentAreaID, targetOnlandVisualTrashAssessmentAreaID)
                 .SetProperty(a => a.IsTransectBackingAssessment, false));
 
-        var refreshedTargetAssessments = await dbContext.OnlandVisualTrashAssessments
+        // A partial move changes both rosters, so recompute baseline score, progress score, and
+        // transect line for the source area as well as the target (previously target-only).
+        await RecomputeAreaScoresAndTransectAsync(dbContext, sourceArea);
+        await RecomputeAreaScoresAndTransectAsync(dbContext, targetArea);
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static async Task RecomputeAreaScoresAndTransectAsync(NeptuneDbContext dbContext, OnlandVisualTrashAssessmentArea area)
+    {
+        var assessments = await dbContext.OnlandVisualTrashAssessments
             .Include(x => x.OnlandVisualTrashAssessmentObservations)
-            .Where(x => x.OnlandVisualTrashAssessmentAreaID == targetOnlandVisualTrashAssessmentAreaID)
+            .Where(x => x.OnlandVisualTrashAssessmentAreaID == area.OnlandVisualTrashAssessmentAreaID)
             .ToListAsync();
 
-        foreach (var assessment in refreshedTargetAssessments)
+        foreach (var assessment in assessments)
         {
             assessment.IsTransectBackingAssessment = false;
         }
 
-        var newTransect = RecomputeTransectLine(refreshedTargetAssessments);
-        targetArea.TransectLine = newTransect;
-        targetArea.TransectLine4326 = newTransect?.ProjectTo4326();
+        var newTransect = RecomputeTransectLine(assessments);
+        area.TransectLine = newTransect;
+        area.TransectLine4326 = newTransect?.ProjectTo4326();
 
-        targetArea.OnlandVisualTrashAssessmentBaselineScoreID =
-            CalculateBaselineScoreFromBackingData(refreshedTargetAssessments)?.OnlandVisualTrashAssessmentScoreID;
-        targetArea.OnlandVisualTrashAssessmentProgressScoreID =
-            OnlandVisualTrashAssessments.CalculateProgressScore(refreshedTargetAssessments)?.OnlandVisualTrashAssessmentScoreID;
-
-        await dbContext.SaveChangesAsync();
+        area.OnlandVisualTrashAssessmentBaselineScoreID =
+            CalculateBaselineScoreFromBackingData(assessments)?.OnlandVisualTrashAssessmentScoreID;
+        area.OnlandVisualTrashAssessmentProgressScoreID =
+            OnlandVisualTrashAssessments.CalculateProgressScore(assessments)?.OnlandVisualTrashAssessmentScoreID;
     }
 
     public static async Task DeleteAreaAsync(NeptuneDbContext dbContext, int onlandVisualTrashAssessmentAreaID)

--- a/Neptune.Models/DataTransferObjects/OnlandVisualTrashAssessment/OnlandVisualTrashAssessmentAreaMoveAssessmentsDto.cs
+++ b/Neptune.Models/DataTransferObjects/OnlandVisualTrashAssessment/OnlandVisualTrashAssessmentAreaMoveAssessmentsDto.cs
@@ -3,4 +3,5 @@ namespace Neptune.Models.DataTransferObjects;
 public class OnlandVisualTrashAssessmentAreaMoveAssessmentsDto
 {
     public int TargetOnlandVisualTrashAssessmentAreaID { get; set; }
+    public IEnumerable<int> OnlandVisualTrashAssessmentIDs { get; set; }
 }

--- a/Neptune.Tests/OnlandVisualTrashAssessmentAreaMoveAssessmentsTests.cs
+++ b/Neptune.Tests/OnlandVisualTrashAssessmentAreaMoveAssessmentsTests.cs
@@ -105,10 +105,11 @@ namespace Neptune.Tests
             var source = CreateArea(_jurisdictionID, $"Test Source {unique}", 0);
             var target = CreateArea(_jurisdictionID, $"Test Target {unique}", 200);
 
-            CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), OnlandVisualTrashAssessmentScoreEnum.B);
-            CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2021, 5, 1), OnlandVisualTrashAssessmentScoreEnum.C);
+            var a1 = CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), OnlandVisualTrashAssessmentScoreEnum.B);
+            var a2 = CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2021, 5, 1), OnlandVisualTrashAssessmentScoreEnum.C);
 
-            await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID);
+            await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID,
+                new[] { a1.OnlandVisualTrashAssessmentID, a2.OnlandVisualTrashAssessmentID });
 
             var sourceAssessments = _dbContext.OnlandVisualTrashAssessments.AsNoTracking().Count(x => x.OnlandVisualTrashAssessmentAreaID == source.OnlandVisualTrashAssessmentAreaID);
             var targetAssessments = _dbContext.OnlandVisualTrashAssessments.AsNoTracking().Count(x => x.OnlandVisualTrashAssessmentAreaID == target.OnlandVisualTrashAssessmentAreaID);
@@ -127,10 +128,11 @@ namespace Neptune.Tests
             // Existing baseline on target (1 assessment) — not enough alone
             CreateCompletedAssessment(_jurisdictionID, target.OnlandVisualTrashAssessmentAreaID, new DateOnly(2019, 5, 1), OnlandVisualTrashAssessmentScoreEnum.B);
             // Source has 2 baselines that, together with target's 1, average to a single rounded score
-            CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), OnlandVisualTrashAssessmentScoreEnum.A); // 1
-            CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2021, 5, 1), OnlandVisualTrashAssessmentScoreEnum.A); // 1
+            var s1 = CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), OnlandVisualTrashAssessmentScoreEnum.A); // 1
+            var s2 = CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2021, 5, 1), OnlandVisualTrashAssessmentScoreEnum.A); // 1
 
-            await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID);
+            await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID,
+                new[] { s1.OnlandVisualTrashAssessmentID, s2.OnlandVisualTrashAssessmentID });
 
             var refreshedTarget = _dbContext.OnlandVisualTrashAssessmentAreas.AsNoTracking().Single(x => x.OnlandVisualTrashAssessmentAreaID == target.OnlandVisualTrashAssessmentAreaID);
             // Average of A(1), A(1), B(2) = 1.33 → rounds to 1 → score A
@@ -143,9 +145,11 @@ namespace Neptune.Tests
             var unique = Guid.NewGuid().ToString().Substring(0, 8);
             var source = CreateArea(_jurisdictionID, $"Test Source {unique}", 0);
             var target = CreateArea(_otherJurisdictionID, $"Test Target {unique}", 200);
+            var a1 = CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), OnlandVisualTrashAssessmentScoreEnum.B);
 
             await Assert.ThrowsAsync<Common.DesignByContract.PreconditionException>(async () =>
-                await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID));
+                await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID,
+                    new[] { a1.OnlandVisualTrashAssessmentID }));
         }
 
         [TestMethod]
@@ -155,33 +159,101 @@ namespace Neptune.Tests
             var source = CreateArea(_jurisdictionID, $"Test Source {unique}", 0);
 
             await Assert.ThrowsAsync<Common.DesignByContract.PreconditionException>(async () =>
-                await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, source.OnlandVisualTrashAssessmentAreaID));
+                await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, source.OnlandVisualTrashAssessmentAreaID,
+                    new[] { 1 }));
+        }
+
+        private OnlandVisualTrashAssessment CreateInProgressAssessment(int jurisdictionID, int areaID)
+        {
+            // Status != Complete with an official area (no DraftGeometry) passes the table CHECK constraints.
+            var assessment = new OnlandVisualTrashAssessment
+            {
+                CreatedByPersonID = _personID,
+                CreatedDate = DateTime.UtcNow,
+                OnlandVisualTrashAssessmentAreaID = areaID,
+                StormwaterJurisdictionID = jurisdictionID,
+                OnlandVisualTrashAssessmentStatusID = (int)OnlandVisualTrashAssessmentStatusEnum.InProgress,
+                IsTransectBackingAssessment = false,
+                IsProgressAssessment = false,
+            };
+            _dbContext.OnlandVisualTrashAssessments.Add(assessment);
+            _dbContext.SaveChanges();
+            return assessment;
         }
 
         [TestMethod]
-        public async Task MoveAssessments_RejectsWhenSourceHasInProgressAssessment()
+        public async Task MoveAssessments_PartialMove_MovesOnlySelected_LeavesInProgressAndUnselectedOnSource()
         {
             var unique = Guid.NewGuid().ToString().Substring(0, 8);
             var source = CreateArea(_jurisdictionID, $"Test Source {unique}", 0);
             var target = CreateArea(_jurisdictionID, $"Test Target {unique}", 200);
 
-            // In-progress assessment with the source as official area is forbidden by check constraint, so use a "complete except status" hack via direct SQL.
-            // Simplest: assessment with OnlandVisualTrashAssessmentAreaID set but Status != Complete, no DraftGeometry — passes the CHECK constraint.
-            var inProgress = new OnlandVisualTrashAssessment
-            {
-                CreatedByPersonID = _personID,
-                CreatedDate = DateTime.UtcNow,
-                OnlandVisualTrashAssessmentAreaID = source.OnlandVisualTrashAssessmentAreaID,
-                StormwaterJurisdictionID = _jurisdictionID,
-                OnlandVisualTrashAssessmentStatusID = (int)OnlandVisualTrashAssessmentStatusEnum.InProgress,
-                IsTransectBackingAssessment = false,
-                IsProgressAssessment = false,
-            };
-            _dbContext.OnlandVisualTrashAssessments.Add(inProgress);
-            _dbContext.SaveChanges();
+            var moved = CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), OnlandVisualTrashAssessmentScoreEnum.B);
+            var stays = CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2021, 5, 1), OnlandVisualTrashAssessmentScoreEnum.C);
+            var inProgress = CreateInProgressAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID);
+
+            // A source with an in-progress assessment used to block the whole move; now a subset of
+            // completed assessments moves fine while the in-progress one is left behind.
+            await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID,
+                new[] { moved.OnlandVisualTrashAssessmentID });
+
+            OnlandVisualTrashAssessment Reload(int id) => _dbContext.OnlandVisualTrashAssessments.AsNoTracking().Single(x => x.OnlandVisualTrashAssessmentID == id);
+            Assert.AreEqual(target.OnlandVisualTrashAssessmentAreaID, Reload(moved.OnlandVisualTrashAssessmentID).OnlandVisualTrashAssessmentAreaID, "Selected assessment should have moved to target.");
+            Assert.AreEqual(source.OnlandVisualTrashAssessmentAreaID, Reload(stays.OnlandVisualTrashAssessmentID).OnlandVisualTrashAssessmentAreaID, "Unselected completed assessment should stay on source.");
+            Assert.AreEqual(source.OnlandVisualTrashAssessmentAreaID, Reload(inProgress.OnlandVisualTrashAssessmentID).OnlandVisualTrashAssessmentAreaID, "In-progress assessment should stay on source.");
+        }
+
+        [TestMethod]
+        public async Task MoveAssessments_RejectsInProgressIDInSelection()
+        {
+            var unique = Guid.NewGuid().ToString().Substring(0, 8);
+            var source = CreateArea(_jurisdictionID, $"Test Source {unique}", 0);
+            var target = CreateArea(_jurisdictionID, $"Test Target {unique}", 200);
+            var inProgress = CreateInProgressAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID);
 
             await Assert.ThrowsAsync<Common.DesignByContract.PreconditionException>(async () =>
-                await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID));
+                await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID,
+                    new[] { inProgress.OnlandVisualTrashAssessmentID }));
+        }
+
+        [TestMethod]
+        public async Task MoveAssessments_RejectsAssessmentIDNotOnSource()
+        {
+            var unique = Guid.NewGuid().ToString().Substring(0, 8);
+            var source = CreateArea(_jurisdictionID, $"Test Source {unique}", 0);
+            var target = CreateArea(_jurisdictionID, $"Test Target {unique}", 200);
+            // A completed assessment that lives on the TARGET, not the source — must not be movable from source.
+            var foreign = CreateCompletedAssessment(_jurisdictionID, target.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), OnlandVisualTrashAssessmentScoreEnum.B);
+
+            await Assert.ThrowsAsync<Common.DesignByContract.PreconditionException>(async () =>
+                await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID,
+                    new[] { foreign.OnlandVisualTrashAssessmentID }));
+        }
+
+        [TestMethod]
+        public async Task MoveAssessments_RecomputesBothSourceAndTargetBaselineScores()
+        {
+            var unique = Guid.NewGuid().ToString().Substring(0, 8);
+            var source = CreateArea(_jurisdictionID, $"Test Source {unique}", 0);
+            var target = CreateArea(_jurisdictionID, $"Test Target {unique}", 200);
+
+            // Source: two A's and one D. Moving the D out should pull the source baseline to a pure-A average.
+            CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), OnlandVisualTrashAssessmentScoreEnum.A);
+            CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2021, 5, 1), OnlandVisualTrashAssessmentScoreEnum.A);
+            var d = CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2022, 5, 1), OnlandVisualTrashAssessmentScoreEnum.D);
+            // Target starts with one assessment (baseline needs >= 2, so target baseline is null until it receives the D).
+            CreateCompletedAssessment(_jurisdictionID, target.OnlandVisualTrashAssessmentAreaID, new DateOnly(2019, 5, 1), OnlandVisualTrashAssessmentScoreEnum.A);
+
+            await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID,
+                new[] { d.OnlandVisualTrashAssessmentID });
+
+            var refreshedSource = _dbContext.OnlandVisualTrashAssessmentAreas.AsNoTracking().Single(x => x.OnlandVisualTrashAssessmentAreaID == source.OnlandVisualTrashAssessmentAreaID);
+            var refreshedTarget = _dbContext.OnlandVisualTrashAssessmentAreas.AsNoTracking().Single(x => x.OnlandVisualTrashAssessmentAreaID == target.OnlandVisualTrashAssessmentAreaID);
+
+            // Source recomputed from the remaining two A's → A.
+            Assert.AreEqual((int)OnlandVisualTrashAssessmentScoreEnum.A, refreshedSource.OnlandVisualTrashAssessmentBaselineScoreID, "Source baseline should be recomputed from its remaining assessments.");
+            // Target went from 1 assessment (null baseline) to 2 → a baseline is now computed.
+            Assert.IsNotNull(refreshedTarget.OnlandVisualTrashAssessmentBaselineScoreID, "Target baseline should be recomputed after receiving the moved assessment.");
         }
 
         [TestMethod]
@@ -231,11 +303,12 @@ namespace Neptune.Tests
             var source = CreateArea(_jurisdictionID, $"Camino Real Dup {unique}", 0);
             var target = CreateArea(_jurisdictionID, $"Camino Real {unique}", 200);
 
-            CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), OnlandVisualTrashAssessmentScoreEnum.B);
-            CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2021, 5, 1), OnlandVisualTrashAssessmentScoreEnum.B);
+            var m1 = CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2020, 5, 1), OnlandVisualTrashAssessmentScoreEnum.B);
+            var m2 = CreateCompletedAssessment(_jurisdictionID, source.OnlandVisualTrashAssessmentAreaID, new DateOnly(2021, 5, 1), OnlandVisualTrashAssessmentScoreEnum.B);
             CreateCompletedAssessment(_jurisdictionID, target.OnlandVisualTrashAssessmentAreaID, new DateOnly(2018, 5, 1), OnlandVisualTrashAssessmentScoreEnum.A);
 
-            await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID);
+            await OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID, target.OnlandVisualTrashAssessmentAreaID,
+                new[] { m1.OnlandVisualTrashAssessmentID, m2.OnlandVisualTrashAssessmentID });
             await OnlandVisualTrashAssessmentAreas.DeleteAreaAsync(_dbContext, source.OnlandVisualTrashAssessmentAreaID);
 
             var sourceExists = _dbContext.OnlandVisualTrashAssessmentAreas.AsNoTracking().Any(x => x.OnlandVisualTrashAssessmentAreaID == source.OnlandVisualTrashAssessmentAreaID);

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/move-ovta-assessments-modal/move-ovta-assessments-modal.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/move-ovta-assessments-modal/move-ovta-assessments-modal.component.ts
@@ -6,8 +6,6 @@ import { AlertDisplayComponent } from "src/app/shared/components/alert-display/a
 import { OnlandVisualTrashAssessmentAreaService } from "src/app/shared/generated/api/onland-visual-trash-assessment-area.service";
 import { OnlandVisualTrashAssessmentAreaMoveAssessmentsDto } from "src/app/shared/generated/model/onland-visual-trash-assessment-area-move-assessments-dto";
 import { AlertService } from "src/app/shared/services/alert.service";
-import { Alert } from "src/app/shared/models/alert";
-import { AlertContext } from "src/app/shared/models/enums/alert-context.enum";
 
 @Component({
     selector: "move-ovta-assessments-modal",
@@ -50,11 +48,12 @@ export class MoveOvtaAssessmentsModalComponent implements OnInit {
     save(): void {
         const dto: OnlandVisualTrashAssessmentAreaMoveAssessmentsDto = {
             TargetOnlandVisualTrashAssessmentAreaID: this.formGroup.controls.TargetOnlandVisualTrashAssessmentAreaID.value!,
+            OnlandVisualTrashAssessmentIDs: this.ref.data.SelectedAssessmentIDs,
         };
         this.onlandVisualTrashAssessmentAreaService.moveAssessmentsOnlandVisualTrashAssessmentArea(this.ref.data.SourceOnlandVisualTrashAssessmentAreaID, dto).subscribe({
             next: () => {
-                this.alertService.clearAlerts();
-                this.alertService.pushAlert(new Alert("Successfully moved assessments to the selected OVTA Area.", AlertContext.Success));
+                // Success alert is pushed by the caller after this modal closes — the modal's own
+                // <app-alert-display> clears alerts on destroy, so pushing it here would not survive.
                 this.ref.close(true);
             },
             // httpErrorInterceptor surfaces the failure alert; modal stays open so the user can retry.
@@ -71,5 +70,6 @@ export class MoveOvtaAssessmentsModalContext {
     SourceOnlandVisualTrashAssessmentAreaID: number;
     SourceOnlandVisualTrashAssessmentAreaName: string;
     SourceStormwaterJurisdictionID: number;
+    SelectedAssessmentIDs: number[];
     SourceAssessmentCount: number;
 }

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.html
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.html
@@ -95,8 +95,19 @@
             [columnDefs]="ovtaColumnDefs"
             downloadFileName="onland-visual-trash-assessments"
             [pagination]="true"
-            [sizeColumnsToFitGrid]="true">
-            <a customGridActionsRight class="btn btn-sm btn-primary-outline" (click)="moveOVTAAssessments(onlandVisualTrashAssessmentArea, onlandVisualTrashAssessments)">Move Assessments</a>
+            [sizeColumnsToFitGrid]="true"
+            rowSelection="multiple"
+            [suppressRowClickSelection]="true"
+            [isRowSelectable]="isRowCompleteSelectable"
+            (selectionChanged)="onAssessmentSelectionChanged($event)">
+            <button
+              customGridActionsRight
+              type="button"
+              class="btn btn-sm btn-primary-outline"
+              [disabled]="selectedRowIDs().length === 0"
+              (click)="moveOVTAAssessments(onlandVisualTrashAssessmentArea)">
+              Move Assessments ({{ selectedRowIDs().length }})
+            </button>
           </neptune-grid>
         </div>
       </div>

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Component } from "@angular/core";
+import { ApplicationRef, Component, signal } from "@angular/core";
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { Input } from "@angular/core";
 import { BehaviorSubject, Observable, switchMap, tap } from "rxjs";
@@ -9,7 +9,7 @@ import { AlertDisplayComponent } from "../../../../shared/components/alert-displ
 import { AsyncPipe, DatePipe } from "@angular/common";
 import { FieldDefinitionComponent } from "../../../../shared/components/field-definition/field-definition.component";
 import { NeptuneGridComponent } from "../../../../shared/components/neptune-grid/neptune-grid.component";
-import { ColDef } from "ag-grid-community";
+import { ColDef, IsRowSelectable, SelectionChangedEvent } from "ag-grid-community";
 import { UtilityFunctionsService } from "src/app/services/utility-functions.service";
 import { NeptuneMapComponent, NeptuneMapInitEvent } from "../../../../shared/components/leaflet/neptune-map/neptune-map.component";
 import * as L from "leaflet";
@@ -51,6 +51,11 @@ export class TrashOvtaAreaDetailComponent {
     public ovtaColumnDefs: ColDef[];
     public onlandVisualTrashAssessments$: Observable<OnlandVisualTrashAssessmentGridDto[]>;
 
+    // Only completed assessments are movable; in-progress rows render a disabled checkbox.
+    public selectedRowIDs = signal<number[]>([]);
+    public isRowCompleteSelectable: IsRowSelectable = (node) =>
+        node.data?.OnlandVisualTrashAssessmentStatusID === OnlandVisualTrashAssessmentStatusEnum.Complete;
+
     public refreshOVTAAreasTrigger: BehaviorSubject<void> = new BehaviorSubject(null);
     public refreshOVTAAreasTrigger$: Observable<void> = this.refreshOVTAAreasTrigger.asObservable();
 
@@ -79,6 +84,7 @@ export class TrashOvtaAreaDetailComponent {
 
     ngOnInit(): void {
         this.ovtaColumnDefs = [
+            { ...this.utilityFunctionsService.createCheckboxSelectionColumnDef(), showDisabledCheckboxes: true },
             this.utilityFunctionsService.createActionsColumnDef((params: any) => {
                 const actions = [
                     { ActionName: "View", ActionIcon: "fas fa-file-alt", ActionHandler: () => this.router.navigate(["trash", "onland-visual-trash-assessments", params.data.OnlandVisualTrashAssessmentID]) },
@@ -132,10 +138,18 @@ export class TrashOvtaAreaDetailComponent {
         );
 
         this.onlandVisualTrashAssessments$ = this.refreshOVTAGridTrigger$.pipe(
-            tap(() => (this.isLoadingGrid = true)),
+            tap(() => {
+                this.isLoadingGrid = true;
+                this.selectedRowIDs.set([]);
+            }),
             switchMap(() => this.onlandVisualTrashAssessmentAreaService.listAssessmentsByOVTAIDOnlandVisualTrashAssessmentArea(this.onlandVisualTrashAssessmentAreaID)),
             tap(() => (this.isLoadingGrid = false))
         );
+    }
+
+    public onAssessmentSelectionChanged(event: SelectionChangedEvent): void {
+        const selected = event.api.getSelectedRows() as OnlandVisualTrashAssessmentGridDto[];
+        this.selectedRowIDs.set(selected.map((r) => r.OnlandVisualTrashAssessmentID));
     }
 
     public handleMapReady(event: NeptuneMapInitEvent): void {
@@ -240,18 +254,28 @@ export class TrashOvtaAreaDetailComponent {
         });
     }
 
-    moveOVTAAssessments(ovtaAreaDto: OnlandVisualTrashAssessmentAreaDetailDto, assessments: OnlandVisualTrashAssessmentGridDto[]) {
+    moveOVTAAssessments(ovtaAreaDto: OnlandVisualTrashAssessmentAreaDetailDto) {
+        const selectedIDs = this.selectedRowIDs();
+        if (selectedIDs.length === 0) return;
+
         const dialogRef = this.dialogService.open(MoveOvtaAssessmentsModalComponent, {
             data: {
                 SourceOnlandVisualTrashAssessmentAreaID: ovtaAreaDto.OnlandVisualTrashAssessmentAreaID,
                 SourceOnlandVisualTrashAssessmentAreaName: ovtaAreaDto.OnlandVisualTrashAssessmentAreaName,
                 SourceStormwaterJurisdictionID: ovtaAreaDto.StormwaterJurisdictionID,
-                SourceAssessmentCount: assessments.length,
+                SelectedAssessmentIDs: selectedIDs,
+                SourceAssessmentCount: selectedIDs.length,
             } as MoveOvtaAssessmentsModalContext,
         });
 
         dialogRef.afterClosed$.subscribe((result) => {
             if (result) {
+                // Push the success alert here (after the modal closes) rather than inside the modal:
+                // the modal's own <app-alert-display> clears alerts on destroy, so a modal-pushed
+                // alert never survives to the detail page.
+                this.alertService.pushAlert(
+                    new Alert(`Successfully moved ${selectedIDs.length} assessment${selectedIDs.length === 1 ? "" : "s"} to the selected OVTA Area.`, AlertContext.Success)
+                );
                 this.refreshOVTAAreasTrigger.next();
                 this.refreshOVTAGridTrigger.next();
             }

--- a/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
+++ b/Neptune.Web/src/app/pages/trash-module/ovtas/trash-ovta-area-detail/trash-ovta-area-detail.component.ts
@@ -273,6 +273,7 @@ export class TrashOvtaAreaDetailComponent {
                 // Push the success alert here (after the modal closes) rather than inside the modal:
                 // the modal's own <app-alert-display> clears alerts on destroy, so a modal-pushed
                 // alert never survives to the detail page.
+                this.alertService.clearAlerts();
                 this.alertService.pushAlert(
                     new Alert(`Successfully moved ${selectedIDs.length} assessment${selectedIDs.length === 1 ? "" : "s"} to the selected OVTA Area.`, AlertContext.Success)
                 );

--- a/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.html
+++ b/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.html
@@ -28,6 +28,7 @@
     [rowSelection]="rowSelection"
     [suppressRowClickSelection]="suppressRowClickSelection"
     [rowMultiSelectWithClick]="rowMultiSelectWithClick"
+    [isRowSelectable]="isRowSelectable"
     [suppressRowTransform]="true"
     [suppressMenuHide]="true"
     [pagination]="pagination"

--- a/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.ts
+++ b/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.ts
@@ -10,6 +10,7 @@ import {
     GridColumnsChangedEvent,
     GridReadyEvent,
     GridSizeChangedEvent,
+    IsRowSelectable,
     SelectionChangedEvent,
 } from "ag-grid-community";
 import { AgGridHelper } from "src/app/shared/helpers/ag-grid-helper";
@@ -48,6 +49,7 @@ export class NeptuneGridComponent implements OnInit, OnChanges {
     @Input() rowSelection: "single" | "multiple";
     @Input() suppressRowClickSelection: boolean = false;
     @Input() rowMultiSelectWithClick: boolean = false;
+    @Input() isRowSelectable: IsRowSelectable;
     @Input() pagination: boolean = false;
     @Input() paginationPageSize: number = 100;
     @Input() getRowId: GetRowIdFunc;

--- a/Neptune.Web/src/app/shared/generated/model/onland-visual-trash-assessment-area-move-assessments-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/onland-visual-trash-assessment-area-move-assessments-dto.ts
@@ -12,6 +12,7 @@
 import { FormControl, FormControlOptions, FormControlState, Validators } from "@angular/forms";
 export class OnlandVisualTrashAssessmentAreaMoveAssessmentsDto { 
     TargetOnlandVisualTrashAssessmentAreaID?: number;
+    OnlandVisualTrashAssessmentIDs?: Array<number> | null;
     constructor(obj?: any) {
         Object.assign(this, obj);
     }
@@ -19,10 +20,21 @@ export class OnlandVisualTrashAssessmentAreaMoveAssessmentsDto {
 
 export interface OnlandVisualTrashAssessmentAreaMoveAssessmentsDtoForm { 
     TargetOnlandVisualTrashAssessmentAreaID?: FormControl<number>;
+    OnlandVisualTrashAssessmentIDs?: FormControl<Array<number>>;
 }
 
 export class OnlandVisualTrashAssessmentAreaMoveAssessmentsDtoFormControls { 
     public static TargetOnlandVisualTrashAssessmentAreaID = (value: FormControlState<number> | number = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<number>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static OnlandVisualTrashAssessmentIDs = (value: FormControlState<Array<number>> | Array<number> = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<Array<number>>(
         value,
         formControlOptions ?? 
         {


### PR DESCRIPTION
## Context

"Move Assessments" on the OVTA Area detail page was all-or-nothing — it moved **every** completed assessment from the source area and refused entirely when the source held any in-progress assessment. This lets users move a **subset** of completed assessments, and recalculates **both** the source and target areas afterward (previously only the target).

## Backend

- **DTO**: added `IEnumerable<int> OnlandVisualTrashAssessmentIDs`.
- **`OnlandVisualTrashAssessmentAreas.MoveAssessmentsAsync`**: takes the ID list; filters the bulk `ExecuteUpdateAsync` to it; **replaced the blanket "source has in-progress" guard with a per-ID guard** (every selected ID must be a completed assessment on the source area — enforces that in-progress rows are never movable, even server-side). Extracted `RecomputeAreaScoresAndTransectAsync` and run it for **both** areas (baseline score, progress score, transect line).
- **Controller**: validates a non-empty selection and that all IDs are completed + on the source; passes them through.

## Frontend

- **`neptune-grid`**: added an `[isRowSelectable]` passthrough (safe additive).
- **Detail grid**: checkbox column (in-progress rows show a **disabled** checkbox via `isRowSelectable` + `showDisabledCheckboxes`), `rowSelection="multiple"`, a `selectedRowIDs` signal, header select-all limited to completed rows, and a **"Move Assessments (N)"** button disabled at zero. Selection resets on grid refresh.
- **Modal**: sends the selected IDs; the count line reflects the selected count.
- **Alerts**: the success alert is pushed by the **caller after the modal closes** — the modal's own `<app-alert-display>` clears alerts on destroy, so a modal-side push never reached the detail page. It now lands on the detail page and reports the moved count; errors still surface in the still-open modal via the http error interceptor.

## Testing

- `dotnet build` clean; **11/11** `MoveAssessments` tests pass (rewrote the in-progress-guard test into partial-move behavior; added reject-in-progress-ID, reject-foreign-area-ID, and recompute-both-areas tests).
- `/codegen` + `npm run build-dev` clean.
- Verified in-browser: disabled checkbox on in-progress rows; select-all toggles only completed; "Move Assessments (N)" tracks the count and is disabled at 0; modal shows the selected count; a partial move moves only the selected rows, leaves the rest (incl. in-progress) on the source, recalculates both areas, and shows the success alert on the detail page.
