### PR TITLE
NPT-943: Rework WQMP GDB export contents per QA review

### DIFF
--- a/Neptune.Database/Neptune.Database.sqlproj
+++ b/Neptune.Database/Neptune.Database.sqlproj
@@ -445,6 +445,7 @@
     <None Include="Scripts\ReleaseScripts\037 - NPT-1068 Rewrite legacy FileResource URLs in NeptunePage content.sql" />
     <None Include="Scripts\ReleaseScripts\038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs.sql" />
     <None Include="Scripts\ReleaseScripts\039 - MakeValid on invalid Delineation geometries (recurrence).sql" />
+    <None Include="Scripts\ReleaseScripts\040 - NPT-943 Normalize WQMP MaintenanceContactState.sql" />
     <Build Include="dbo\Tables\dbo.WaterQualityManagementPlanExtractionResult.sql" />
     <Build Include="dbo\Tables\dbo.AITokenUsage.sql" />
   </ItemGroup>

--- a/Neptune.Database/Scripts/ReleaseScripts/040 - NPT-943 Normalize WQMP MaintenanceContactState.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/040 - NPT-943 Normalize WQMP MaintenanceContactState.sql
@@ -12,6 +12,13 @@ SET MaintenanceContactState = LTRIM(RTRIM(MaintenanceContactState))
 WHERE MaintenanceContactState IS NOT NULL
   AND MaintenanceContactState <> LTRIM(RTRIM(MaintenanceContactState));
 
+-- 1b) Uppercase existing 2-letter codes to canonical USPS casing (e.g. 'ca' -> 'CA').
+UPDATE dbo.WaterQualityManagementPlan
+SET MaintenanceContactState = UPPER(MaintenanceContactState)
+WHERE MaintenanceContactState IS NOT NULL
+  AND LEN(MaintenanceContactState) = 2
+  AND MaintenanceContactState <> UPPER(MaintenanceContactState);
+
 -- 2) Map any full state / territory name to its 2-letter code (default CI collation = case-insensitive).
 ;WITH StateMap(FullName, Abbr) AS (
     SELECT * FROM (VALUES

--- a/Neptune.Database/Scripts/ReleaseScripts/040 - NPT-943 Normalize WQMP MaintenanceContactState.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/040 - NPT-943 Normalize WQMP MaintenanceContactState.sql
@@ -1,0 +1,35 @@
+-- NPT-943: normalize legacy WaterQualityManagementPlan.MaintenanceContactState values to the
+-- canonical 2-letter USPS codes the editor dropdown (US_STATES) now enforces. QA review found mixed
+-- values ('California', 'Colorado', 'CA ' with trailing whitespace, …) entered before the dropdown /
+-- via the XLSX importer, which are exposed for the first time by the WQMP GDB export's discrete State
+-- field. Idempotent: already-clean 2-letter codes are untouched; re-running is a no-op. Zip formats
+-- (5-digit vs ZIP+4) are intentionally left alone (flagged only).
+SET NOCOUNT ON;
+
+-- 1) Trim surrounding whitespace (e.g. 'CA ').
+UPDATE dbo.WaterQualityManagementPlan
+SET MaintenanceContactState = LTRIM(RTRIM(MaintenanceContactState))
+WHERE MaintenanceContactState IS NOT NULL
+  AND MaintenanceContactState <> LTRIM(RTRIM(MaintenanceContactState));
+
+-- 2) Map any full state / territory name to its 2-letter code (default CI collation = case-insensitive).
+;WITH StateMap(FullName, Abbr) AS (
+    SELECT * FROM (VALUES
+        ('Alabama','AL'),('Alaska','AK'),('Arizona','AZ'),('Arkansas','AR'),('California','CA'),
+        ('Colorado','CO'),('Connecticut','CT'),('Delaware','DE'),('District of Columbia','DC'),
+        ('Florida','FL'),('Georgia','GA'),('Hawaii','HI'),('Idaho','ID'),('Illinois','IL'),
+        ('Indiana','IN'),('Iowa','IA'),('Kansas','KS'),('Kentucky','KY'),('Louisiana','LA'),
+        ('Maine','ME'),('Maryland','MD'),('Massachusetts','MA'),('Michigan','MI'),('Minnesota','MN'),
+        ('Mississippi','MS'),('Missouri','MO'),('Montana','MT'),('Nebraska','NE'),('Nevada','NV'),
+        ('New Hampshire','NH'),('New Jersey','NJ'),('New Mexico','NM'),('New York','NY'),
+        ('North Carolina','NC'),('North Dakota','ND'),('Ohio','OH'),('Oklahoma','OK'),('Oregon','OR'),
+        ('Pennsylvania','PA'),('Puerto Rico','PR'),('Rhode Island','RI'),('South Carolina','SC'),
+        ('South Dakota','SD'),('Tennessee','TN'),('Texas','TX'),('Utah','UT'),('Vermont','VT'),
+        ('Virginia','VA'),('Washington','WA'),('West Virginia','WV'),('Wisconsin','WI'),('Wyoming','WY')
+    ) AS s(FullName, Abbr)
+)
+UPDATE w
+SET w.MaintenanceContactState = m.Abbr
+FROM dbo.WaterQualityManagementPlan w
+JOIN StateMap m ON w.MaintenanceContactState = m.FullName
+WHERE w.MaintenanceContactState <> m.Abbr;

