### PR TITLE
NPT-1099: Fix OVTA Areas reference layer not rendering (invalid geometry) (PO rework)

### DIFF
--- a/Neptune.Database/dbo/Views/dbo.vGeoServerOnlandVisualTrashAssessmentArea.sql
+++ b/Neptune.Database/dbo/Views/dbo.vGeoServerOnlandVisualTrashAssessmentArea.sql
@@ -19,7 +19,15 @@ create view dbo.vGeoServerOnlandVisualTrashAssessmentArea as
 		where CompletedDate is not null
 	) ovta on area.OnlandVisualTrashAssessmentAreaID = ovta.OnlandVisualTrashAssessmentAreaID
 	left join dbo.OnlandVisualTrashAssessmentScore score on ovta.OnlandVisualTrashAssessmentScoreID = score.OnlandVisualTrashAssessmentScoreID
-	where 
-		RankByCompletedDate between 1 and 5
-		or RankByCompletedDate is null -- have to account for this being null so we get the results of the left outer join
+	where
+		(
+			RankByCompletedDate between 1 and 5
+			or RankByCompletedDate is null -- have to account for this being null so we get the results of the left outer join
+		)
+		-- NPT-1099: exclude SQL-invalid geometry rows so GeoServer's WMS/WFS render never hits SQL error
+		-- 24144 (a single invalid row blanks the whole layer). STIsValid() tests validity without throwing.
+		-- Invalid rows are repaired at the source (save-path MakeValid, plus a one-time manual cleanup of
+		-- existing rows) and reappear here once valid. Deliberately NOT MakeValid-ing on read (unlike
+		-- vGeoServerDelineation).
+		and area.OnlandVisualTrashAssessmentAreaGeometry4326.STIsValid() = 1
 go

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentArea.GdbExport.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentArea.GdbExport.cs
@@ -82,8 +82,11 @@ public static class OnlandVisualTrashAssessmentAreaGdbExport
             if (existingAreas.TryGetValue(staging.AreaName, out var existing))
             {
                 existing.AssessmentAreaDescription = staging.Description;
-                existing.OnlandVisualTrashAssessmentAreaGeometry = staging.Geometry.ProjectTo2771();
-                existing.OnlandVisualTrashAssessmentAreaGeometry4326 = staging.Geometry.ProjectTo4326();
+                // NPT-1099: MakeValid before storing — the GDB validator checks NTS IsValid, but that
+                // disagrees with SQL STIsValid in edge cases and reprojection can re-introduce invalidity,
+                // which would blank the OVTA GeoServer layer (SQL 24144).
+                existing.OnlandVisualTrashAssessmentAreaGeometry = staging.Geometry.ProjectTo2771().MakeValid();
+                existing.OnlandVisualTrashAssessmentAreaGeometry4326 = staging.Geometry.ProjectTo4326().MakeValid();
             }
             else
             {
@@ -92,8 +95,8 @@ public static class OnlandVisualTrashAssessmentAreaGdbExport
                     OnlandVisualTrashAssessmentAreaName = staging.AreaName,
                     AssessmentAreaDescription = staging.Description,
                     StormwaterJurisdictionID = staging.StormwaterJurisdictionID,
-                    OnlandVisualTrashAssessmentAreaGeometry = staging.Geometry,
-                    OnlandVisualTrashAssessmentAreaGeometry4326 = staging.Geometry.ProjectTo4326(),
+                    OnlandVisualTrashAssessmentAreaGeometry = staging.Geometry.MakeValid(),
+                    OnlandVisualTrashAssessmentAreaGeometry4326 = staging.Geometry.ProjectTo4326().MakeValid(),
                 });
             }
         }

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentAreas.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentAreas.cs
@@ -72,23 +72,30 @@ public static class OnlandVisualTrashAssessmentAreas
             // or wiping the non-nullable area geometry — an empty save is a no-op.
             if (geometry != null)
             {
-                onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = geometry;
-                onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = geometry.ProjectTo4326();
+                // NPT-1099: MakeValid before storing so GeoServer's WMS/WFS render (and the .NET GeoJSON
+                // path) never hit SQL-invalid geometry that throws SQL error 24144 and blanks the layer.
+                // Reprojection can re-introduce invalidity, so repair each stored SRID. Mirrors
+                // WaterQualityManagementPlanBoundaries.UpdateBoundary.
+                onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = geometry.MakeValid();
+                onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = geometry.ProjectTo4326().MakeValid();
             }
         }
         else if (onlandVisualTrashAssessmentAreaGeometryDto.OvtaAreaSourceTypeID == (int)OvtaAreaSourceTypeEnum.Parcel)
         {
-            // parcels are already in the correct system (State Plane); no reprojection needed
-            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = ParcelGeometries.UnionAggregateByParcelIDs(dbContext, onlandVisualTrashAssessmentAreaGeometryDto.ParcelIDs);
-            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = ParcelGeometries.UnionAggregate4326ByParcelIDs(dbContext, onlandVisualTrashAssessmentAreaGeometryDto.ParcelIDs);
+            // parcels are already in the correct system (State Plane); no reprojection needed.
+            // NPT-1099: MakeValid the union result before storing (see LandUseBlock branch).
+            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = ParcelGeometries.UnionAggregateByParcelIDs(dbContext, onlandVisualTrashAssessmentAreaGeometryDto.ParcelIDs).MakeValid();
+            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = ParcelGeometries.UnionAggregate4326ByParcelIDs(dbContext, onlandVisualTrashAssessmentAreaGeometryDto.ParcelIDs).MakeValid();
         }
         else
         {
             // manually drawn (Geoman) — comes from the browser, so transform to State Plane
             var newGeometry4326 = GeoJsonSerializer.Deserialize<IFeature>(onlandVisualTrashAssessmentAreaGeometryDto.GeometryAsGeoJson);
             newGeometry4326.Geometry.SRID = Proj4NetHelper.WEB_MERCATOR;
-            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = newGeometry4326.Geometry;
-            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = newGeometry4326.Geometry.ProjectTo2771();
+            // NPT-1099: repair self-intersecting freehand (Geoman) draws before storing (see LandUseBlock branch).
+            var validGeometry4326 = newGeometry4326.Geometry.MakeValid();
+            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = validGeometry4326;
+            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = validGeometry4326.ProjectTo2771().MakeValid();
         }
     }
 

