### PR TITLE
NPT-1116: Add Status (Verified/Provisional) column to Treatment BMP list

### DIFF
--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -63,6 +63,17 @@ public class TreatmentBMPController(
             .ToListAsync();
 
         var treatmentBMPGridDtos = entities.Select(x => x.AsGridDto()).ToList();
+
+        // NPT-1116: the Verified/Provisional Status column is only for Admin/SitkaAdmin/JurisdictionManager/
+        // JurisdictionEditor. Null the value for anyone else (Unassigned/anonymous) so it is not served via
+        // the API to roles that don't see the column (defense in depth; the SPA also hides the column).
+        var canSeeInventoryStatus = CallingUser.RoleID is (int)RoleEnum.Admin or (int)RoleEnum.SitkaAdmin
+            or (int)RoleEnum.JurisdictionManager or (int)RoleEnum.JurisdictionEditor;
+        if (!canSeeInventoryStatus)
+        {
+            treatmentBMPGridDtos.ForEach(x => x.InventoryStatus = null);
+        }
+
         return Ok(treatmentBMPGridDtos);
     }
 

--- a/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
+++ b/Neptune.API/Controllers/TreatmentBMP/TreatmentBMPController.cs
@@ -62,17 +62,23 @@ public class TreatmentBMPController(
             .Where(x => !publicUser || x.InventoryIsVerified)
             .ToListAsync();
 
-        var treatmentBMPGridDtos = entities.Select(x => x.AsGridDto()).ToList();
-
         // NPT-1116: the Verified/Provisional Status column is only for Admin/SitkaAdmin/JurisdictionManager/
-        // JurisdictionEditor. Null the value for anyone else (Unassigned/anonymous) so it is not served via
+        // JurisdictionEditor. Don't populate it for anyone else (Unassigned/anonymous) so it is not served via
         // the API to roles that don't see the column (defense in depth; the SPA also hides the column).
-        var canSeeInventoryStatus = CallingUser.RoleID is (int)RoleEnum.Admin or (int)RoleEnum.SitkaAdmin
-            or (int)RoleEnum.JurisdictionManager or (int)RoleEnum.JurisdictionEditor;
-        if (!canSeeInventoryStatus)
+        var canSeeInventoryStatus = CallingUser.RoleID == (int)RoleEnum.Admin
+                                    || CallingUser.RoleID == (int)RoleEnum.SitkaAdmin
+                                    || CallingUser.RoleID == (int)RoleEnum.JurisdictionManager
+                                    || CallingUser.RoleID == (int)RoleEnum.JurisdictionEditor;
+
+        var treatmentBMPGridDtos = entities.Select(x =>
         {
-            treatmentBMPGridDtos.ForEach(x => x.InventoryStatus = null);
-        }
+            var dto = x.AsGridDto();
+            if (!canSeeInventoryStatus)
+            {
+                dto.InventoryStatus = null;
+            }
+            return dto;
+        }).ToList();
 
         return Ok(treatmentBMPGridDtos);
     }

--- a/Neptune.API/swagger.json
+++ b/Neptune.API/swagger.json
@@ -22141,6 +22141,10 @@
             "type": "string",
             "nullable": true
           },
+          "InventoryStatus": {
+            "type": "string",
+            "nullable": true
+          },
           "StormwaterJurisdictionID": {
             "type": "integer",
             "format": "int32"

--- a/Neptune.EFModels/Entities/vTreatmentBMPDetailedExtensionMethods.cs
+++ b/Neptune.EFModels/Entities/vTreatmentBMPDetailedExtensionMethods.cs
@@ -12,6 +12,7 @@ namespace Neptune.EFModels.Entities
                 TreatmentBMPName = entity.TreatmentBMPName,
                 TreatmentBMPTypeID = entity.TreatmentBMPTypeID,
                 TreatmentBMPTypeName = entity.TreatmentBMPTypeName,
+                InventoryStatus = entity.InventoryIsVerified ? "Verified" : "Provisional",
                 StormwaterJurisdictionID = entity.StormwaterJurisdictionID,
                 StormwaterJurisdictionName = entity.OrganizationName,
                 WaterQualityManagementPlanID = entity.WaterQualityManagementPlanID,

--- a/Neptune.Models/DataTransferObjects/TreatmentBMP/TreatmentBMPGridDto.cs
+++ b/Neptune.Models/DataTransferObjects/TreatmentBMP/TreatmentBMPGridDto.cs
@@ -6,6 +6,9 @@ public class TreatmentBMPGridDto
     public string? TreatmentBMPName { get; set; }
     public int TreatmentBMPTypeID { get; set; }
     public string? TreatmentBMPTypeName { get; set; }
+    // NPT-1116: "Verified"/"Provisional" from InventoryIsVerified. Null when the caller's role isn't
+    // permitted to see the Status column (gated server-side in TreatmentBMPController.List).
+    public string? InventoryStatus { get; set; }
     public int StormwaterJurisdictionID { get; set; }
     public string StormwaterJurisdictionName { get; set; }
     public int? WaterQualityManagementPlanID { get; set; }

--- a/Neptune.Tests/TreatmentBMPGridDtoTests.cs
+++ b/Neptune.Tests/TreatmentBMPGridDtoTests.cs
@@ -1,0 +1,27 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neptune.EFModels.Entities;
+
+namespace Neptune.Tests
+{
+    /// <summary>
+    /// NPT-1116 — the Treatment BMP list "Status" column maps the InventoryIsVerified flag on the
+    /// vTreatmentBMPDetailed view to the plain-text "Verified"/"Provisional" values. DB-independent.
+    /// </summary>
+    [TestClass]
+    public class TreatmentBMPGridDtoTests
+    {
+        [TestMethod]
+        public void AsGridDto_VerifiedInventory_MapsToVerified()
+        {
+            var entity = new vTreatmentBMPDetailed { InventoryIsVerified = true };
+            Assert.AreEqual("Verified", entity.AsGridDto().InventoryStatus);
+        }
+
+        [TestMethod]
+        public void AsGridDto_UnverifiedInventory_MapsToProvisional()
+        {
+            var entity = new vTreatmentBMPDetailed { InventoryIsVerified = false };
+            Assert.AreEqual("Provisional", entity.AsGridDto().InventoryStatus);
+        }
+    }
+}

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmps.component.ts
@@ -176,6 +176,9 @@ export class TreatmentBmpsComponent {
                 FieldDefinitionLabelOverride: "Type",
                 UseCustomDropdownFilter: true,
             }),
