### PR TITLE
NPT-1108: Case-insensitive Treatment BMP CSV headers + attribute values

### DIFF
--- a/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
@@ -559,11 +559,14 @@ namespace Neptune.EFModels.Entities
         }
 
         // NPT-1108: resolve a case-insensitively-matched entry to the canonical casing stored in the
-        // custom attribute's acceptable-values (options schema). Returns the input unchanged when there
-        // is no match (invalid entries are already rejected during validation).
+        // custom attribute's acceptable-values (options schema). Trims first to match how validation
+        // compares entries, so a value like " liner " (which passes validation) still normalizes to
+        // "Liner". Returns the trimmed input when there is no match (invalid entries are already
+        // rejected during validation).
         private static string NormalizeToCanonicalCasing(string value, List<string> acceptableValues)
         {
-            return acceptableValues?.FirstOrDefault(o => string.Equals(o, value, StringComparison.OrdinalIgnoreCase)) ?? value;
+            var trimmed = (value ?? "").Trim();
+            return acceptableValues?.FirstOrDefault(o => string.Equals(o, trimmed, StringComparison.OrdinalIgnoreCase)) ?? trimmed;
         }
 
         private static bool ValidateCustomAttributeValueEntry(string value, CustomAttributeDataTypeEnum customAttributeDataType, List<string> customAttributeTypeAcceptableValues)

--- a/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
+++ b/Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs
@@ -342,7 +342,7 @@ namespace Neptune.EFModels.Entities
                 var fieldValue = row[fieldsDict[fieldName]];
                 if (!string.IsNullOrWhiteSpace(fieldValue))
                 {
-                    if (!lookupValues.Select(funcDisplayName.Invoke).Contains(fieldValue))
+                    if (!lookupValues.Select(funcDisplayName.Invoke).Contains(fieldValue, StringComparer.OrdinalIgnoreCase))
                     {
                         var errorMessage = $"No {fieldName} with the name '{fieldValue}' exists in our records, row: {rowNumber}.";
                         if (showAvailableValuesInErrorMessage)
@@ -353,7 +353,7 @@ namespace Neptune.EFModels.Entities
                     }
                     else
                     {
-                        var entity = lookupValues.Single(x => funcDisplayName.Invoke(x) == fieldValue);
+                        var entity = lookupValues.Single(x => string.Equals(funcDisplayName.Invoke(x), fieldValue, StringComparison.OrdinalIgnoreCase));
                         return funcID.Invoke(entity);
                     }
                 }
@@ -502,17 +502,24 @@ namespace Neptune.EFModels.Entities
 
                         if (customAttributeType.CustomAttributeDataType == CustomAttributeDataType.MultiSelect)
                         {
+                            // NPT-1108: store the canonical casing from the acceptable-values list
+                            // (e.g. user typed "liner" -> stored "Liner").
                             var attributeValues = value.Split(new[] {','}).Select(x => x.Trim())
                                 .Where(x => !string.IsNullOrEmpty(x))
                                 .Select(x =>
-                                new CustomAttributeValue { CustomAttribute = customAttribute, AttributeValue = x });
+                                new CustomAttributeValue { CustomAttribute = customAttribute, AttributeValue = NormalizeToCanonicalCasing(x, customAttributeTypeAcceptableValues) });
                             customAttributeValues.AddRange(attributeValues);
                         }
                         else
                         {
+                            // NPT-1108: normalize PickFromList to canonical casing; leave Integer/Decimal/
+                            // DateTime/String values verbatim (this branch is shared by all of them).
+                            var storedValue = customAttributeType.CustomAttributeDataType == CustomAttributeDataType.PickFromList
+                                ? NormalizeToCanonicalCasing(value, customAttributeTypeAcceptableValues)
+                                : value;
                             customAttributeValues.Add(new CustomAttributeValue
                             {
-                                CustomAttribute = customAttribute, AttributeValue = value
+                                CustomAttribute = customAttribute, AttributeValue = storedValue
                             });
                         }
                     }
@@ -539,7 +546,7 @@ namespace Neptune.EFModels.Entities
                     // mixed multi-select like "Gravel, InvalidMedia" reports only "InvalidMedia".
                     var invalidEntries = value.Split(',').Select(x => x.Trim())
                         .Where(x => !string.IsNullOrEmpty(x))
-                        .Where(x => customAttributeTypeAcceptableValues == null || !customAttributeTypeAcceptableValues.Contains(x))
+                        .Where(x => customAttributeTypeAcceptableValues == null || !customAttributeTypeAcceptableValues.Contains(x, StringComparer.OrdinalIgnoreCase))
                         .Distinct()
                         .ToList();
                     var invalidEntryDisplay = invalidEntries.Any() ? string.Join(", ", invalidEntries) : value;
