### PR TITLE
NPT-1092: Speed up parcel/WQMP reference layers in the WQMP boundary editors (PO rework)

### DIFF
--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -585,7 +585,7 @@ namespace Neptune.API.Controllers
                     ? new BoundingBoxDto(boundary.Geometry4326)
                     : StormwaterJurisdictions.GetBoundingBoxDtoByJurisdictionID(
                         DbContext,
-                        WaterQualityManagementPlans.GetByID(DbContext, waterQualityManagementPlanID).StormwaterJurisdictionID)
+                        WaterQualityManagementPlans.GetStormwaterJurisdictionID(DbContext, waterQualityManagementPlanID))
             };
             return Ok(response);
         }

--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -574,10 +574,18 @@ namespace Neptune.API.Controllers
             var boundary = WaterQualityManagementPlanBoundaries.GetByWaterQualityManagementPlanID(DbContext, waterQualityManagementPlanID);
             var response = new WaterQualityManagementPlanBoundaryResponseDto
             {
-                BoundaryAsFeatureCollection = WaterQualityManagementPlanBoundaries.GetBoundaryAsFeatureCollection(DbContext, waterQualityManagementPlanID),
+                BoundaryAsFeatureCollection = WaterQualityManagementPlanBoundaries.GetBoundaryAsFeatureCollection(boundary),
                 Parcels = WaterQualityManagementPlanParcels.ListAsParcelDisplayDtos(DbContext, waterQualityManagementPlanID),
-                CalculatedWQMPAcreage = WaterQualityManagementPlanBoundaries.CalculateAcreage(DbContext, waterQualityManagementPlanID),
-                BoundingBox = boundary?.Geometry4326 != null ? new BoundingBoxDto(boundary.Geometry4326) : new BoundingBoxDto()
+                CalculatedWQMPAcreage = WaterQualityManagementPlanBoundaries.CalculateAcreage(boundary),
+                // NPT-1092: when the WQMP has no boundary yet (the normal Pick Parcels case), fall back
+                // to the WQMP's jurisdiction extent rather than the whole-county BoundingBoxDto default,
+                // so the map opens zoomed to the jurisdiction and the parcel WMS isn't forced to
+                // rasterize every OC parcel at county scale (>1 min / timeout).
+                BoundingBox = boundary?.Geometry4326 != null
+                    ? new BoundingBoxDto(boundary.Geometry4326)
+                    : StormwaterJurisdictions.GetBoundingBoxDtoByJurisdictionID(
+                        DbContext,
+                        WaterQualityManagementPlans.GetByID(DbContext, waterQualityManagementPlanID).StormwaterJurisdictionID)
             };
             return Ok(response);
         }

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlanBoundaries.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlanBoundaries.cs
@@ -29,7 +29,12 @@ public static class WaterQualityManagementPlanBoundaries
 
     public static FeatureCollection GetBoundaryAsFeatureCollection(NeptuneDbContext dbContext, int waterQualityManagementPlanID)
     {
-        var boundary = GetByWaterQualityManagementPlanID(dbContext, waterQualityManagementPlanID);
+        return GetBoundaryAsFeatureCollection(GetByWaterQualityManagementPlanID(dbContext, waterQualityManagementPlanID));
+    }
+
+    // NPT-1092: overload that reuses an already-loaded boundary so GetBoundary doesn't re-query it.
+    public static FeatureCollection GetBoundaryAsFeatureCollection(WaterQualityManagementPlanBoundary? boundary)
+    {
         if (boundary?.Geometry4326 != null)
         {
             return boundary.Geometry4326.MultiPolygonToFeatureCollection();
@@ -76,7 +81,12 @@ public static class WaterQualityManagementPlanBoundaries
 
     public static double? CalculateAcreage(NeptuneDbContext dbContext, int waterQualityManagementPlanID)
     {
-        var boundary = GetByWaterQualityManagementPlanID(dbContext, waterQualityManagementPlanID);
+        return CalculateAcreage(GetByWaterQualityManagementPlanID(dbContext, waterQualityManagementPlanID));
+    }
+
+    // NPT-1092: overload that reuses an already-loaded boundary so GetBoundary doesn't re-query it.
+    public static double? CalculateAcreage(WaterQualityManagementPlanBoundary? boundary)
+    {
         if (boundary?.GeometryNative != null)
         {
             return Math.Round(boundary.GeometryNative.Area * Constants.SquareMetersToAcres, 1);

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlans.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlans.cs
@@ -56,6 +56,17 @@ public static partial class WaterQualityManagementPlans
     }
 
 
+    // NPT-1092: the boundary endpoint's no-boundary bbox fallback only needs the row's jurisdiction
+    // id. Project just that column instead of GetByID's heavy include graph (parcels, BMPs +
+    // delineations, jurisdiction geometry, ...), which would undercut this endpoint's perf goal.
+    public static int GetStormwaterJurisdictionID(NeptuneDbContext dbContext, int waterQualityManagementPlanID)
+    {
+        return dbContext.WaterQualityManagementPlans
+            .Where(x => x.WaterQualityManagementPlanID == waterQualityManagementPlanID)
+            .Select(x => x.StormwaterJurisdictionID)
+            .Single();
+    }
+
     public static async Task<List<WaterQualityManagementPlanDto>> ListAsDtoAsync(NeptuneDbContext dbContext)
     {
         var dtos = await dbContext.WaterQualityManagementPlans

--- a/Neptune.Web/src/app/shared/components/leaflet/layers/parcel-layer/parcel-layer.component.ts
+++ b/Neptune.Web/src/app/shared/components/leaflet/layers/parcel-layer/parcel-layer.component.ts
@@ -25,6 +25,10 @@ export class ParcelLayerComponent extends MapLayerBase implements OnChanges, Aft
             format: "image/png",
             tiled: true,
             styles: this.styles,
+            // NPT-1092: guardrail against GeoServer rasterizing every OC parcel at county-wide scale
+            // (the >1 min / never-loads symptom). Below this zoom the parcel tiles aren't requested;
+            // jurisdiction-and-tighter views (the normal editing zoom) still render.
+            minZoom: 11,
             maxZoom: 22,
         } as any;
 


### PR DESCRIPTION
## NPT-1092 rework

PO feedback (KE 7/28/26): all the BMP-reference-layer ACs passed, but the **parcel and WQMP reference layers took >1 min or never loaded** in the Pick Parcels and Refine Boundary editors (worst in Pick Parcels).

## Root cause
A WQMP with **no boundary yet** (the normal Pick Parcels case) made `GET /{id}/boundary` return the parameterless `new BoundingBoxDto()` — the **whole Orange County** extent. Combined with the parcel WMS layer being on-by-default with no scale floor, the map opened at county scale and GeoServer had to rasterize **every OC parcel (~1M polygons)** per tile → >1 min / timeout.

## Changes
- **`WaterQualityManagementPlanController.GetBoundary`** — when the WQMP has no boundary, fall back to the WQMP's **jurisdiction** bounding box (`StormwaterJurisdictions.GetBoundingBoxDtoByJurisdictionID`) instead of the whole-county default, so the map opens zoomed to the jurisdiction (the delineation-map pattern). Also query the boundary **once** and reuse it via new boundary-accepting overloads of `GetBoundaryAsFeatureCollection` / `CalculateAcreage` (was querying it 3×), trimming the call the map is gated behind.
- **`parcel-layer.component.ts`** — add a `minZoom: 11` guardrail so the parcel WMS is never requested at county-wide scale even if the user zooms out.

## Decisions (per PO)
- Default view for boundary-less WQMPs = **jurisdiction extent**.
- WQMP reference layer left **off-by-default** (no change); the new BMP reference layer is untouched (passed).
- Parcel layer stays **visible** in the editors (Pick Parcels needs it) — the fix makes it fast, not hidden.

## Verification
- `Neptune.API` and `Neptune.Web` build clean.
- No response-contract change → **no codegen**.
- Loads fast locally, but local GeoServer has limited parcel data — **perf to be confirmed in QA** against realistic parcel volume. Also confirm in QA that `minZoom: 11` still shows parcels at the default jurisdiction view (lower the floor if a large jurisdiction fits below z11).

## Testing note
No controller-test harness exists in `Neptune.Tests` (suite is repo/helper-level), and the fallback only composes two already-tested helpers, so no unit test was added for the one-line bbox fallback — it's an integration/visual perf change validated in QA.