### PR TITLE
NPT-1114: Fix trash-screen upload of the pre-populated template (PO rework)

### DIFF
--- a/Neptune.API/Controllers/DataHubController.cs
+++ b/Neptune.API/Controllers/DataHubController.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using ClosedXML.Excel;
@@ -90,6 +92,17 @@ public class DataHubController(
     // pre-populated rows must land on this exact tab.
     private const string TrashScreenTemplateWorksheetName = "Field Visits";
 
+    // Header text of the pre-populated columns in the "Field Visits" sheet. Resolved by name at
+    // generation time (see DownloadTrashScreenUploadTemplate) so the generator doesn't couple to
+    // column letters and stays aligned with the importer, which reads back by header name. (NPT-1114)
+    private const string BMPNameHeader = "BMP Name";
+    private const string JurisdictionHeader = "Jurisdiction";
+    private const string YearBuiltHeader = "Year Built";
+    private const string NotesHeader = "BMP Notes";
+    private const string InletScreensHeader = "# of inlet screens";
+    private const string TrashBasketsHeader = "# of trash baskets";
+    private const string ConnectorPipeScreensHeader = "# of connector pipe screens";
+
     /// <summary>
     /// NPT-1114: regenerates the Trash Screen Field Visit upload template with one pre-populated
     /// row per trash-screen BMP (TreatmentBMPType "Inlet and Trash Screen") the caller can access,
@@ -130,22 +143,42 @@ public class DataHubController(
                 statusCode: StatusCodes.Status500InternalServerError);
         }
 
