### PR TITLE
NPT-1117: Reword provisional/verify copy - public visibility is per-jurisdiction

### DIFF
--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.html
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.html
@@ -25,10 +25,12 @@
 <app-alert-display></app-alert-display>
 @if (treatmentBMP$ | async; as treatmentBMP) {
     <div class="grid-12">
-    <!-- NPT-1117: provisional state — info banner (matches the WQMP promote banner). Provisional gates PUBLIC VISIBILITY only, not modeling/trash. -->
+    <!-- NPT-1117: provisional state — info banner (matches the WQMP promote banner). Provisional gates PUBLIC VISIBILITY only, not modeling/trash —
+         and only in jurisdictions whose StormwaterJurisdictionPublicBMPVisibilityType is VerifiedOnly. Most jurisdictions are set to None, where
+         verifying changes nothing publicly, so this copy must not promise a public-visibility outcome. (NPT-1117 rework) -->
     @if (!treatmentBMP.InventoryIsVerified && !isAnonymousOrUnassigned) {
         <note noteType="info" class="g-col-12">
-            This BMP's inventory is <strong>provisional</strong>. Provisional BMPs are hidden from public users until the inventory is verified.
+            This BMP's inventory is <strong>provisional</strong>. Review the record below and mark verified when ready.
             @if (treatmentBMP.CurrentPersonCanManage) {
                 <div note-action class="flex">
                     <button type="button" class="btn btn-sm btn-primary" [disabled]="isVerifying" (click)="confirmVerifyInventory(treatmentBMP)">

--- a/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
+++ b/Neptune.Web/src/app/pages/treatment-bmps/treatment-bmp-detail/treatment-bmp-detail.component.ts
@@ -219,7 +219,7 @@ export class TreatmentBmpDetailComponent implements OnInit, OnChanges {
         const confirmed = await this.confirmService.confirm(
             {
                 title: "Verify Inventory",
-                message: `Verify the inventory for "${escapeHtml(treatmentBMP.TreatmentBMPName)}"? Once verified, this BMP becomes visible to public users.`,
+                message: `Verify the inventory for "${escapeHtml(treatmentBMP.TreatmentBMPName)}"? You will be recorded as the verifier as of today.`,
                 buttonTextYes: "Verify Inventory",
                 buttonTextNo: "Cancel",
                 buttonClassYes: "btn-primary",
@@ -248,7 +248,7 @@ export class TreatmentBmpDetailComponent implements OnInit, OnChanges {
         const confirmed = await this.confirmService.confirm(
             {
                 title: "Mark as Provisional",
-                message: `Mark "${escapeHtml(treatmentBMP.TreatmentBMPName)}" as provisional? Provisional BMPs are hidden from public users.`,
+                message: `Mark "${escapeHtml(treatmentBMP.TreatmentBMPName)}" as provisional? You can verify it again at any time.`,
                 buttonTextYes: "Mark as Provisional",
                 buttonTextNo: "Cancel",
                 buttonClassYes: "btn-primary",


### PR DESCRIPTION
Rework for [NPT-1117](https://sitkatech.atlassian.net/browse/NPT-1117), following KE's 8/3/26 testing pass — 11 of 12 checks passed, one came back red.

> **[ KE 8/3/26 needs work ]** Current message is alarming for jurisidictions who keep all the BMPs private (no public visibility) Remove "Provisional BMPs are hidden from public users until the inventory is verified." - replace with "Review the record below and mark verified when ready"

## The copy wasn't just alarming — it was wrong

Public BMP visibility is a **per-jurisdiction** setting, `StormwaterJurisdiction.StormwaterJurisdictionPublicBMPVisibilityTypeID`, with two values: `1 = VerifiedOnly`, `2 = None`. Anonymous callers only ever see jurisdictions set to `VerifiedOnly` (`StormwaterJurisdictionPeople.cs:22-26`), and the per-BMP verified gate is applied on top of that (`TreatmentBMPController.cs:58-62`).

In prod:

| Public BMP visibility | Jurisdictions |
| --- | --- |
| Verified Only | 12 |
| **None** | **23** |

So for **23 of 35 jurisdictions**, verifying a BMP does nothing for public visibility — the jurisdiction is excluded from anonymous results either way. KE read the banner as alarming; it was also false for most of the tenancy.

## Changes

Copy only, both in `treatment-bmp-detail`. **No API, DTO, codegen, or schema change.**

**Banner** (`treatment-bmp-detail.component.html:31`) — KE's replacement copy, verbatim:
```diff
- This BMP's inventory is <strong>provisional</strong>. Provisional BMPs are hidden from public users until the inventory is verified.
+ This BMP's inventory is <strong>provisional</strong>. Review the record below and mark verified when ready.
```

**Verify Inventory dialog** (`treatment-bmp-detail.component.ts:222`) — not flagged by KE, but the same defect and the only *affirmatively false* one of the three. Now states what the endpoint actually does (`TreatmentBMP.MarkAsVerified` stamps verifier + date):
```diff
- ...? Once verified, this BMP becomes visible to public users.
+ ...? You will be recorded as the verifier as of today.
```

**Mark as Provisional dialog** (`treatment-bmp-detail.component.ts:251`) — same claim; replaced with the reassurance that actually matters at that prompt:
```diff
- ...as provisional? Provisional BMPs are hidden from public users.
+ ...as provisional? You can verify it again at any time.
```

**Template comment** (`treatment-bmp-detail.component.html:28`) — extended to record the per-jurisdiction nuance, so the claim doesn't get reinstated later.

Grep for `public users` / `visible to public` / `hidden from public` across the component directory returns zero hits.

## Two stale ACs for KE to amend

- **AC #2** reads "The banner explains that the inventory is provisional *and that provisional BMPs are hidden from public users*." The second half is now superseded by KE's own rework.
- **AC #22 / pt4b** ("a BMP verified from the detail page becomes visible to anonymous users") passed, but only holds for `VerifiedOnly` jurisdictions — worth noting so it isn't retested against a `None` jurisdiction and logged as a regression.

## Testing

`npm run build-dev` clean. Nothing else in NPT-1117 changed — the banner styling/placement, `note-action` slot, `CurrentPersonCanManage` button gating, spinner states, endpoints, and permission behavior are all untouched, so KE's 11 passing checks should still pass.

Note: `npm run lint` currently fails repo-wide on `Package subpath './@typescript-eslint' is not defined by "exports" in eslint-config-prettier` — pre-existing on `develop`, unrelated to this branch.