@@ -549,6 +556,14 @@ namespace Neptune.EFModels.Entities
                     return
                         $"{customAttributeTypeName} entry at row: {rowNumber} experienced an unknown error. Please double check the sheet, and contact support with further questions.";
             }
+        }
+
+        // NPT-1108: resolve a case-insensitively-matched entry to the canonical casing stored in the
+        // custom attribute's acceptable-values (options schema). Returns the input unchanged when there
+        // is no match (invalid entries are already rejected during validation).
+        private static string NormalizeToCanonicalCasing(string value, List<string> acceptableValues)
+        {
+            return acceptableValues?.FirstOrDefault(o => string.Equals(o, value, StringComparison.OrdinalIgnoreCase)) ?? value;
         }
 
         private static bool ValidateCustomAttributeValueEntry(string value, CustomAttributeDataTypeEnum customAttributeDataType, List<string> customAttributeTypeAcceptableValues)
@@ -571,7 +586,7 @@ namespace Neptune.EFModels.Entities
 
                     return splitValues.Any() &&
                            customAttributeTypeAcceptableValues != null &&
-                           splitValues.All(customAttributeTypeAcceptableValues.Contains);
+                           splitValues.All(v => customAttributeTypeAcceptableValues.Contains(v, StringComparer.OrdinalIgnoreCase));
                 case CustomAttributeDataTypeEnum.String:
                     return true;
                 default:
@@ -583,7 +598,10 @@ namespace Neptune.EFModels.Entities
         private static Dictionary<string, int> ValidateHeader(string[] row, List<string> requiredFields, List<string> optionalFields, List<string> customAttributes, out List<string> errorList, TreatmentBMPType treatmentBMPType)
         {
             errorList = new List<string>();
-            var fieldsDict = new Dictionary<string, int>();
+            // NPT-1108: case-insensitive header matching. This dict's keys are looked up throughout the
+            // parser (fieldsDict.ContainsKey / fieldsDict[fieldName]), so OrdinalIgnoreCase here makes
+            // every header lookup case-insensitive in one shot.
+            var fieldsDict = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
             for (var fieldIndex = 0; fieldIndex < row.Length; fieldIndex++)
             {
@@ -595,9 +613,9 @@ namespace Neptune.EFModels.Entities
             }
 
             var headers = fieldsDict.Keys.ToList();
-            var requiredFieldDifference = requiredFields.Except(headers).ToList();
-            var optionalFieldDifference = headers.Except(requiredFields).Except(optionalFields);
-            var customAttributesDifference = optionalFieldDifference.Except(customAttributes).ToList();
+            var requiredFieldDifference = requiredFields.Except(headers, StringComparer.OrdinalIgnoreCase).ToList();
+            var optionalFieldDifference = headers.Except(requiredFields, StringComparer.OrdinalIgnoreCase).Except(optionalFields, StringComparer.OrdinalIgnoreCase);
+            var customAttributesDifference = optionalFieldDifference.Except(customAttributes, StringComparer.OrdinalIgnoreCase).ToList();
 
             if (requiredFieldDifference.Any())
             {

--- a/Neptune.Tests/TestTreatmentCSVParser.cs
+++ b/Neptune.Tests/TestTreatmentCSVParser.cs
@@ -1414,8 +1414,9 @@ Frank,30,10,City of Orange,Sitka Technology Group,2008,ABCD,Perpetuity/Life of P
         // ---- NPT-1108: case-insensitive headers + attribute values, with canonical normalization ----
 
         // Swaps the case of each letter, so the result differs from the input for any value that has letters.
+        // Invariant casing avoids locale-dependent behavior (e.g. Turkish dotless-I).
         private static string FlipCase(string value) =>
-            new string(value.Select(c => char.IsUpper(c) ? char.ToLower(c) : char.ToUpper(c)).ToArray());
+            new string(value.Select(c => char.IsUpper(c) ? char.ToLowerInvariant(c) : char.ToUpperInvariant(c)).ToArray());
 
         private (int TreatmentBMPTypeID, string AttributeName, List<string> ValidValues)? FindPickFromListCustomAttribute()
         {

--- a/Neptune.Tests/TestTreatmentCSVParser.cs
+++ b/Neptune.Tests/TestTreatmentCSVParser.cs
@@ -1410,5 +1410,116 @@ Frank,30,10,City of Orange,Sitka Technology Group,2008,ABCD,Perpetuity/Life of P
             Assert.IsTrue(errorList.Any(x => x.Contains(attributeName) && x.Contains("is not a valid")),
                 "A purely invalid multi-select entry should be rejected.");
         }
+
+        // ---- NPT-1108: case-insensitive headers + attribute values, with canonical normalization ----
+
+        // Swaps the case of each letter, so the result differs from the input for any value that has letters.
+        private static string FlipCase(string value) =>
+            new string(value.Select(c => char.IsUpper(c) ? char.ToLower(c) : char.ToUpper(c)).ToArray());
+
+        private (int TreatmentBMPTypeID, string AttributeName, List<string> ValidValues)? FindPickFromListCustomAttribute()
+        {
+            var pickFromListDataTypeID = (int)CustomAttributeDataTypeEnum.PickFromList;
+            var candidate = _dbContext.CustomAttributeTypes
+                .Include(x => x.TreatmentBMPTypeCustomAttributeTypes)
+                .AsNoTracking()
+                .Where(x => x.CustomAttributeDataTypeID == pickFromListDataTypeID
+                            && x.CustomAttributeTypeOptionsSchema != null
+                            && x.TreatmentBMPTypeCustomAttributeTypes.Any())
+                .ToList()
+                .Select(x => new
+                {
+                    Type = x,
+                    Options = System.Text.Json.JsonSerializer.Deserialize<List<string>>(x.CustomAttributeTypeOptionsSchema)
+                })
+                .FirstOrDefault(x => x.Options != null && x.Options.Count >= 1);
+
+            if (candidate == null)
+            {
+                return null;
+            }
+
+            return (candidate.Type.TreatmentBMPTypeCustomAttributeTypes.First().TreatmentBMPTypeID,
+                candidate.Type.CustomAttributeTypeName,
+                candidate.Options);
+        }
+
+        [TestMethod]
+        public void TestHeaderMatchingIsCaseInsensitive()
+        {
+            // Same valid header as TestValidColumns, upper-cased. Case-insensitive header matching means
+            // no "required headers"/"did not match a property" errors.
+            const string header = "BMP Name,Latitude,Longitude,Jurisdiction, Owner,Year Built or Installed,Asset ID in System of Record, Required Lifespan of Installation,Allowable End Date of Installation (if applicable), Required Field Visits Per Year, Required Post-Storm Field Visits Per Year,Notes,Trash Capture Status,Sizing Basis";
+            var csv = header.ToUpperInvariant();
+            const int treatmentBMPTypeID = 17;
+            TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out _);
+            Assert.IsTrue(!errorList.Any(), "Upper-cased headers should be accepted (case-insensitive header matching). Errors: " + string.Join("; ", errorList));
+        }
+
+        [TestMethod]
+        public void TestLookupValuesAreCaseInsensitive()
+        {
+            // Jurisdiction / Owner / Trash Capture Status lower-cased — all lookups must still resolve.
+            const string csv = @"BMP Name,Latitude,Longitude,Jurisdiction, Owner,Year Built or Installed,Asset ID in System of Record, Required Lifespan of Installation,Allowable End Date of Installation (if applicable), Required Field Visits Per Year, Required Post-Storm Field Visits Per Year,Notes,Trash Capture Status,Sizing Basis
+Frank,30,10,city of dana point,sitka technology group,2008,ABCD,Perpetuity/Life of Project,11/12/2022,5,6,Happy,full,Not Provided";
+            const int treatmentBMPTypeID = 17;
+            var treatmentBMPs = TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out _);
+            Assert.IsFalse(errorList.Any(x => x.Contains("No Jurisdiction with the name")), "Lower-cased jurisdiction should resolve.");
+            Assert.IsFalse(errorList.Any(x => x.Contains("No Owner with the name")), "Lower-cased owner should resolve.");
+            Assert.IsFalse(errorList.Any(x => x.Contains("No Trash Capture Status with the name")), "Lower-cased Trash Capture Status should resolve.");
+            Assert.AreEqual(2, treatmentBMPs[0].StormwaterJurisdictionID, "Jurisdiction should resolve to the same ID regardless of casing.");
+        }
+
+        [TestMethod]
+        public void TestCustomAttributeMultiSelectValueIsCaseInsensitiveAndNormalized()
+        {
+            var ms = FindMultiSelectCustomAttribute();
+            if (ms == null)
+            {
+                Assert.Inconclusive("No MultiSelect custom attribute type with options exists in the local database.");
+            }
+            var (treatmentBMPTypeID, attributeName, validValues) = ms.Value;
+            var canonical = validValues.FirstOrDefault(v => FlipCase(v) != v);
+            if (canonical == null)
+            {
+                Assert.Inconclusive("No alphabetic MultiSelect option available to exercise casing.");
+            }
+
+            var csv = BuildMultiSelectCsv("NPT1108 MultiSelect CaseInsensitive", attributeName, FlipCase(canonical));
+            TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out var customAttributeValues);
+
+            Assert.IsFalse(errorList.Any(x => x.Contains(attributeName)),
+                "A differently-cased valid MultiSelect value should be accepted. Errors: " + string.Join("; ", errorList));
+            Assert.IsTrue(customAttributeValues.Any(v => v.AttributeValue == canonical),
+                "The stored value should use the canonical casing from the acceptable-values list.");
+            Assert.IsFalse(customAttributeValues.Any(v => v.AttributeValue == FlipCase(canonical)),
+                "The user's non-canonical casing should not be stored.");
+        }
+
+        [TestMethod]
+        public void TestCustomAttributePickFromListValueIsCaseInsensitiveAndNormalized()
+        {
+            var pick = FindPickFromListCustomAttribute();
+            if (pick == null)
+            {
+                Assert.Inconclusive("No PickFromList custom attribute type with options exists in the local database.");
+            }
+            var (treatmentBMPTypeID, attributeName, validValues) = pick.Value;
+            var canonical = validValues.FirstOrDefault(v => FlipCase(v) != v);
+            if (canonical == null)
+            {
+                Assert.Inconclusive("No alphabetic PickFromList option available to exercise casing.");
+            }
+
+            var csv = BuildMultiSelectCsv("NPT1108 PickFromList CaseInsensitive", attributeName, FlipCase(canonical));
+            TreatmentBMPCsvParserHelper.CSVUpload(_dbContext, csv, treatmentBMPTypeID, out var errorList, out _, out var customAttributeValues);
+
+            Assert.IsFalse(errorList.Any(x => x.Contains(attributeName)),
+                "A differently-cased valid PickFromList value should be accepted. Errors: " + string.Join("; ", errorList));
+            Assert.IsTrue(customAttributeValues.Any(v => v.AttributeValue == canonical),
+                "The stored PickFromList value should use the canonical casing from the acceptable-values list.");
+            Assert.IsFalse(customAttributeValues.Any(v => v.AttributeValue == FlipCase(canonical)),
+                "The user's non-canonical casing should not be stored.");
+        }
     }
 }