--- a/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -86,4 +86,6 @@ GO
 GO
 :r ".\039 - MakeValid on invalid Delineation geometries (recurrence).sql"
 GO
+:r ".\040 - NPT-943 Normalize WQMP MaintenanceContactState.sql"
+GO
 

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlan.GdbExport.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlan.GdbExport.cs
@@ -2,10 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Globalization;
 using Microsoft.EntityFrameworkCore;
+using Neptune.Common;
 using Neptune.Common.GeoSpatial;
 using Neptune.Common.Services.GDAL;
 using NetTopologySuite.Features;
+using NetTopologySuite.Geometries.Utilities;
 
 namespace Neptune.EFModels.Entities;
 
@@ -22,11 +25,13 @@ public static class WaterQualityManagementPlanGdbExport
         var jurisdictionIDs = viewableJurisdictionIDs.ToList();
         var idFilter = ids.ToList();
         // Most lookups (Priority/Status/LandUse/…) are in-memory computed getters off AllLookupDictionary
-        // — resolved from the FK with no Include. Only WaterQualityManagementPlanBoundary and
-        // HydrologicSubarea are real EF navigations, so those are the only Includes.
+        // — resolved from the FK with no Include. WaterQualityManagementPlanBoundary and HydrologicSubarea
+        // are real EF navigations; StormwaterJurisdiction → Organization is Included for the Jurisdiction
+        // attribute (NPT-943 rework).
         return dbContext.WaterQualityManagementPlans.AsNoTracking()
             .Include(x => x.WaterQualityManagementPlanBoundary)
             .Include(x => x.HydrologicSubarea)
+            .Include(x => x.StormwaterJurisdiction).ThenInclude(sj => sj.Organization)
             .Where(x => x.WaterQualityManagementPlanBoundary != null
                         && x.WaterQualityManagementPlanBoundary.GeometryNative != null
                         && jurisdictionIDs.Contains(x.StormwaterJurisdictionID)
@@ -39,7 +44,15 @@ public static class WaterQualityManagementPlanGdbExport
         var featureCollection = new FeatureCollection();
         foreach (var wqmp in waterQualityManagementPlans)
         {
-            featureCollection.Add(new Feature(wqmp.WaterQualityManagementPlanBoundary.GeometryNative, BuildAttributes(wqmp)));
+            // NPT-943: repair SQL-invalid boundaries (self-intersecting parcel-union bowties) before export
+            // so ArcGIS Check Geometry / geoprocessing tools don't error on them. Fixed NTS-side because the
+            // geometry is materialized as NTS here (NTS IsValid != SQL STIsValid); the repair preserves area.
+            var geometry = wqmp.WaterQualityManagementPlanBoundary.GeometryNative;
+            if (!geometry.IsValid)
+            {
+                geometry = GeometryFixer.Fix(geometry);
+            }
+            featureCollection.Add(new Feature(geometry, BuildAttributes(wqmp)));
         }
         return featureCollection;
     }
