### PR TITLE
NPT-943: Move grid downloads into a footer Download menu (PO rework)

### DIFF
--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.html
@@ -1,9 +1,6 @@
 <page-header pageTitle="All Treatment BMPs" [customRichTextTypeID]="customRichTextTypeID" [templateRight]="headerActions"></page-header>
 <ng-template #headerActions>
     @if (currentPersonCanEdit$ | async) {
-        <button class="btn btn-primary-outline ml-2" style="margin-right: 0.5rem" type="button" [disabled]="isDownloadingGdb()" (click)="downloadGdb()">
-            @if (isDownloadingGdb()) { <i class="fa fa-spinner fa-spin"></i> Building... } @else { <i class="fa fa-download"></i> Download GDB }
-        </button>
         <button class="btn btn-orange" [routerLink]="['/treatment-bmps/new']" type="button">+ Create New Treatment BMP</button>
     }
 </ng-template>
@@ -49,6 +46,9 @@
         [selectedValue]="selectedTreatmentBMPID"
         [selectionFromMap]="selectionFromMap"
         (selectedValueChange)="onSelectedTreatmentBMPChangedFromGrid($event)"
+        [showGdbDownloadOption]="(currentPersonCanEdit$ | async) ?? false"
+        [isDownloadingGdb]="isDownloadingGdb()"
+        (gdbDownloadRequested)="downloadGdb()"
         [boundingBox]="boundingBox$ | async">
         <ng-container mapLayers>
             @if (map) {

--- a/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
+++ b/Neptune.Web/src/app/pages/wqmps/wqmps.component.html
@@ -23,11 +23,6 @@
             <a class="dropdown-item" [routerLink]="['/data-hub/wqmp-locations-upload']">Bulk Upload WQMP Boundaries From APNs</a>
         </div>
     }
-    @if (currentPersonCanEdit$ | async) {
-        <button type="button" class="btn btn-primary-outline ml-2" style="margin-left: 0.5rem" [disabled]="isDownloadingGdb()" (click)="downloadGdb()">
-            @if (isDownloadingGdb()) { <i class="fa fa-spinner fa-spin"></i> Building... } @else { <i class="fa fa-download"></i> Download GDB }
-        </button>
-    }
 </ng-template>
 <page-header pageTitle="Water Quality Management Plans" [customRichTextTypeID]="customRichTextTypeID" [templateRight]="addButton"></page-header>
 <app-alert-display></app-alert-display>
@@ -43,6 +38,9 @@
                 [selectedValue]="selectedWaterQualityManagementPlanID"
                 [selectionFromMap]="true"
                 (selectedValueChange)="onSelectedWaterQualityManagementPlanIDChanged($event)"
+                [showGdbDownloadOption]="(currentPersonCanEdit$ | async) ?? false"
+                [isDownloadingGdb]="isDownloadingGdb()"
+                (gdbDownloadRequested)="downloadGdb()"
                 [boundingBox]="boundingBox">
                 <wqmps-layer
                     [map]="map"

--- a/Neptune.Web/src/app/shared/components/full-screen-button/full-screen-button.component.html
+++ b/Neptune.Web/src/app/shared/components/full-screen-button/full-screen-button.component.html
@@ -1,8 +1,8 @@
-<a
+<button
+    type="button"
     class="btn btn-sm btn-primary-outline grid-footer-action"
     (click)="isFullScreen ? exitFullScreen() : enterFullScreen()"
-    role="button"
     title="{{ !isFullScreen ? enterFullScreenTitleText : exitFullScreenTitleText }}">
     {{ isFullScreen ? "Collapse" : "Expand" }}
     <icon [icon]="!isFullScreen ? 'EnterFullScreen' : 'ExitFullScreen'"></icon>
-</a>
+</button>

--- a/Neptune.Web/src/app/shared/components/full-screen-button/full-screen-button.component.html
+++ b/Neptune.Web/src/app/shared/components/full-screen-button/full-screen-button.component.html
@@ -1,3 +1,8 @@
-<a class="btn btn-primary-outline btn-icon" (click)="isFullScreen ? exitFullScreen() : enterFullScreen()" title="{{ !isFullScreen ? enterFullScreenTitleText : exitFullScreenTitleText }}">
+<a
+    class="btn btn-sm btn-primary-outline grid-footer-action"
+    (click)="isFullScreen ? exitFullScreen() : enterFullScreen()"
+    role="button"
+    title="{{ !isFullScreen ? enterFullScreenTitleText : exitFullScreenTitleText }}">
+    {{ isFullScreen ? "Collapse" : "Expand" }}
     <icon [icon]="!isFullScreen ? 'EnterFullScreen' : 'ExitFullScreen'"></icon>
 </a>