### PR DESCRIPTION
## Context

Users uploading Treatment BMPs via CSV hit validation errors from harmless casing differences — `Time of Concentration` vs `Time Of Concentration`, or `liner` vs `Liner` for Underlying Hydrologic Soil Group. The parser matched case-sensitively for column headers, lookup-field values, and PickFromList/MultiSelect custom-attribute values. This makes all three case-insensitive (`OrdinalIgnoreCase`) and normalizes PickFromList/MultiSelect stored values to the canonical casing.

Entirely one file: `Neptune.EFModels/Entities/TreatmentBMPCsvParserHelper.cs`.

## Changes

- **Headers** (`ValidateHeader`): the header→index `fieldsDict` now uses `StringComparer.OrdinalIgnoreCase` — one change makes **every** downstream header lookup case-insensitive — plus `OrdinalIgnoreCase` on the three header `.Except(...)` comparisons.
- **Lookup values** (`FindLookupValue`) — Trash Capture Status, Sizing Basis, Lifespan Type, Jurisdiction, Owner: case-insensitive `Contains` / `string.Equals`.
- **PickFromList / MultiSelect** custom attributes (`ValidateCustomAttributeValueEntry`, `GetErrorForCustomAttributeType`): case-insensitive acceptable-value matching.
- **Canonical normalization** (new `NormalizeToCanonicalCasing` helper): when a PickFromList/MultiSelect value matches case-insensitively, the stored `AttributeValue` uses the canonical casing from the options schema (`liner` → `Liner`). Gated to PickFromList/MultiSelect so Integer/Decimal/DateTime/String values are stored verbatim. Lookups store by ID, so no normalization needed there.

## Testing

- 4 new tests (`TestTreatmentCSVParser.cs`), all pass: uppercase headers accepted; lowercased Jurisdiction/Owner/Trash Capture Status resolve to the same ID; MultiSelect and PickFromList values matched case-insensitively **and** stored canonical (adds a `FindPickFromListCustomAttribute` discovery helper mirroring the existing MultiSelect one).
- `dotnet build` clean. No DB/DTO/API/frontend/codegen changes.

Note: one unrelated pre-existing test (`TestBMPNameExistsAndMatchingJurisdictionAndType`) fails identically on the clean baseline (data-dependent on a specific local fixture) — not touched by this change.