@@ -50,6 +63,8 @@ public static class WaterQualityManagementPlanGdbExport
         return new AttributesTable
         {
             { "Name", wqmp.WaterQualityManagementPlanName },
+            // NPT-943 rework: jurisdiction key so the unfiltered Data Hub export can distinguish permittees.
+            { "Jurisdiction", wqmp.StormwaterJurisdiction?.Organization?.OrganizationName },
             { "Land_Use", wqmp.WaterQualityManagementPlanLandUse?.WaterQualityManagementPlanLandUseDisplayName },
             { "Priority", wqmp.WaterQualityManagementPlanPriority?.WaterQualityManagementPlanPriorityDisplayName },
             { "Status", wqmp.WaterQualityManagementPlanStatus?.WaterQualityManagementPlanStatusDisplayName },
@@ -59,9 +74,17 @@ public static class WaterQualityManagementPlanGdbExport
             { "Hydromodification_Controls_Applies", wqmp.HydromodificationAppliesType?.HydromodificationAppliesTypeDisplayName },
             { "Hydrologic_Subarea", wqmp.HydrologicSubarea?.HydrologicSubareaName },
             { "Modeling_Approach", wqmp.WaterQualityManagementPlanModelingApproach?.WaterQualityManagementPlanModelingApproachDisplayName },
-            { "Approval_Date", wqmp.ApprovalDate },
-            { "Date_of_Construction", wqmp.DateOfConstruction },
+            // NPT-943 rework: emit date-only strings (no ToUniversalTime) so OGR types these as timezone-naive
+            // Date fields. The stored datetime values are date-only (midnight local); the global
+            // DateTimeConverter would otherwise shift them to a UTC timestamp (…08:00:00+00:00).
+            { "Approval_Date", wqmp.ApprovalDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) },
+            { "Date_of_Construction", wqmp.DateOfConstruction?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) },
             { "Recorded_WQMP_Area_Acres", wqmp.RecordedWQMPAreaInAcres },
+            // NPT-943 rework: area of the exported polygon (the recorded acreage above does not describe the
+            // delivered geometry). Same formula as WaterQualityManagementPlan.DtoProjections "CalculatedWQMPAcreage".
+            { "Calculated_Boundary_Acreage", wqmp.WaterQualityManagementPlanBoundary?.GeometryNative != null
+                ? (double?)Math.Round(wqmp.WaterQualityManagementPlanBoundary.GeometryNative.Area * Constants.SquareMetersToAcres, 1)
+                : null },
             { "Trash_Capture_Effectiveness", wqmp.TrashCaptureEffectiveness },
             { "Maintenance_Contact_Name", wqmp.MaintenanceContactName },
             { "Maintenance_Contact_Organization", wqmp.MaintenanceContactOrganization },