--- a/Neptune.Web/src/app/shared/components/full-screen-button/full-screen-button.component.scss
+++ b/Neptune.Web/src/app/shared/components/full-screen-button/full-screen-button.component.scss
@@ -1,3 +1,11 @@
+// Matches .grid-download-trigger so the footer's Expand and Download pills are identical in size.
+.grid-footer-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+}
+
 .fullscreen {
     position: fixed !important;
     width: 100% !important;

--- a/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.html
+++ b/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.html
@@ -39,7 +39,10 @@
       (gridRefReady)="onGridRefReady($event)"
       (selectionChanged)="onGridSelectionChanged()"
       [downloadFileName]="downloadFileName"
-    [colIDsToExclude]=""></neptune-grid>
+      [colIDsToExclude]=""
+      [showGdbDownloadOption]="showGdbDownloadOption"
+      [isDownloadingGdb]="isDownloadingGdb"
+    (gdbDownloadRequested)="gdbDownloadRequested.emit()"></neptune-grid>
   </div>
 
   <div class="tab-nav-container__panel tab-nav-container__map-panel" [class.hidden]="selectedPanel === 'Grid'">

--- a/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.html
+++ b/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.html
@@ -39,7 +39,6 @@
       (gridRefReady)="onGridRefReady($event)"
       (selectionChanged)="onGridSelectionChanged()"
       [downloadFileName]="downloadFileName"
-      [colIDsToExclude]=""
       [showGdbDownloadOption]="showGdbDownloadOption"
       [isDownloadingGdb]="isDownloadingGdb"
     (gdbDownloadRequested)="gdbDownloadRequested.emit()"></neptune-grid>

--- a/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.ts
+++ b/Neptune.Web/src/app/shared/components/hybrid-map-grid/hybrid-map-grid.component.ts
@@ -25,9 +25,13 @@ export class HybridMapGridComponent {
     @Input() entityIDField: string = "";
     @Input() gridHeight: string = "675px";
     @Input() boundingBox: BoundingBoxDto;
+    // NPT-943: forwarded to neptune-grid's footer download menu; the host page owns the GDB export.
+    @Input() showGdbDownloadOption: boolean = false;
+    @Input() isDownloadingGdb: boolean = false;
 
     @Output() onMapLoad: EventEmitter<NeptuneMapInitEvent> = new EventEmitter();
     @Output() selectedValueChange: EventEmitter<number> = new EventEmitter<number>();
+    @Output() gdbDownloadRequested: EventEmitter<void> = new EventEmitter<void>();
     public gridApi: GridApi;
     public gridRef: AgGridAngular;
 

--- a/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.html
+++ b/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.html
@@ -1,0 +1,21 @@
+<a
+    class="btn btn-sm btn-primary-outline grid-download-trigger"
+    id="grid-download-menu-trigger"
+    [dropdownToggle]="downloadMenuTemplate"
+    [attachToBody]="true"
+    role="button"
+    title="Download grid data">
+    Download
+    <icon [icon]="'Download'"></icon>
+    <i class="fas fa-chevron-down caret"></i>
+</a>
+<ng-template #downloadMenuTemplate>
+    <div class="grid-download-menu" aria-labelledby="grid-download-menu-trigger">
+        <a href="javascript:void(0);" (click)="exportCsv()">Text File (.csv)</a>
+        @if (showGdbOption) {
+            <a href="javascript:void(0);" [class.disabled]="isDownloadingGdb" (click)="onGdbClick()">
+                @if (isDownloadingGdb) { <i class="fa fa-spinner fa-spin"></i> Building... } @else { GIS (.gdb.zip) }
+            </a>
+        }
+    </div>
+</ng-template>

--- a/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.html
+++ b/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.html
@@ -1,16 +1,15 @@
-<a
+<button
+    type="button"
     class="btn btn-sm btn-primary-outline grid-download-trigger"
-    id="grid-download-menu-trigger"
     [dropdownToggle]="downloadMenuTemplate"
     [attachToBody]="true"
-    role="button"
     title="Download grid data">
     Download
     <icon [icon]="'Download'"></icon>
     <i class="fas fa-chevron-down caret"></i>
-</a>
+</button>
 <ng-template #downloadMenuTemplate>
-    <div class="grid-download-menu" aria-labelledby="grid-download-menu-trigger">
+    <div class="grid-download-menu">
         <a href="javascript:void(0);" (click)="exportCsv()">Text File (.csv)</a>
         @if (showGdbOption) {
             <a href="javascript:void(0);" [class.disabled]="isDownloadingGdb" (click)="onGdbClick()">

--- a/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.scss
+++ b/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.scss
@@ -1,0 +1,54 @@
+@use "/src/scss/abstracts" as *;
+
+.grid-download-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+
+    .caret {
+        font-size: 0.65rem;
+    }
+}
+
+// Rendered in a CDK overlay (attachToBody) so the grid's footer / table-responsive container
+// can't clip it. Mirrors the Qanat grid-download-menu pattern.
+.grid-download-menu {
+    display: grid;
+    position: absolute;
+    min-width: 11rem;
+    top: 0.65rem;
+    left: 0.25rem;
+    background: white;
+    padding: 0.75rem;
+    box-shadow: 0 2px 8px rgba($black, 0.15);
+    border-radius: 0.25rem;
+    border: 1px solid $primary;
+
+    a {
+        font-size: $type-size-200;
+        display: inline-block;
+        padding: 0;
+        border: none;
+        text-align: left;
+        color: $primary;
+        background: none;
+        line-height: 1.5em;
+        cursor: pointer;
+
+        & + a {
+            margin-top: 0.5rem;
+        }
+
+        &:hover {
+            text-decoration: underline;
+        }
+
+        &.disabled {
+            opacity: 0.6;
+            cursor: default;
+            pointer-events: none;
+            text-decoration: none;
+        }
+    }
+}

--- a/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.ts
+++ b/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.ts
@@ -1,0 +1,41 @@
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { AgGridAngular } from "ag-grid-angular";
+import { IconComponent } from "src/app/shared/components/icon/icon.component";
+import { DropdownToggleDirective } from "src/app/shared/directives/dropdown-toggle.directive";
+import { UtilityFunctionsService } from "src/app/services/utility-functions.service";
+
+@Component({
+    selector: "neptune-grid-download-menu",
+    imports: [IconComponent, DropdownToggleDirective],
+    templateUrl: "./neptune-grid-download-menu.component.html",
+    styleUrls: ["./neptune-grid-download-menu.component.scss"],
+})
+export class GridDownloadMenuComponent {
+    @Input() grid: AgGridAngular;
+    @Input() fileName: string;
+    @Input() colIDsToExclude: string[] = [];
+
+    // When true the menu offers a "GIS (.gdb.zip)" option. The GDB export itself is owned by the host
+    // page (WQMP is a filtered POST of the displayed IDs, BMP is a plain GET), so the menu only emits
+    // the request and reflects the page's downloading state — it does not perform the download.
+    @Input() showGdbOption: boolean = false;
+    @Input() isDownloadingGdb: boolean = false;
+
+    @Output() gdbDownloadRequested: EventEmitter<void> = new EventEmitter<void>();
+
+    constructor(private utilityFunctionsService: UtilityFunctionsService) {}
+
+    public exportCsv(): void {
+        if (!this.grid) return;
+        const columnIDs = this.grid.api
+            .getAllDisplayedColumns()
+            .map((column) => column.getColId())
+            .filter((id) => this.colIDsToExclude.indexOf(id) < 0);
+        this.utilityFunctionsService.exportGridToCsv(this.grid, this.fileName + ".csv", columnIDs);
+    }
+
+    public onGdbClick(): void {
+        if (this.isDownloadingGdb) return;
+        this.gdbDownloadRequested.emit();
+    }
+}

--- a/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.html
+++ b/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.html
@@ -56,7 +56,13 @@
       }
       @if (!hideDownloadButton) {
         <div class="download-button">
-          <neptune-csv-download-button [grid]="gridref" [fileName]="downloadFileName" [colIDsToExclude]="colIDsToExclude"></neptune-csv-download-button>
+          <neptune-grid-download-menu
+            [grid]="gridref"
+            [fileName]="downloadFileName"
+            [colIDsToExclude]="colIDsToExclude"
+            [showGdbOption]="showGdbDownloadOption"
+            [isDownloadingGdb]="isDownloadingGdb"
+          (gdbDownloadRequested)="gdbDownloadRequested.emit()"></neptune-grid-download-menu>
         </div>
       }
     </div>

--- a/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.ts
+++ b/Neptune.Web/src/app/shared/components/neptune-grid/neptune-grid.component.ts
@@ -17,13 +17,13 @@ import { AgGridHelper } from "src/app/shared/helpers/ag-grid-helper";
 import { TooltipComponent } from "src/app/shared/components/ag-grid/tooltip/tooltip.component";
 import { FormsModule } from "@angular/forms";
 import { PaginationControlsComponent } from "src/app/shared/components/ag-grid/pagination-controls/pagination-controls.component";
-import { CsvDownloadButtonComponent } from "../csv-download-button/csv-download-button.component";
+import { GridDownloadMenuComponent } from "../neptune-grid-download-menu/neptune-grid-download-menu.component";
 import { NeptuneGridHeaderComponent } from "../neptune-grid-header/neptune-grid-header.component";
 import { FullScreenButtonComponent } from "../full-screen-button/full-screen-button.component";
 
 @Component({
     selector: "neptune-grid",
-    imports: [CommonModule, AgGridModule, FormsModule, PaginationControlsComponent, CsvDownloadButtonComponent, NeptuneGridHeaderComponent, FullScreenButtonComponent],
+    imports: [CommonModule, AgGridModule, FormsModule, PaginationControlsComponent, GridDownloadMenuComponent, NeptuneGridHeaderComponent, FullScreenButtonComponent],
     templateUrl: "./neptune-grid.component.html",
     styleUrls: ["./neptune-grid.component.scss"]
 })
@@ -61,6 +61,11 @@ export class NeptuneGridComponent implements OnInit, OnChanges {
     @Input() downloadFileName: string = "grid-data";
     @Input() colIDsToExclude: string[] = [];
     @Input() hideDownloadButton: boolean = false;
+    // When true, the footer download menu offers a "GIS (.gdb.zip)" option; the host page performs the
+    // actual export via (gdbDownloadRequested) and reports progress via [isDownloadingGdb]. (NPT-943)
+    @Input() showGdbDownloadOption: boolean = false;
+    @Input() isDownloadingGdb: boolean = false;
+    @Output() gdbDownloadRequested: EventEmitter<void> = new EventEmitter<void>();
     @Input() hideFullscreenButton: boolean = false;
     @Input() hideTooltips: boolean = false;
     @Input() hideGlobalFilter: boolean = false;


### PR DESCRIPTION
## NPT-943 rework

PO feedback (KE 7/28/26): the Download GDB buttons were at the top of the page — they should live in the **grid footer** alongside CSV, matching the Qanat pattern.

## Changes
- **New `neptune-grid-download-menu`** — a "Download ▾" dropdown offering **Text File (.csv)** and, when enabled, **GIS (.gdb.zip)**. Replaces the standalone CSV icon button in the `neptune-grid` footer **app-wide**.
- **`neptune-grid`** — new `showGdbDownloadOption` / `isDownloadingGdb` inputs and `gdbDownloadRequested` output; `hybrid-map-grid` forwards them.
- **WQMP Index** and **View All BMPs** — GDB moved from the page header into the grid footer via those bindings. Existing download handlers unchanged (WQMP = filtered POST of displayed IDs; BMP = GET full inventory).
- **`full-screen-button`** — icon-only → labeled **Expand/Collapse** pill so it matches the Download pill size (KE reference screenshot).

## Scope notes
- GDB row shows for editors only (`currentPersonCanEdit$`); Viewers/Unassigned see the dropdown with **CSV only** — satisfies the permissions AC (control absent, not disabled).
- Data Hub WQMP tab left unchanged (no grid, per scope decision).
- The footer "Download ▾" and "Expand" changes apply to **every** `neptune-grid` in the app, per the agreed app-wide styling.

## Verification
- `npm run build-dev` clean (exit 0).
- Verified in browser: matching Expand/Download pills, dropdown contents, filter-respecting WQMP export, full-inventory BMP export, Viewer sees CSV-only.