### PR TITLE
NPT-1115: Fix Provisional Delineation layer missing in prod (invalid geometry) + default on

### DIFF
--- a/Neptune.API/Controllers/DelineationController.cs
+++ b/Neptune.API/Controllers/DelineationController.cs
@@ -103,6 +103,14 @@ namespace Neptune.API.Controllers
 
             await DbContext.SaveChangesAsync();
 
+            // NPT-1115: repair the just-saved geometry if the freehand draw produced a SQL-invalid
+            // polygon (self-intersection). Uses SQL Server MakeValid — NTS validity differs from
+            // STIsValid, and both the GeoServer WMS layer and the NTS overlay key off STIsValid.
+            if (existing != null)
+            {
+                await DbContext.Database.ExecuteSqlRawAsync("EXEC dbo.pDelineationMakeValid @DelineationID = {0}", existing.DelineationID);
+            }
+
             var treatmentBMPType = TreatmentBMPTypes.GetByIDWithChangeTracking(DbContext, treatmentBMP.TreatmentBMPTypeID);
             if (!(newShape == null && oldShape == null) && treatmentBMPType.TreatmentBMPModelingType != null)
             {

--- a/Neptune.API/Controllers/DelineationController.cs
+++ b/Neptune.API/Controllers/DelineationController.cs
@@ -103,12 +103,17 @@ namespace Neptune.API.Controllers
 
             await DbContext.SaveChangesAsync();
 
-            // NPT-1115: repair the just-saved geometry if the freehand draw produced a SQL-invalid
-            // polygon (self-intersection). Uses SQL Server MakeValid — NTS validity differs from
-            // STIsValid, and both the GeoServer WMS layer and the NTS overlay key off STIsValid.
             if (existing != null)
             {
+                // NPT-1115: repair the just-saved geometry if the freehand draw produced a SQL-invalid
+                // polygon (self-intersection). Uses SQL Server MakeValid — NTS validity differs from
+                // STIsValid, and both the GeoServer WMS layer and the NTS overlay key off STIsValid.
                 await DbContext.Database.ExecuteSqlRawAsync("EXEC dbo.pDelineationMakeValid @DelineationID = {0}", existing.DelineationID);
+                // Reload so the LGU refresh below unions the actually-stored (now valid) geometry
+                // rather than the pre-repair in-memory shape: the original could be NTS-invalid and
+                // throw in QueueLGURefreshForArea's Union, and would compute the wrong refresh area.
+                await DbContext.Entry(existing).ReloadAsync();
+                newShape = existing.DelineationGeometry;
             }
 
             var treatmentBMPType = TreatmentBMPTypes.GetByIDWithChangeTracking(DbContext, treatmentBMP.TreatmentBMPTypeID);

--- a/Neptune.Database/Neptune.Database.sqlproj
+++ b/Neptune.Database/Neptune.Database.sqlproj
@@ -442,6 +442,7 @@
     <None Include="Scripts\ReleaseScripts\036 - Recalculate OVTA Progress Scores for 5yr-1OVTA rule.sql" />
     <None Include="Scripts\ReleaseScripts\037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content.sql" />
     <None Include="Scripts\ReleaseScripts\038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs.sql" />
+    <None Include="Scripts\ReleaseScripts\039 - MakeValid on invalid Delineation geometries (recurrence).sql" />
     <Build Include="dbo\Tables\dbo.WaterQualityManagementPlanExtractionResult.sql" />
     <Build Include="dbo\Tables\dbo.AITokenUsage.sql" />
   </ItemGroup>

--- a/Neptune.Database/Scripts/ReleaseScripts/039 - MakeValid on invalid Delineation geometries (recurrence).sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/039 - MakeValid on invalid Delineation geometries (recurrence).sql
@@ -1,0 +1,8 @@
+-- NPT-1115: Repair any Delineation rows whose DelineationGeometry / DelineationGeometry4326 fail
+-- SQL Server's STIsValid() check. Invalid geometry causes GeoServer to throw SQL error 24144 when
+-- rendering WMS tiles, silently blanking the Provisional Delineations layer (same symptom as the
+-- one-time NPT-1030 backfill in script 024). Recurred because the delineation write paths had no
+-- validity guard; this ships alongside the view guard (vGeoServerDelineation), save-time repair,
+-- and the nightly full-model-run repair so it cannot recur. Idempotent — a no-op where all rows
+-- are already valid (e.g. QA).
+EXEC dbo.pDelineationMakeValid;

--- a/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -84,4 +84,6 @@ GO
 GO
 :r ".\038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs.sql"
 GO
+:r ".\039 - MakeValid on invalid Delineation geometries (recurrence).sql"
+GO
 

--- a/Neptune.Database/dbo/Procs/dbo.pDelineationMakeValid.sql
+++ b/Neptune.Database/dbo/Procs/dbo.pDelineationMakeValid.sql
@@ -1,9 +1,15 @@
 create procedure dbo.pDelineationMakeValid
+    -- NPT-1115: optional scoping — null repairs every invalid row (nightly full run / one-time
+    -- backfill), a value repairs just that delineation (save-time repair after an upsert).
+    @DelineationID int = null
 as
 begin
 
-    update dbo.Delineation set DelineationGeometry = DelineationGeometry.MakeValid() where DelineationGeometry.STIsValid() = 0
-    update dbo.Delineation set DelineationGeometry4326 = DelineationGeometry4326.MakeValid() where DelineationGeometry4326.STIsValid() = 0
+    update dbo.Delineation set DelineationGeometry = DelineationGeometry.MakeValid()
+    where DelineationGeometry.STIsValid() = 0 and (@DelineationID is null or DelineationID = @DelineationID)
+
+    update dbo.Delineation set DelineationGeometry4326 = DelineationGeometry4326.MakeValid()
+    where DelineationGeometry4326.STIsValid() = 0 and (@DelineationID is null or DelineationID = @DelineationID)
 end
 
 GO

--- a/Neptune.Database/dbo/Views/dbo.vGeoServerDelineation.sql
+++ b/Neptune.Database/dbo/Views/dbo.vGeoServerDelineation.sql
@@ -3,7 +3,11 @@ Select
 	2 * DelineationID - 1 as PrimaryKey,
 	d.DelineationID,
 	Null as WaterQualityManagementPlanID,
-	DelineationGeometry4326 as DelineationGeometry,
+	-- NPT-1115: guard against SQL-invalid geometry (self-intersecting freehand draws). A single
+	-- invalid row makes GeoServer's WMS GetMap throw SQL error 24144 and blanks the whole layer.
+	-- Repair only invalid rows on read so GeoServer never sees invalid geometry (valid polygons
+	-- pass through untouched, avoiding needless normalization / geometry-type shifts).
+	case when DelineationGeometry4326.STIsValid() = 1 then DelineationGeometry4326 else DelineationGeometry4326.MakeValid() end as DelineationGeometry,
 	DelineationTypeName as DelineationType,
 	t.TreatmentBMPID,
 	sj.StormwaterJurisdictionID,

--- a/Neptune.Database/dbo/Views/dbo.vGeoServerTreatmentBMPDelineation.sql
+++ b/Neptune.Database/dbo/Views/dbo.vGeoServerTreatmentBMPDelineation.sql
@@ -1,7 +1,9 @@
 Create View dbo.vGeoServerTreatmentBMPDelineation as
 Select
 	d.DelineationID as PrimaryKey,
-	DelineationGeometry4326 as DelineationGeometry,
+	-- NPT-1115: repair SQL-invalid geometry on read so GeoServer's WMS never throws error 24144
+	-- (see vGeoServerDelineation). Valid polygons pass through untouched.
+	case when DelineationGeometry4326.STIsValid() = 1 then DelineationGeometry4326 else DelineationGeometry4326.MakeValid() end as DelineationGeometry,
 	t.TreatmentBMPID,
 	t.TreatmentBMPName,
 	p.ProjectName

--- a/Neptune.EFModels/Entities/DelineationStagings.StaticHelpers.cs
+++ b/Neptune.EFModels/Entities/DelineationStagings.StaticHelpers.cs
@@ -203,6 +203,11 @@ public static class DelineationStagings
         }
 
         await dbContext.SaveChangesAsync();