@@ -79,9 +102,10 @@ public static class WaterQualityManagementPlanGdbExport
         var attrs = new AttributesTable();
         foreach (var key in new[]
                  {
-                     "Name", "Land_Use", "Priority", "Status", "Development_Type", "Trash_Capture_Status",
+                     "Name", "Jurisdiction", "Land_Use", "Priority", "Status", "Development_Type", "Trash_Capture_Status",
                      "Permit_Term", "Hydromodification_Controls_Applies", "Hydrologic_Subarea", "Modeling_Approach",
-                     "Approval_Date", "Date_of_Construction", "Recorded_WQMP_Area_Acres", "Trash_Capture_Effectiveness",
+                     "Approval_Date", "Date_of_Construction", "Recorded_WQMP_Area_Acres", "Calculated_Boundary_Acreage",
+                     "Trash_Capture_Effectiveness",
                      "Maintenance_Contact_Name", "Maintenance_Contact_Organization", "Maintenance_Contact_Phone",
                      "Maintenance_Contact_Address_1", "Maintenance_Contact_Address_2", "Maintenance_Contact_City",
                      "Maintenance_Contact_State", "Maintenance_Contact_Zip",

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlan.GdbExport.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlan.GdbExport.cs
@@ -8,6 +8,7 @@ using Neptune.Common;
 using Neptune.Common.GeoSpatial;
 using Neptune.Common.Services.GDAL;
 using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Utilities;
 
 namespace Neptune.EFModels.Entities;
@@ -46,19 +47,22 @@ public static class WaterQualityManagementPlanGdbExport
         {
             // NPT-943: repair SQL-invalid boundaries (self-intersecting parcel-union bowties) before export
             // so ArcGIS Check Geometry / geoprocessing tools don't error on them. Fixed NTS-side because the
-            // geometry is materialized as NTS here (NTS IsValid != SQL STIsValid); the repair preserves area.
+            // geometry is materialized as NTS here (NTS IsValid != SQL STIsValid). The repaired geometry is
+            // also what Calculated_Boundary_Acreage is derived from, so the acreage always describes the
+            // polygon actually written.
             var geometry = wqmp.WaterQualityManagementPlanBoundary.GeometryNative;
             if (!geometry.IsValid)
             {
                 geometry = GeometryFixer.Fix(geometry);
             }
-            featureCollection.Add(new Feature(geometry, BuildAttributes(wqmp)));
+            featureCollection.Add(new Feature(geometry, BuildAttributes(wqmp, geometry)));
         }
         return featureCollection;
     }
 
-    // GDB column names must be GDB-safe (letters/digits/underscores).
-    private static AttributesTable BuildAttributes(WaterQualityManagementPlan wqmp)
+    // GDB column names must be GDB-safe (letters/digits/underscores). `geometry` is the geometry actually
+    // exported for this WQMP (post-repair), so Calculated_Boundary_Acreage describes the delivered polygon.
+    private static AttributesTable BuildAttributes(WaterQualityManagementPlan wqmp, Geometry geometry)
     {
         return new AttributesTable
         {
@@ -81,9 +85,10 @@ public static class WaterQualityManagementPlanGdbExport
             { "Date_of_Construction", wqmp.DateOfConstruction?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) },
             { "Recorded_WQMP_Area_Acres", wqmp.RecordedWQMPAreaInAcres },
             // NPT-943 rework: area of the exported polygon (the recorded acreage above does not describe the
-            // delivered geometry). Same formula as WaterQualityManagementPlan.DtoProjections "CalculatedWQMPAcreage".
-            { "Calculated_Boundary_Acreage", wqmp.WaterQualityManagementPlanBoundary?.GeometryNative != null
-                ? (double?)Math.Round(wqmp.WaterQualityManagementPlanBoundary.GeometryNative.Area * Constants.SquareMetersToAcres, 1)
+            // delivered geometry). Computed from the exported geometry; same acres formula as
+            // WaterQualityManagementPlan.DtoProjections "CalculatedWQMPAcreage".
+            { "Calculated_Boundary_Acreage", geometry != null
+                ? (double?)Math.Round(geometry.Area * Constants.SquareMetersToAcres, 1)
                 : null },
             { "Trash_Capture_Effectiveness", wqmp.TrashCaptureEffectiveness },
             { "Maintenance_Contact_Name", wqmp.MaintenanceContactName },

--- a/Neptune.Tests/WaterQualityManagementPlanGdbExportTests.cs
+++ b/Neptune.Tests/WaterQualityManagementPlanGdbExportTests.cs
@@ -2,7 +2,9 @@ using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.Common;
 using Neptune.EFModels.Entities;
+using NetTopologySuite.Geometries;
 
 namespace Neptune.Tests
 {
@@ -93,10 +95,58 @@ namespace Neptune.Tests
 
             Assert.AreEqual(wqmps.Count, fc.Count, "One feature per WQMP.");
             Assert.IsTrue(fc.All(f => f.Geometry != null), "Every feature has boundary geometry.");
-            foreach (var key in new[] { "Name", "Priority", "Trash_Capture_Status", "Maintenance_Contact_Name", "Recorded_WQMP_Area_Acres" })
+            foreach (var key in new[] { "Name", "Jurisdiction", "Priority", "Trash_Capture_Status", "Maintenance_Contact_Name", "Recorded_WQMP_Area_Acres", "Calculated_Boundary_Acreage" })
             {
                 Assert.IsTrue(fc.All(f => f.Attributes.Exists(key)), $"Every feature must carry the '{key}' attribute.");
             }
+        }
+
+        // A real exportable WQMP (valid lookup FKs so BuildAttributes' lookup getters resolve); we then
+        // mutate just the date / geometry in-memory to exercise the export projection deterministically.
+        private WaterQualityManagementPlan FirstExportableWqmp()
+        {
+            var jurisdictionID = JurisdictionWithBoundaries();
+            if (jurisdictionID == null) return null;
+            return WaterQualityManagementPlanGdbExport
+                .ListForGdbExport(_dbContext, new[] { jurisdictionID.Value }, Array.Empty<int>())
+                .FirstOrDefault();
+        }
+
+        [TestMethod]
+        public void ToFeatureCollection_EmitsDateOnlyStringAndCalculatedAcreage()
+        {
+            var wqmp = FirstExportableWqmp();
+            if (wqmp == null) { Assert.Inconclusive("No exportable WQMP in the local DB."); return; }
+
+            // Seed a value with a time component to prove it is dropped (not shifted to a UTC timestamp).
+            wqmp.ApprovalDate = new DateTime(2004, 11, 10, 8, 30, 0);
+            var attrs = WaterQualityManagementPlanGdbExport.ToFeatureCollection(new[] { wqmp }).Single().Attributes;
+
+            // Date-only, timezone-naive (NPT-943 item 3).
+            Assert.AreEqual("2004-11-10", attrs["Approval_Date"], "Approval_Date must be a date-only string with no time/offset.");
+            // Calculated acreage matches the exported polygon area (NPT-943 item 2), same formula as DtoProjections.
+            var expectedAcres = Math.Round(wqmp.WaterQualityManagementPlanBoundary.GeometryNative.Area * Constants.SquareMetersToAcres, 1);
+            Assert.AreEqual(expectedAcres, attrs["Calculated_Boundary_Acreage"], "Calculated_Boundary_Acreage must equal the polygon area in acres.");
+        }
+
+        [TestMethod]
+        public void ToFeatureCollection_RepairsInvalidBoundaryGeometry()
+        {
+            var wqmp = FirstExportableWqmp();
+            if (wqmp == null) { Assert.Inconclusive("No exportable WQMP in the local DB."); return; }
+
+            // Replace the boundary with a self-intersecting "bowtie" ring — invalid per OGC, like the
+            // parcel-union pinch points KE flagged — keeping the WQMP's real lookup FKs intact.
+            var srid = wqmp.WaterQualityManagementPlanBoundary.GeometryNative.SRID;
+            var bowtie = new GeometryFactory(new PrecisionModel(), srid).CreatePolygon(new[]
+            {
+                new Coordinate(0, 0), new Coordinate(2, 2), new Coordinate(0, 2), new Coordinate(2, 0), new Coordinate(0, 0),
+            });
+            Assert.IsFalse(bowtie.IsValid, "Precondition: the constructed bowtie should be invalid.");
+            wqmp.WaterQualityManagementPlanBoundary.GeometryNative = bowtie;
+
+            var feature = WaterQualityManagementPlanGdbExport.ToFeatureCollection(new[] { wqmp }).Single();
+            Assert.IsTrue(feature.Geometry.IsValid, "Export must repair invalid boundary geometry (NPT-943 item 5a).");
         }
     }
 }

--- a/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.html
+++ b/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.html
@@ -15,6 +15,9 @@
             <a href="javascript:void(0);" [class.disabled]="isDownloadingGdb" (click)="onGdbClick()">
                 @if (isDownloadingGdb) { <i class="fa fa-spinner fa-spin"></i> Building... } @else { GIS (.gdb.zip) }
             </a>
+            <!-- NPT-943: state the export CRS so users aren't surprised by the unit mismatch with the
+                 State Plane feet (Zone 406) convention used for PLU/land-use uploads. -->
+            <span class="gdb-crs-note">Projection: NAD83(HARN) CA Zone VI · meters</span>
         }
     </div>
 </ng-template>