+        // NPT-1114: resolve target columns by header text instead of hard-coded letters, so the
+        // generated cells stay aligned with the importer (which reads by header name) even if the
+        // template's column order changes. BMP Name + Jurisdiction are the importer's lookup keys, so
+        // the file is unusable on re-upload if either is missing — guard those explicitly.
+        var headerColumns = BuildHeaderColumnMap(worksheet);
+        if (!headerColumns.TryGetValue(BMPNameHeader, out var bmpNameColumn) ||
+            !headerColumns.TryGetValue(JurisdictionHeader, out var jurisdictionColumn))
+        {
+            return Problem(
+                $"The Trash Screen upload template is missing the '{BMPNameHeader}' or '{JurisdictionHeader}' column.",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+
+        int? ColumnFor(string header) => headerColumns.TryGetValue(header, out var c) ? c : null;
+        var yearBuiltColumn = ColumnFor(YearBuiltHeader);
+        var notesColumn = ColumnFor(NotesHeader);
+        var inletScreensColumn = ColumnFor(InletScreensHeader);
+        var trashBasketsColumn = ColumnFor(TrashBasketsHeader);
+        var connectorPipeScreensColumn = ColumnFor(ConnectorPipeScreensHeader);
+
         var row = 2;
         foreach (var bmp in trashScreens)
         {
-            worksheet.Cell($"A{row}").Value = bmp.TreatmentBMPName;
-            worksheet.Cell($"B{row}").Value = bmp.StormwaterJurisdictionName;
-            if (bmp.YearBuilt.HasValue)
+            worksheet.Cell(row, bmpNameColumn).Value = bmp.TreatmentBMPName;
+            worksheet.Cell(row, jurisdictionColumn).Value = bmp.StormwaterJurisdictionName;
+            if (yearBuiltColumn.HasValue && bmp.YearBuilt.HasValue)
             {
-                worksheet.Cell($"C{row}").Value = bmp.YearBuilt.Value;
+                worksheet.Cell(row, yearBuiltColumn.Value).Value = bmp.YearBuilt.Value;
             }
-            if (!string.IsNullOrWhiteSpace(bmp.Notes))
+            if (notesColumn.HasValue && !string.IsNullOrWhiteSpace(bmp.Notes))
             {
-                worksheet.Cell($"D{row}").Value = bmp.Notes;
+                worksheet.Cell(row, notesColumn.Value).Value = bmp.Notes;
             }
-            SetIntAttributeCell(worksheet, bmp, CustomAttributeTypes.CustomAttributeTypeIDNumberOfInletScreens, "E", row);
-            SetIntAttributeCell(worksheet, bmp, CustomAttributeTypes.CustomAttributeTypeIDNumberOfTrashBaskets, "F", row);
-            SetIntAttributeCell(worksheet, bmp, CustomAttributeTypes.CustomAttributeTypeIDNumberOfConnectorPipeScreens, "G", row);
+            SetIntAttributeCell(worksheet, bmp, CustomAttributeTypes.CustomAttributeTypeIDNumberOfInletScreens, inletScreensColumn, row);
+            SetIntAttributeCell(worksheet, bmp, CustomAttributeTypes.CustomAttributeTypeIDNumberOfTrashBaskets, trashBasketsColumn, row);
+            SetIntAttributeCell(worksheet, bmp, CustomAttributeTypes.CustomAttributeTypeIDNumberOfConnectorPipeScreens, connectorPipeScreensColumn, row);
             row++;
         }
 
@@ -155,13 +188,33 @@ public class DataHubController(
         return File(stream.ToArray(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", downloadFileName);
     }
 
-    // Writes a custom-attribute count into the given column only when the stored value parses as an
-    // int — matches the legacy SetCellValueFromCustomAttribute (numeric cell, blank otherwise).
-    private static void SetIntAttributeCell(IXLWorksheet worksheet, TreatmentBMPByTypeGridDto bmp, int customAttributeTypeID, string column, int row)
+    // Writes a custom-attribute count into the given column only when the column exists in the
+    // template (non-null) and the stored value parses as an int — matches the legacy
+    // SetCellValueFromCustomAttribute (numeric cell, blank otherwise).
+    private static void SetIntAttributeCell(IXLWorksheet worksheet, TreatmentBMPByTypeGridDto bmp, int customAttributeTypeID, int? column, int row)
     {
-        if (bmp.CustomAttributeValues.TryGetValue(customAttributeTypeID, out var raw) && int.TryParse(raw, out var value))
+        if (column.HasValue
+            && bmp.CustomAttributeValues.TryGetValue(customAttributeTypeID, out var raw)
+            && int.TryParse(raw, out var value))
         {
-            worksheet.Cell($"{column}{row}").Value = value;
+            worksheet.Cell(row, column.Value).Value = value;
         }
+    }
+
+    // NPT-1114: maps each non-empty header cell in row 1 to its 1-based column number
+    // (case-insensitive, trimmed; first occurrence wins) so the generator can address columns by
+    // header text rather than assuming a fixed A/B/C… order.
+    private static Dictionary<string, int> BuildHeaderColumnMap(IXLWorksheet worksheet)
+    {
+        var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var cell in worksheet.Row(1).CellsUsed())
+        {
+            var header = cell.GetString().Trim();
+            if (!string.IsNullOrEmpty(header) && !map.ContainsKey(header))
+            {
+                map[header] = cell.Address.ColumnNumber;
+            }
+        }
+        return map;
     }
 }

--- a/Neptune.EFModels/Entities/TrashScreenFieldVisitImporter.cs
+++ b/Neptune.EFModels/Entities/TrashScreenFieldVisitImporter.cs
@@ -49,7 +49,16 @@ public static class TrashScreenFieldVisitImporter
         {
             foreach (DataRow row in dataTable.Rows)
             {
-                var rowJurisdiction = row["Jurisdiction"].ToString();
+                // NPT-1114: the pre-populated template lists one row per BMP. Skip rows the user
+                // didn't fill in (fully blank, or reference-only rows with no field-visit data) so a
+                // blank row doesn't read an empty Jurisdiction and fail this check with a blank
+                // jurisdiction name ("...in Jurisdiction , which you do not have permission to manage").
+                if (RowHasNoFieldVisitData(row))
+                {
+                    continue;
+                }
+
+                var rowJurisdiction = row["Jurisdiction"].ToString()?.Trim();
                 if (!stormwaterJurisdictionsPersonCanView.Select(x => x.Organization.OrganizationName).Contains(rowJurisdiction))
                 {
                     result.Errors.Add($"You attempted to upload a spreadsheet containing BMPs in Jurisdiction {rowJurisdiction}, which you do not have permission to manage.");
@@ -79,7 +88,6 @@ public static class TrashScreenFieldVisitImporter
             .ToDictionary(name => name, name => treatmentBMPTypeAssessmentObservationTypes.Select(x => x.TreatmentBMPAssessmentObservationType).Single(x => x.TreatmentBMPAssessmentObservationTypeName == name));
 
         var numRows = dataTable.Rows.Count;
-        var numColumns = dataTable.Columns.Count;
         var errors = new List<string>();
 
         try
@@ -89,13 +97,13 @@ public static class TrashScreenFieldVisitImporter
                 try
                 {
                     var row = dataTable.Rows[i];
-                    var rowEmpty = true;
-                    for (var j = 0; j < numColumns; j++)
+                    // NPT-1114: ignore rows with no field-visit data — both fully blank rows and the
+                    // reference-only rows the pre-populated template lists for BMPs the user didn't
+                    // visit. Only rows carrying actual field-visit data are imported/validated.
+                    if (RowHasNoFieldVisitData(row))
                     {
-                        rowEmpty = string.IsNullOrWhiteSpace(row[j].ToString());
-                        if (!rowEmpty) break;
+                        continue;
                     }
-                    if (rowEmpty) continue;
 
                     var treatmentBMPName = row["BMP Name"].ToString()?.Trim();
                     var jurisdictionName = row["Jurisdiction"].ToString()?.Trim();
@@ -527,6 +535,25 @@ public static class TrashScreenFieldVisitImporter
             await dbContext.TreatmentBMPObservations.AddAsync(observation);
         }
         return observation;
+    }
+
+    // NPT-1114: a row carries no field-visit data when every column from "Field Visit Type" onward
+    // is blank. That covers both fully blank rows and the reference-only rows the pre-populated
+    // download lists (BMP Name / Jurisdiction / Year Built / Notes / screen-count columns filled, but
+    // no visit entered). Such rows are skipped rather than validated as incomplete field visits.
+    private static bool RowHasNoFieldVisitData(DataRow row)
+    {
+        var fieldVisitStartIndex = row.Table.Columns.IndexOf("Field Visit Type");
+        // Defensive: if the expected header is absent, fall back to "row is entirely blank".
+        var startIndex = fieldVisitStartIndex >= 0 ? fieldVisitStartIndex : 0;
+        for (var j = startIndex; j < row.Table.Columns.Count; j++)
+        {
+            if (!string.IsNullOrWhiteSpace(row[j].ToString()))
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static DataTable ReadDataTableFromExcel(Stream inputStream, string worksheetName)

--- a/Neptune.Tests/TrashScreenFieldVisitImporterTests.cs
+++ b/Neptune.Tests/TrashScreenFieldVisitImporterTests.cs
@@ -66,7 +66,12 @@ namespace Neptune.Tests
         // names and indices (e.g. for the all-or-nothing assessment block checks).
         private static readonly string[] Columns =
         {
-            "BMP Name", "Jurisdiction", "Field Visit Type", "Field Visit Date",
+            "BMP Name", "Jurisdiction",
+            // NPT-1114: reference columns the pre-populated download fills in. Kept between
+            // Jurisdiction and Field Visit Type to mirror the production "Field Visits" layout.
+            "Year Built", "BMP Notes",
+            "# of inlet screens", "# of trash baskets", "# of connector pipe screens",
+            "Field Visit Type", "Field Visit Date",
 
             // Initial assessment block (ends with "Notes")
             "Inlet Condition", "Inlet Condition Notes",
@@ -319,6 +324,64 @@ namespace Neptune.Tests
             var afterCount = await _dbContext.FieldVisits.CountAsync(x => x.TreatmentBMPID == bmp.TreatmentBMPID);
             Assert.AreEqual(beforeCount + 1, afterCount,
                 "Exactly one new FieldVisit should have been added for this BMP.");
+        }
+
+        [TestMethod]
+        public async Task PrePopulatedReferenceRows_AreSkipped_OnlyFilledRowProcessed()
+        {
+            // NPT-1114 rework: the pre-populated template lists one row per BMP. Rows the user didn't
+            // fill in (only the reference columns populated, no field-visit data) must be ignored, not
+            // treated as incomplete visits. A fake BMP name on the reference row proves it's skipped
+            // before the BMP lookup — otherwise we'd get "Invalid BMP Name or Jurisdiction".
+            var bmp = GetAnyTrashScreenBMP();
+            if (bmp == null)
+            {
+                Assert.Inconclusive("No Inlet-And-Trash-Screen BMPs in dev DB.");
+                return;
+            }
+            var jurisdictionName = bmp.StormwaterJurisdiction.Organization.OrganizationName;
+
+            var referenceOnlyRow = BlankRow();
+            Set(referenceOnlyRow, "BMP Name", "___NPT_1114_REFERENCE_ONLY___");
+            Set(referenceOnlyRow, "Jurisdiction", jurisdictionName);
+            Set(referenceOnlyRow, "Year Built", "2001");
+            Set(referenceOnlyRow, "# of inlet screens", "2");
+
+            var filledRow = BlankRow();
+            Set(filledRow, "BMP Name", bmp.TreatmentBMPName);
+            Set(filledRow, "Jurisdiction", jurisdictionName);
+            Set(filledRow, "Field Visit Type", FieldVisitType.All.First().FieldVisitTypeDisplayName);
+            Set(filledRow, "Field Visit Date", "01/02/2099");
+
+            using var xlsx = BuildXlsx(new[] { referenceOnlyRow, filledRow });
+            var result = await TrashScreenFieldVisitImporter.BulkUploadAsync(_dbContext, xlsx, GetAdminPerson());
+
+            Assert.AreEqual(0, result.Errors.Count, string.Join("; ", result.Errors));
+            Assert.AreEqual(1, result.RowsProcessed,
+                "Only the filled row should be imported; the reference-only row is skipped.");
+        }
+
+        [TestMethod]
+        public async Task NonAdmin_BlankRow_NotBlockedByPermissionCheck()
+        {
+            // NPT-1114 rework regression: a blank row (a cleared pre-populated row, or a trailing
+            // empty row in the template's used range) used to make the non-admin permission pre-check
+            // read an empty Jurisdiction and fail with "...in Jurisdiction , which you do not have
+            // permission to manage." Blank/reference-only rows must be skipped instead.
+            var editor = _dbContext.People.AsNoTracking()
+                .FirstOrDefault(x => x.RoleID == (int)RoleEnum.JurisdictionEditor || x.RoleID == (int)RoleEnum.JurisdictionManager);
+            if (editor == null)
+            {
+                Assert.Inconclusive("No JurisdictionEditor/Manager users in dev DB.");
+                return;
+            }
+
+            using var xlsx = BuildXlsx(new[] { BlankRow() });
+            var result = await TrashScreenFieldVisitImporter.BulkUploadAsync(_dbContext, xlsx, editor);
+
+            Assert.IsFalse(result.Errors.Any(x => x.Contains("do not have permission to manage")),
+                "A blank row must not trip the jurisdiction permission pre-check. Errors: " + string.Join("; ", result.Errors));
+            Assert.AreEqual(0, result.RowsProcessed);
         }
 
         // ----- NPT-1071 Bug #2: numeric range validation (pure helpers) -----


### PR DESCRIPTION
## NPT-1114 rework

PO feedback (KE 7/28/26): the download side passed (pre-populated rows, jurisdiction filtering, data accuracy), but **uploading** the pre-populated template failed for JurisdictionEditor/Manager with *"You attempted to upload a spreadsheet containing BMPs in Jurisdiction **,** which you do not have permission to manage."* (blank jurisdiction).

## Root cause
Not a column/field mismatch — the deployed template and generator both key jurisdiction on `Organization.OrganizationName`, and the columns align. The defect is that `TrashScreenFieldVisitImporter` treats **every non-blank row as a field visit to import**, which collides with NPT-1114's new *one-row-per-BMP* pre-population:
- The jurisdiction permission pre-check didn't skip blank rows → a blank/cleared row (or a trailing empty row in the template's used range) read an empty `Jurisdiction` → the blank-jurisdiction error.
- The processing loop only skipped *fully* blank rows → a reference-only pre-populated row (BMP Name + Jurisdiction filled, no visit data) fell through and errored as *"Invalid Field Visit Type"*, so a filled-in template couldn't be uploaded.

## Changes
- **`TrashScreenFieldVisitImporter`** — add `RowHasNoFieldVisitData(row)` (true when every column from `"Field Visit Type"` onward is blank; falls back to fully-blank if that header is absent). Skip such rows in **both** the permission pre-check and the processing loop, and trim the row jurisdiction before comparison. Net: reference-only rows are ignored, only rows with actual visit data are validated/imported, and the false permission error is gone.
- **`DataHubController` (generator hardening)** — resolve each target column by **header text** (`BuildHeaderColumnMap`) instead of hard-coded `A–G`, so the generator stays aligned with the header-name-based importer even if the template's column order changes; guard that the BMP Name + Jurisdiction headers exist (500 otherwise), degrade gracefully for optional columns.
- **Tests** — align the fixture column layout with the production template (Year Built / BMP Notes / three screen-count columns before Field Visit Type); add `PrePopulatedReferenceRows_AreSkipped_OnlyFilledRowProcessed` and `NonAdmin_BlankRow_NotBlockedByPermissionCheck`.

## Verification
- `Neptune.API` + `Neptune.Tests` build clean.
- Both new regression tests pass against the dev DB; existing importer tests unaffected.
- Manual round-trip verified in the app: download → fill one row → upload processes the filled row with no blank-jurisdiction error and no Invalid-Field-Visit-Type flood.

## Notes
- No codegen / DTO / API-surface changes.
- The template itself is a blob-only artifact (not tracked in the repo since WebMvc was retired in NPT-1068); no repo→blob drift, so no template file change is needed here.