+
+        // NPT-1115: repair any SQL-invalid geometry brought in by the staging import so GeoServer
+        // (WMS) and the NTS overlay never see invalid polygons.
+        await dbContext.Database.ExecuteSqlRawAsync("EXEC dbo.pDelineationMakeValid");
+
         await dbContext.DelineationStagings
             .Where(x => x.UploadedByPersonID == currentPerson.PersonID)
             .ExecuteDeleteAsync();

--- a/Neptune.EFModels/Entities/Delineations.cs
+++ b/Neptune.EFModels/Entities/Delineations.cs
@@ -198,6 +198,11 @@ namespace Neptune.EFModels.Entities
                 allDelineationsInDatabase);
 
             await dbContext.SaveChangesAsync();
+
+            // NPT-1115: repair any SQL-invalid geometry persisted by this bulk upsert so GeoServer
+            // (WMS) and the NTS overlay never see invalid polygons. STIsValid-based, so it no-ops
+            // when everything is already valid.
+            await dbContext.Database.ExecuteSqlRawAsync("EXEC dbo.pDelineationMakeValid");
         }
 
         public static Delineation DelineationFromUpsertDto(DelineationUpsertDto delineationUpsertDto)

--- a/Neptune.Jobs/Hangfire/TotalNetworkSolveJob.cs
+++ b/Neptune.Jobs/Hangfire/TotalNetworkSolveJob.cs
@@ -20,6 +20,12 @@ public class TotalNetworkSolveJob(
 
     public async Task RunJob()
     {
+        // NPT-1115: repair any SQL-invalid delineation geometry before the solve consumes it.
+        // Invalid geometry breaks NetTopologySuite overlay operations and also blanks the
+        // GeoServer Delineations WMS layer (SQL error 24144); the nightly full run is the
+        // natural place to re-heal the whole table.
+        await DbContext.Database.ExecuteSqlRawAsync("EXEC dbo.pDelineationMakeValid");
+
         // clear out all dirty nodes since the whole network is being run.
         await DbContext.DirtyModelNodes.ExecuteDeleteAsync();
         // clear out all the nereid results since we are rerunning it for the whole network

--- a/Neptune.Tests/DelineationMakeValidTests.cs
+++ b/Neptune.Tests/DelineationMakeValidTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1115 — an invalid Delineation geometry (self-intersecting freehand draw) makes GeoServer's
+    /// WMS GetMap throw SQL error 24144, blanking the Delineations layer. These integration tests
+    /// (real local DB, rolled back) cover the two SQL-side guards: dbo.pDelineationMakeValid repairs
+    /// invalid rows (whole-table and scoped by @DelineationID), and dbo.vGeoServerDelineation returns
+    /// valid geometry even when the underlying row is invalid. Requires the updated view + sproc to be
+    /// deployed to the local DB.
+    /// </summary>
+    [TestClass]
+    public class DelineationMakeValidTests
+    {
+        private NeptuneDbContext _dbContext = null!;
+        private IDbContextTransaction _transaction = null!;
+
+        // Self-intersecting "bowtie" polygons — SQL Server STIsValid() = 0. State-plane (2771) and WGS84 (4326).
+        private const string InvalidNativeWkt = "POLYGON((1840000 660000, 1840100 660100, 1840100 660000, 1840000 660100, 1840000 660000))";
+        private const string Invalid4326Wkt = "POLYGON((-118 33.5, -117.9 33.6, -117.9 33.5, -118 33.6, -118 33.5))";
+
+        private static NeptuneDbContext GetDbContext()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<NeptuneDbContext>();
+            optionsBuilder.UseSqlServer(
+                "Data Source=localhost;Initial Catalog=NeptuneDB;Persist Security Info=True;Integrated Security=true;Encrypt=False;",
+                x =>
+                {
+                    x.CommandTimeout((int)TimeSpan.FromMinutes(3).TotalSeconds);
+                    x.UseNetTopologySuite();
+                });
+            return new NeptuneDbContext(optionsBuilder.Options);
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _dbContext = GetDbContext();
+            _transaction = _dbContext.Database.BeginTransaction();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _transaction.Rollback();
+            _transaction.Dispose();
+            _dbContext.Dispose();
+        }
+
+        private int ScalarInt(string sql) => _dbContext.Database.SqlQueryRaw<int>(sql).AsEnumerable().First();
+
+        // Inserts an invalid-geometry Delineation for a BMP that has none (the FK is UNIQUE), returns its ID.
+        // Returns null (→ Inconclusive) if the local DB has no delineation-free BMP or no DelineationType.
+        private int? InsertInvalidDelineation()
+        {
+            var bmpId = _dbContext.Database.SqlQueryRaw<int>(
+                "SELECT TOP 1 TreatmentBMPID AS Value FROM dbo.TreatmentBMP WHERE TreatmentBMPID NOT IN (SELECT TreatmentBMPID FROM dbo.Delineation) ORDER BY TreatmentBMPID")
+                .AsEnumerable().Cast<int?>().FirstOrDefault();
+            var typeId = _dbContext.Database.SqlQueryRaw<int>(
+                "SELECT TOP 1 DelineationTypeID AS Value FROM dbo.DelineationType ORDER BY DelineationTypeID")
+                .AsEnumerable().Cast<int?>().FirstOrDefault();
+            if (bmpId == null || typeId == null) return null;
+
+            _dbContext.Database.ExecuteSqlRaw($@"
+                INSERT INTO dbo.Delineation (DelineationGeometry, DelineationGeometry4326, DelineationTypeID, IsVerified, TreatmentBMPID, DateLastModified, HasDiscrepancies)
+                VALUES (geometry::STGeomFromText('{InvalidNativeWkt}', 2771), geometry::STGeomFromText('{Invalid4326Wkt}', 4326), {typeId}, 0, {bmpId}, GETUTCDATE(), 0)");
+
+            return ScalarInt($"SELECT DelineationID AS Value FROM dbo.Delineation WHERE TreatmentBMPID = {bmpId}");
+        }
+
+        private int NativeValid(int delineationID) => ScalarInt($"SELECT CAST(DelineationGeometry.STIsValid() AS int) AS Value FROM dbo.Delineation WHERE DelineationID = {delineationID}");
+        private int Valid4326(int delineationID) => ScalarInt($"SELECT CAST(DelineationGeometry4326.STIsValid() AS int) AS Value FROM dbo.Delineation WHERE DelineationID = {delineationID}");
+
+        [TestMethod]
+        public void PDelineationMakeValid_RepairsInvalidGeometry()
+        {
+            var id = InsertInvalidDelineation();
+            if (id == null) { Assert.Inconclusive("No delineation-free TreatmentBMP available in the local DB."); return; }
+
+            Assert.AreEqual(0, NativeValid(id.Value), "Native geometry should start invalid.");
+            Assert.AreEqual(0, Valid4326(id.Value), "4326 geometry should start invalid.");
+
+            _dbContext.Database.ExecuteSqlRaw("EXEC dbo.pDelineationMakeValid");
+
+            Assert.AreEqual(1, NativeValid(id.Value), "Native geometry should be valid after MakeValid.");
+            Assert.AreEqual(1, Valid4326(id.Value), "4326 geometry should be valid after MakeValid.");
+        }
+
+        [TestMethod]
+        public void PDelineationMakeValid_Scoped_OnlyRepairsTargetDelineation()
+        {
+            var first = InsertInvalidDelineation();
+            var second = InsertInvalidDelineation();
+            if (first == null || second == null) { Assert.Inconclusive("Need two delineation-free TreatmentBMPs in the local DB."); return; }
+
+            _dbContext.Database.ExecuteSqlRaw("EXEC dbo.pDelineationMakeValid @DelineationID = {0}", first.Value);
+
+            Assert.AreEqual(1, NativeValid(first.Value), "Scoped repair should fix the targeted delineation.");
+            Assert.AreEqual(1, Valid4326(first.Value), "Scoped repair should fix the targeted delineation (4326).");
+            Assert.AreEqual(0, NativeValid(second.Value), "Scoped repair must not touch other delineations.");
+        }
+
+        [TestMethod]
+        public void VGeoServerDelineation_ReturnsValidGeometry_EvenWhenSourceRowInvalid()
+        {
+            var id = InsertInvalidDelineation();
+            if (id == null) { Assert.Inconclusive("No delineation-free TreatmentBMP available in the local DB."); return; }
+
+            // Underlying row is still invalid (no sproc run) — the view's MakeValid guard must repair on read.
+            Assert.AreEqual(0, Valid4326(id.Value), "Precondition: the stored 4326 geometry is invalid.");
+
+            var viewValid = ScalarInt($"SELECT CAST(DelineationGeometry.STIsValid() AS int) AS Value FROM dbo.vGeoServerDelineation WHERE DelineationID = {id.Value}");
+            Assert.AreEqual(1, viewValid, "vGeoServerDelineation must never expose invalid geometry to GeoServer.");
+        }
+    }
+}

--- a/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.html
+++ b/Neptune.Web/src/app/pages/delineation/delineation-map/delineation-map.component.html
@@ -126,7 +126,7 @@
                              (selected) on each layer emits the clicked DelineationID; the parent
                              matches it to the local BMP cache to populate the side panel. -->
                         <delineations-layer [delineationStatus]="'Verified'" [displayOnLoad]="true" [map]="map" [layerControl]="layerControl" [sortOrder]="50" (selected)="onDelineationSelected($event)"></delineations-layer>
-                        <delineations-layer [delineationStatus]="'Provisional'" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="51" (selected)="onDelineationSelected($event)"></delineations-layer>
+                        <delineations-layer [delineationStatus]="'Provisional'" [displayOnLoad]="true" [map]="map" [layerControl]="layerControl" [sortOrder]="51" (selected)="onDelineationSelected($event)"></delineations-layer>
                         <parcels-layer [mode]="OverlayMode.ReferenceOnly" [displayOnLoad]="false" [map]="map" [layerControl]="layerControl" [sortOrder]="60"></parcels-layer>
                     }
                 </neptune-map>