--- a/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.scss
+++ b/Neptune.Web/src/app/shared/components/neptune-grid-download-menu/neptune-grid-download-menu.component.scss
@@ -51,4 +51,12 @@
             text-decoration: none;
         }
     }
+
+    // NPT-943: muted CRS caption under the GIS option.
+    .gdb-crs-note {
+        margin-top: 0.5rem;
+        font-size: $type-size-200;
+        color: rgba($black, 0.6);
+        line-height: 1.3;
+    }
 }


### PR DESCRIPTION
Addresses Kathleen's 7/30 QA review of the WQMP GDB export (`WaterQualityManagementPlan.GdbExport`). The button-placement feedback was already handled in #633; this round is the GDB **contents**.

## Changes
- **`Jurisdiction` (Text)** on every feature — `Include` `StormwaterJurisdiction → Organization`; the unfiltered Data Hub export had no way to distinguish permittees.
- **`Calculated_Boundary_Acreage` (Double)** alongside the existing recorded acreage — the recorded value doesn't describe the exported geometry (diverged materially in QA). Same formula as `WaterQualityManagementPlan.DtoProjections`.
- **Date-only dates** — `Approval_Date` / `Date_of_Construction` now emit `yyyy-MM-dd` (scoped to the export, not the global `DateTimeConverter`) so OGR types them as timezone-naive Date fields instead of the UTC-shifted timestamps QA saw.
- **Geometry repair** — invalid boundaries (self-intersecting parcel-union bowties) are repaired with NTS `GeometryFixer.Fix` before export so ArcGIS Check Geometry doesn't error.
- **CRS note** on the grid download menu — states the export CRS (NAD83(HARN) CA Zone VI, meters) to flag the unit mismatch with the State Plane feet upload convention.
- **Release script `040`** normalizes legacy `MaintenanceContactState` values to 2-letter USPS codes (the editor already enforces the `US_STATES` dropdown; dirty values pre-date it / came via XLSX import).

## Testing
- `WaterQualityManagementPlanGdbExportTests` extended (date-only, calculated acreage, geometry repair, new-field presence) — 5/5 pass.
- DacPac builds; the release-script aggregator regenerated to include `040`; the cleanup SQL validated in a rolled-back transaction.

## Deferred follow-ups
- `Date_of_Construction` typed Date when an entire export is null (needs a GDALAPI `OGR_SCHEMA` change; already Date whenever any row has a value).
- One-time `MakeValid` of stored invalid WQMP boundary rows (data cleanup, like the Delineation scripts).
- XLSX importer `MaintenanceContactState` normalization (recurrence vector; needs a reject-vs-coerce decision).