### PR TITLE
NPT-1110: Show 400 MB limit on the BMP Documents upload dialog (PO rework)

### DIFF
--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPDocumentByTreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPDocumentByTreatmentBMPController.cs
@@ -21,6 +21,12 @@ public class TreatmentBMPDocumentByTreatmentBMPController(NeptuneDbContext dbCon
 {
     [HttpPost]
     [JurisdictionEditFeature]
+    // NPT-1110: unify the upload cap at 400 MB. The global Kestrel/FormOptions cap (Startup.cs) already
+    // covers this endpoint, but set the per-action attributes for parity with WQMP CreateDocument and
+    // every other upload endpoint.
+    [Consumes("multipart/form-data")]
+    [RequestSizeLimit(400 * 1024 * 1024)]
+    [RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]
     [EntityNotFound(typeof(TreatmentBMP), "treatmentBMPID")]
     public async Task<ActionResult<TreatmentBMPDocumentDto>> Create([FromRoute] int treatmentBMPID, [FromForm] TreatmentBMPDocumentCreateDto documentCreateDto)
     {

--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPDocumentByTreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPDocumentByTreatmentBMPController.cs
@@ -30,8 +30,15 @@ public class TreatmentBMPDocumentByTreatmentBMPController(NeptuneDbContext dbCon
     [EntityNotFound(typeof(TreatmentBMP), "treatmentBMPID")]
     public async Task<ActionResult<TreatmentBMPDocumentDto>> Create([FromRoute] int treatmentBMPID, [FromForm] TreatmentBMPDocumentCreateDto documentCreateDto)
     {
+        // ModelState must be valid before we call ValidateFileUpload — that helper dereferences
+        // documentCreateDto.File.FileName and would throw if binding failed and File is null (File is
+        // [Required], so an absent file surfaces here as a clean 400). Mirrors WQMP CreateDocument.
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
         var errors = FileResources.ValidateFileUpload(documentCreateDto.File);
-        if (!ModelState.IsValid || errors.Any())
+        if (errors.Any())
         {
             errors.ForEach(x => ModelState.AddModelError(x.Type, x.Message));
             return BadRequest(ModelState);

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.html
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.html
@@ -32,7 +32,7 @@
                 @if (fileError) {
                     <div class="text-danger mb-1">{{ fileError }}</div>
                 }
-                <em>Maximum total file size should not exceed 400MB. Accepted extensions: PDF, PNG, JPG, DOCX, DOC, XLSX, CSV, TXT</em>
+                <em>Maximum total file size should not exceed 400MB. Accepted extensions: PDF, PNG, JPG, JPEG, DOCX, DOC, XLSX, CSV, TXT</em>
                 <i class="fas fa-file-open"></i>
             </div>
             <div class="field g-col-12">

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.html
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.html
@@ -32,7 +32,7 @@
                 @if (fileError) {
                     <div class="text-danger mb-1">{{ fileError }}</div>
                 }
-                <em>Accepted extensions: PDF, PNG, JPG, DOCX, DOC, XLSX, CSV, TXT</em>
+                <em>Maximum total file size should not exceed 400MB. Accepted extensions: PDF, PNG, JPG, DOCX, DOC, XLSX, CSV, TXT</em>
                 <i class="fas fa-file-open"></i>
             </div>
             <div class="field g-col-12">

--- a/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.ts
+++ b/Neptune.Web/src/app/shared/components/file-resource-list/file-upload-modal/file-upload-modal.component.ts
@@ -55,7 +55,7 @@ export class FileUploadModalComponent {
                 this.fileName = null;
                 this.fileExtension = null;
                 event.target.value = "";
-                this.fileError = `${extension ? extension.slice(1).toUpperCase() : "This file type"} is not an accepted file type. Accepted extensions: PDF, PNG, JPG, DOCX, DOC, XLSX, CSV, TXT.`;
+                this.fileError = `${extension ? extension.slice(1).toUpperCase() : "This file type"} is not an accepted file type. Accepted extensions: PDF, PNG, JPG, JPEG, DOCX, DOC, XLSX, CSV, TXT.`;
                 this.fileChanged.emit(null);
                 return;
             }


### PR DESCRIPTION
## NPT-1110 rework

PO feedback (KE 7/28/26): under "every upload dialog that shows a size limit reads 400 MB", the **BMP Documents** dialog was missed (WQMP Documents and WQMP AI upload passed).

## Root cause
BMP documents use the generic shared `FileUploadModalComponent`, which showed **no size note at all** (only accepted extensions). The WQMP flow uses a dedicated `wqmp-document-modal` that renders the 400 MB note via `form-field`. Backend was already functionally 400 MB (global Kestrel/FormOptions cap in `Startup.cs` + the shared `FileResources.ValidateFileUpload` validator at 400 MB); the BMP endpoint just lacked the per-action attributes WQMP has.

## Changes (2 files)
- **`file-upload-modal.component.html`** — add *"Maximum total file size should not exceed 400MB. Accepted extensions: …"*, mirroring the shared `form-field` wording. This modal's only consumers are the Treatment BMP detail page (BMP documents), all 400 MB-capped, so the note is correct everywhere it shows. No 100-page AI note (BMP documents aren't AI-processed — that note is WQMP-specific).
- **`TreatmentBMPDocumentByTreatmentBMPController.Create`** — add `[Consumes("multipart/form-data")]`, `[RequestSizeLimit(400 * 1024 * 1024)]`, `[RequestFormLimits(MultipartBodyLengthLimit = 400 * 1024 * 1024)]` for parity with WQMP `CreateDocument` and every other upload endpoint (requirement #3). Not strictly functional — the global cap already covers it; validator unchanged (shared, already 400 MB).

## Verification
- `Neptune.API` + `Neptune.Web` build clean.
- No DTO/route/signature change → **no codegen**. No size-limit tests exist (only an unrelated WQMP-doc authorization test), so nothing to update.
- Browser: the BMP Documents add-document dialog now displays the 400 MB note.