+            // NPT-1116: Verified/Provisional inventory status. Hidden from anonymous/unassigned users by the
+            // publicHeaders filter below (not in that allow-list), and null-served to them by the API.
+            this.utilityFunctionsService.createBasicColumnDef("Status", "InventoryStatus", { UseCustomDropdownFilter: true }),
             this.utilityFunctionsService.createBasicColumnDef("Year Built", "YearBuilt"),
             this.utilityFunctionsService.createDateColumnDef("Last Assessment Date", "LatestAssessmentDate", "MM/dd/yyyy"),
             this.utilityFunctionsService.createBasicColumnDef("Last Assessed Score", "LatestAssessmentScore"),

--- a/Neptune.Web/src/app/shared/generated/model/treatment-bmp-grid-dto.ts
+++ b/Neptune.Web/src/app/shared/generated/model/treatment-bmp-grid-dto.ts
@@ -15,6 +15,7 @@ export class TreatmentBMPGridDto {
     TreatmentBMPName?: string | null;
     TreatmentBMPTypeID?: number;
     TreatmentBMPTypeName?: string | null;
+    InventoryStatus?: string | null;
     StormwaterJurisdictionID?: number;
     StormwaterJurisdictionName?: string | null;
     WaterQualityManagementPlanID?: number | null;
@@ -49,6 +50,7 @@ export interface TreatmentBMPGridDtoForm {
     TreatmentBMPName?: FormControl<string>;
     TreatmentBMPTypeID?: FormControl<number>;
     TreatmentBMPTypeName?: FormControl<string>;
+    InventoryStatus?: FormControl<string>;
     StormwaterJurisdictionID?: FormControl<number>;
     StormwaterJurisdictionName?: FormControl<string>;
     WaterQualityManagementPlanID?: FormControl<number>;
@@ -107,6 +109,16 @@ export class TreatmentBMPGridDtoFormControls {
         }
     );
     public static TreatmentBMPTypeName = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
+        value,
+        formControlOptions ?? 
+        {
+            nonNullable: false,
+            validators: 
+            [
+            ],
+        }
+    );
+    public static InventoryStatus = (value: FormControlState<string> | string = undefined, formControlOptions?: FormControlOptions | null) => new FormControl<string>(
         value,
         formControlOptions ?? 
         {


### PR DESCRIPTION
Adds a read-only **Status** column to the Treatment BMP list (`treatment-bmps`), immediately right of **Type**, showing **"Verified"** when `TreatmentBMP.InventoryIsVerified` is true and **"Provisional"** when false. Sourced from the existing `vTreatmentBMPDetailed.InventoryIsVerified` flag (no DB work).

## Changes
- `TreatmentBMPGridDto` gains `InventoryStatus` (string); `vTreatmentBMPDetailedExtensionMethods.AsGridDto` computes `"Verified"`/`"Provisional"`.
- `TreatmentBMPController.List` nulls `InventoryStatus` for callers outside Admin/SitkaAdmin/JurisdictionManager/JurisdictionEditor (**defense in depth** — the value isn't served to Unassigned/anonymous, AC #9).
- Frontend: `createBasicColumnDef("Status","InventoryStatus")` after Type with `UseCustomDropdownFilter` (sortable + checkbox set filter listing Verified/Provisional).
- Mapping unit tests; regenerated `swagger.json` + `treatment-bmp-grid-dto.ts`.

## Visibility (roles finding)
The story lists Viewer/ExternalViewer, but **those roles don't exist in this repo** (`RoleEnum` = Admin/Unassigned/SitkaAdmin/JurisdictionManager/JurisdictionEditor). So the requirement reduces to: show to the four target roles, hide from **Unassigned + anonymous**. No new frontend gate was needed — the existing NPT-1079 `publicHeaders` allow-list already excludes "Status" for anonymous/unassigned, and those are the only non-target roles.

## Testing
- `TreatmentBMPGridDtoTests` — Verified/Provisional mapping (2/2 pass).
- Manual per AC: column right of Type; Verified/Provisional text; sort + checkbox filter; absent + `InventoryStatus: null` for anonymous/unassigned; present for JurisdictionEditor and JurisdictionManager.

Note: KE's terse "colored text" comment is left as plain text per AC #2 (no colored-status precedent exists in the app); flag for her if she intended styling.