### PR DESCRIPTION
## Context

The Provisional Delineation WMS layer renders in QA but is blank in prod, and it was off by default. **Root cause: an invalid geometry in the `Delineation` table.** A single row failing SQL Server's `STIsValid()` makes GeoServer's WMS GetMap throw **SQL error 24144**, blanking the whole layer — the exact symptom documented in the one-time NPT-1030 backfill (release script 024). It recurred because the delineation write paths persist geometry with **no validity guard** (freehand self-intersecting polygons). This ships a defense-in-depth fix so it can't recur, plus the two requested UX changes.

(The earlier `gt_pk_metadata` theory was a red herring — that row is present in the prod restore.)

## Changes

1. **Frontend** — default the Provisional `delineations-layer` on (`displayOnLoad` false→true). No draw-mode change: `editMode !== "idle"` only gates click-to-select, never the WMS tiles.
2. **View guard** — `vGeoServerDelineation` (and sibling `vGeoServerTreatmentBMPDelineation`) repair invalid geometry on read via `CASE WHEN STIsValid()=1 THEN geom ELSE geom.MakeValid() END`, so GeoServer never sees an invalid polygon. Immediate on deploy; unbypassable.
3. **Save-time repair** — after each delineation write path (`DelineationController.UpsertForTreatmentBMP` scoped by ID, project-bulk `MergeDelineations`, `DelineationStagings` import) run `pDelineationMakeValid` so invalid geometry never persists. The sproc gains an optional `@DelineationID` for scoping (whole-table when null).
4. **Nightly repair** — `EXEC dbo.pDelineationMakeValid` at the start of the existing full model run (`TotalNetworkSolveJob.RunJob`), protecting the NetTopologySuite overlay and re-healing the table. No new Hangfire job/cron.
5. **Deploy repair** — release script `039` (mirrors `024`) heals existing invalid rows on deploy; no manual ops step. (For immediate prod unblock before deploy, ops can run `EXEC dbo.pDelineationMakeValid`.)

## Testing

- `Neptune.Tests/DelineationMakeValidTests.cs`: whole-table repair, `@DelineationID`-scoped repair, and view-guard-returns-valid-geometry-even-when-the-row-is-invalid. **25 Delineation tests pass.**
- Backend compiles; Angular `build-dev` clean.
- The SQL DACPAC project builds in Visual Studio (SSDT); the view + sproc were also validated by applying them to a live DB and running the tests.
- Verified in-browser: Provisional layer on by default and visible while drawing.

## Notes

- `vGeoServerTreatmentBMPDelineation` guarded too (same `DelineationGeometry4326` exposure).
- No DTO/API contract or codegen changes.