--- a/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentAreas.cs
+++ b/Neptune.EFModels/Entities/OnlandVisualTrashAssessmentAreas.cs
@@ -83,9 +83,16 @@ public static class OnlandVisualTrashAssessmentAreas
         else if (onlandVisualTrashAssessmentAreaGeometryDto.OvtaAreaSourceTypeID == (int)OvtaAreaSourceTypeEnum.Parcel)
         {
             // parcels are already in the correct system (State Plane); no reprojection needed.
-            // NPT-1099: MakeValid the union result before storing (see LandUseBlock branch).
-            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = ParcelGeometries.UnionAggregateByParcelIDs(dbContext, onlandVisualTrashAssessmentAreaGeometryDto.ParcelIDs).MakeValid();
-            onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = ParcelGeometries.UnionAggregate4326ByParcelIDs(dbContext, onlandVisualTrashAssessmentAreaGeometryDto.ParcelIDs).MakeValid();
+            var parcelGeometry = ParcelGeometries.UnionAggregateByParcelIDs(dbContext, onlandVisualTrashAssessmentAreaGeometryDto.ParcelIDs);
+            var parcelGeometry4326 = ParcelGeometries.UnionAggregate4326ByParcelIDs(dbContext, onlandVisualTrashAssessmentAreaGeometryDto.ParcelIDs);
+            // UnionAggregate*ByParcelIDs return null for an empty selection (UnionListGeometries). Guard
+            // as a no-op like the LandUseBlock branch — avoids an NRE on .MakeValid() and avoids nulling
+            // the non-nullable native geometry column. NPT-1099: MakeValid before storing.
+            if (parcelGeometry != null && parcelGeometry4326 != null)
+            {
+                onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry = parcelGeometry.MakeValid();
+                onlandVisualTrashAssessmentArea.OnlandVisualTrashAssessmentAreaGeometry4326 = parcelGeometry4326.MakeValid();
+            }
         }
         else
         {


### PR DESCRIPTION
## NPT-1099 rework

PO feedback (KE 7/28/26): the OVTA Areas WMS reference layer appeared in the layer control + legend but **rendered no tiles in any of the 3 editor modes** (Draw / Land Use Blocks / Parcels).

## Root cause
Not the frontend/cql wiring (that's correct). The WMS `GetMap` returns a GeoServer `ServiceException`:
```
Rendering process failed. Layers: OnlandVisualTrashAssessmentAreas
SQLServerException ... "geometry": 24144: ... the instance is not valid. Use MakeValid ...
```
One or more `OnlandVisualTrashAssessmentArea` geometries are **SQL-invalid** (self-intersecting freehand draws), so SQL Server throws when GeoServer's render query touches them → the whole tile fails → blank layer. Same class of bug already fixed for **Delineations** (NPT-1115 / NPT-1030). OVTA geometries were stored **raw, never `MakeValid`-ed**, and the GeoServer-backing view had no validity guard.

## Changes (3 files)
- **`vGeoServerOnlandVisualTrashAssessmentArea`** — exclude SQL-invalid rows via `… and …Geometry4326.STIsValid() = 1` (the existing `OR` wrapped in parens to keep precedence). A single invalid row can no longer blank the whole WMS/WFS layer. Per PO direction, the view **excludes** invalid rows rather than `MakeValid`-ing them on read (unlike `vGeoServerDelineation`).
- **`OnlandVisualTrashAssessmentAreas.UpdateGeometry`** — `MakeValid` each stored SRID before persisting (Draw / Land Use Block / Parcel branches), mirroring `WaterQualityManagementPlanBoundaries.UpdateBoundary`, so new invalid rows can't enter.
- **`OnlandVisualTrashAssessmentArea.GdbExport` bulk importer** — `MakeValid` on both the update and insert paths (the GDB validator checks NTS `IsValid`, which disagrees with SQL `STIsValid` in edge cases, and reprojection can re-introduce invalidity).

## Existing data / recurrence
- Existing invalid rows are repaired by a **one-time manual `MakeValid`** on QA/prod (no release script needed for a single bad row):
  ```sql
  update dbo.OnlandVisualTrashAssessmentArea set OnlandVisualTrashAssessmentAreaGeometry     = OnlandVisualTrashAssessmentAreaGeometry.MakeValid()     where OnlandVisualTrashAssessmentAreaGeometry.STIsValid()     = 0;
  update dbo.OnlandVisualTrashAssessmentArea set OnlandVisualTrashAssessmentAreaGeometry4326 = OnlandVisualTrashAssessmentAreaGeometry4326.MakeValid() where OnlandVisualTrashAssessmentAreaGeometry4326.STIsValid() = 0;
  ```
- The save-path `MakeValid` prevents recurrence, so **no nightly repair job** was added (unlike delineation).

## Verification
- `Neptune.EFModels` builds clean. The `.sqlproj` (view change) builds under SSDT/VS, not the `dotnet` CLI — validate the DACPAC in VS.
- Confirm in **QA** (where the invalid geometry exists): run the manual cleanup above, then the OVTA reference layer renders in all 3 modes. No API contract change → no codegen.