### PR TITLE
NPT-1120: Normalize PDF headers before uploading to the Anthropic Files API

### DIFF
--- a/Neptune.API/Services/AI/AnthropicFileService.cs
+++ b/Neptune.API/Services/AI/AnthropicFileService.cs
@@ -165,7 +165,15 @@ public class AnthropicFileService
         // so the multipart envelope is well-formed without a server-side buffer.
         // Cuts peak memory from O(file size) to a small read window per upload.
         var canonicalName = document.FileResource.GetFileResourceGUIDAsString().ToLower();
-        using var blobDownload = await _blobService.DownloadBlobFromBlobStorageAsStream(canonicalName);
+
+        // Skip any junk ahead of the %PDF signature — see FindPdfHeaderOffsetAsync.
+        var headerOffset = await FindPdfHeaderOffsetAsync(
+            canonicalName, document.WaterQualityManagementPlanDocumentID, cancellationToken);
+
+        using var blobDownload = headerOffset == 0
+            ? await _blobService.DownloadBlobFromBlobStorageAsStream(canonicalName)
+            : await _blobService.DownloadBlobRangeFromBlobStorageAsStream(canonicalName, headerOffset);
+
         var filename = document.FileResource.GetOriginalCompleteFileName();
         if (string.IsNullOrWhiteSpace(filename))
         {
@@ -173,7 +181,7 @@ public class AnthropicFileService
         }
 
         var fileID = await UploadViaHttpClientAsync(
-            blobDownload.Content, document.FileResource.ContentLength, filename, cancellationToken);
+            blobDownload.Content, document.FileResource.ContentLength - headerOffset, filename, cancellationToken);
 
         document.AnthropicFileID = fileID;
         document.AnthropicFileUploadedDate = DateTime.UtcNow;
@@ -183,6 +191,78 @@ public class AnthropicFileService
             document.WaterQualityManagementPlanDocumentID, fileID);
 
         return fileID;
+    }
+
+    /// <summary>
+    /// Number of leading bytes scanned for the %PDF signature. Matches the tolerance window
+    /// used by mainstream readers, which is where these files pick up their reputation for
+    /// being fine.
+    /// </summary>
+    private const int PdfHeaderScanBytes = 1024;
+
+    private static readonly byte[] PdfSignature = "%PDF"u8.ToArray();
+
+    /// <summary>
+    /// Returns the offset of the %PDF signature within the first <see cref="PdfHeaderScanBytes"/>
+    /// bytes of the blob, or 0 if it is already at byte 0 (or cannot be found).
+    ///
+    /// A valid PDF starts with %PDF at byte 0, but real-world files sometimes carry junk ahead
+    /// of it — one WQMP arrived with a single stray 0x01 byte. Acrobat and browsers scan the
+    /// leading kilobyte for the signature and open such files without complaint, so they look
+    /// healthy to the uploader. Anthropic's parser requires the signature at byte 0; without it
+    /// the document is sniffed as application/octet-stream and the extraction call fails with
+    /// "Unsupported document file format", which names the wrong problem entirely and sends you
+    /// hunting for a MIME-type bug. Trimming the leading bytes makes those documents extractable.
+    /// </summary>
+    private async Task<int> FindPdfHeaderOffsetAsync(
+        string canonicalName, int documentID, CancellationToken cancellationToken)
+    {
+        using var head = await _blobService.DownloadBlobRangeFromBlobStorageAsStream(
+            canonicalName, 0, PdfHeaderScanBytes);
+        using var buffer = new MemoryStream();
+        await head.Content.CopyToAsync(buffer, cancellationToken);
+        var bytes = buffer.ToArray();
+
+        var offset = IndexOfSignature(bytes);
+        if (offset < 0)
+        {
+            // Not a PDF as far as we can tell. Upload unchanged rather than inventing a new
+            // failure mode — Anthropic will reject it, and that rejection is the honest answer.
+            _logger.LogWarning(
+                "No %PDF signature in the first {ScanBytes} bytes for documentID={DocumentID}; uploading unchanged. Extraction will likely fail — the file may not be a PDF.",
+                PdfHeaderScanBytes, documentID);
+            return 0;
+        }
+
+        if (offset > 0)
+        {
+            _logger.LogWarning(
+                "PDF for documentID={DocumentID} has {Offset} junk byte(s) before the %PDF signature; skipping them so Anthropic can parse the document.",
+                documentID, offset);
+        }
+
+        return offset;
+    }
+
+    private static int IndexOfSignature(byte[] bytes)
+    {
+        for (var i = 0; i + PdfSignature.Length <= bytes.Length; i++)
+        {
+            var matched = true;
+            for (var j = 0; j < PdfSignature.Length; j++)
+            {
+                if (bytes[i + j] != PdfSignature[j])
+                {
+                    matched = false;
+                    break;
+                }
+            }
+            if (matched)
+            {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private async Task<string> UploadViaHttpClientAsync(

--- a/Neptune.API/Services/AI/AnthropicFileService.cs
+++ b/Neptune.API/Services/AI/AnthropicFileService.cs
@@ -171,8 +171,9 @@ public class AnthropicFileService
             canonicalName, document.WaterQualityManagementPlanDocumentID, cancellationToken);
 
         using var blobDownload = headerOffset == 0
-            ? await _blobService.DownloadBlobFromBlobStorageAsStream(canonicalName)
-            : await _blobService.DownloadBlobRangeFromBlobStorageAsStream(canonicalName, headerOffset);
+            ? await _blobService.DownloadBlobFromBlobStorageAsStream(canonicalName, cancellationToken)
+            : await _blobService.DownloadBlobRangeFromBlobStorageAsStream(
+                canonicalName, headerOffset, cancellationToken: cancellationToken);
 
         var filename = document.FileResource.GetOriginalCompleteFileName();
         if (string.IsNullOrWhiteSpace(filename))
@@ -218,7 +219,7 @@ public class AnthropicFileService
         string canonicalName, int documentID, CancellationToken cancellationToken)
     {
         using var head = await _blobService.DownloadBlobRangeFromBlobStorageAsStream(
-            canonicalName, 0, PdfHeaderScanBytes);
+            canonicalName, 0, PdfHeaderScanBytes, cancellationToken);
         using var buffer = new MemoryStream();
         await head.Content.CopyToAsync(buffer, cancellationToken);
         var bytes = buffer.ToArray();

--- a/Neptune.Common/Services/AzureBlobStorageService.cs
+++ b/Neptune.Common/Services/AzureBlobStorageService.cs
@@ -4,6 +4,7 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Neptune.Common.Services;
@@ -766,10 +767,11 @@ public class AzureBlobStorageService
         return downloadResult.Value;
     }
 
-    public async Task<BlobDownloadStreamingResult> DownloadBlobFromBlobStorageAsStream(string canonicalName)
+    public async Task<BlobDownloadStreamingResult> DownloadBlobFromBlobStorageAsStream(
+        string canonicalName, CancellationToken cancellationToken = default)
     {
         var blobClient = _fileResourceContainerClient.GetBlobClient(canonicalName);
-        var downloadResult = await blobClient.DownloadStreamingAsync();
+        var downloadResult = await blobClient.DownloadStreamingAsync(cancellationToken: cancellationToken);
         return downloadResult.Value;
     }
 
@@ -780,11 +782,11 @@ public class AzureBlobStorageService
     /// Pass a null <paramref name="length"/> to read from <paramref name="offset"/> to the end.
     /// </summary>
     public async Task<BlobDownloadStreamingResult> DownloadBlobRangeFromBlobStorageAsStream(
-        string canonicalName, long offset, long? length = null)
+        string canonicalName, long offset, long? length = null, CancellationToken cancellationToken = default)
     {
         var blobClient = _fileResourceContainerClient.GetBlobClient(canonicalName);
         var downloadResult = await blobClient.DownloadStreamingAsync(
-            new BlobDownloadOptions { Range = new Azure.HttpRange(offset, length) });
+            new BlobDownloadOptions { Range = new Azure.HttpRange(offset, length) }, cancellationToken);
         return downloadResult.Value;
     }
 

--- a/Neptune.Common/Services/AzureBlobStorageService.cs
+++ b/Neptune.Common/Services/AzureBlobStorageService.cs
@@ -773,6 +773,21 @@ public class AzureBlobStorageService
         return downloadResult.Value;
     }
 
+    /// <summary>
+    /// Streams a byte range of a blob. The stream returned by the download is not seekable,
+    /// so callers that need to inspect a file's leading bytes and then send it from an offset
+    /// have to ask for the range up front rather than peeking and rewinding.
+    /// Pass a null <paramref name="length"/> to read from <paramref name="offset"/> to the end.
+    /// </summary>
+    public async Task<BlobDownloadStreamingResult> DownloadBlobRangeFromBlobStorageAsStream(
+        string canonicalName, long offset, long? length = null)
+    {
+        var blobClient = _fileResourceContainerClient.GetBlobClient(canonicalName);
+        var downloadResult = await blobClient.DownloadStreamingAsync(
+            new BlobDownloadOptions { Range = new Azure.HttpRange(offset, length) });
+        return downloadResult.Value;
+    }
+
     public async Task<bool> ExistsFromBlobStorage(string canonicalName)
     {
         var blobClient = _fileResourceContainerClient.GetBlobClient(canonicalName);

--- a/Neptune.Database/Neptune.Database.sqlproj
+++ b/Neptune.Database/Neptune.Database.sqlproj
@@ -446,6 +446,7 @@
     <None Include="Scripts\ReleaseScripts\038 - NPT-1095 Stamp IsTransectBackingAssessment on legacy backing OVTAs.sql" />
     <None Include="Scripts\ReleaseScripts\039 - MakeValid on invalid Delineation geometries (recurrence).sql" />
     <None Include="Scripts\ReleaseScripts\040 - NPT-943 Normalize WQMP MaintenanceContactState.sql" />
+    <None Include="Scripts\ReleaseScripts\041 - NPT-1120 Clear cached Anthropic file ids so PDFs re-upload.sql" />
     <Build Include="dbo\Tables\dbo.WaterQualityManagementPlanExtractionResult.sql" />
     <Build Include="dbo\Tables\dbo.AITokenUsage.sql" />
   </ItemGroup>

--- a/Neptune.Database/Scripts/ReleaseScripts/041 - NPT-1120 Clear cached Anthropic file ids so PDFs re-upload.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/041 - NPT-1120 Clear cached Anthropic file ids so PDFs re-upload.sql
@@ -1,0 +1,23 @@
+-- NPT-1120: clear the cached Anthropic Files API ids on WQMP documents so every document
+-- re-uploads through the new PDF-header normalization in AnthropicFileService.
+--
+-- Some source PDFs carry junk ahead of the %PDF signature (the reported case: a single stray
+-- 0x01 byte). Anthropic requires the signature at byte 0 and otherwise sniffs the document as
+-- application/octet-stream, failing extraction with "Unsupported document file format" — an
+-- error that names the wrong problem. The fix trims those leading bytes at upload time, but it
+-- only runs on a cache miss: AnthropicFileID short-circuits the upload entirely, so any document
+-- already uploaded with the bad header keeps failing until its cached id is cleared.
+--
+-- Clearing the id is safe and cheap: the next extraction or chat call re-uploads the PDF and
+-- re-caches a fresh id. The only cost is one repeat upload per document. Idempotent — rows with
+-- a NULL id are untouched, so re-running is a no-op.
+--
+-- Note: this orphans the previously-uploaded files on the Anthropic account. They are unreferenced
+-- after this runs and count toward the 100GB org storage limit; delete them via the Files API if
+-- that ever matters.
+SET NOCOUNT ON;
+
+UPDATE dbo.WaterQualityManagementPlanDocument
+SET AnthropicFileID = NULL,
+    AnthropicFileUploadedDate = NULL
+WHERE AnthropicFileID IS NOT NULL;

--- a/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/Neptune.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -88,4 +88,6 @@ GO
 GO
 :r ".\040 - NPT-943 Normalize WQMP MaintenanceContactState.sql"
 GO
+:r ".\041 - NPT-1120 Clear cached Anthropic file ids so PDFs re-upload.sql"
+GO
 


### PR DESCRIPTION
[NPT-1120](https://sitkatech.atlassian.net/browse/NPT-1120)

## Why

WQMP AI extraction failed for some documents with:

> `messages.0.content.0.source: Unsupported document file format: application/octet-stream. Only PDF and plaintext documents are supported.`

**The error names the wrong problem.** It reads like a MIME/content-type bug and sends you through the upload headers, the SDK, and the document-block shape — none of which are at fault.

The cause is a malformed PDF header. The reported document (WQMP 3321) carries a stray `0x01` byte ahead of the `%PDF-1.6` signature:

```
01 25 50 44 46 2D 31 2E 36
^^ %  P  D  F  -  1  .  6
```

A PDF must begin with `%PDF` at byte 0. Acrobat and Chrome scan the leading ~1 KB for the signature and open such files without complaint, so they look perfectly healthy to whoever uploaded them. Anthropic requires it at byte 0 and otherwise sniffs the document as `application/octet-stream`.

Stripping that single byte and re-uploading the otherwise-identical file: **accepted, 182,009 input tokens, 37s.**

## What changed

- **`AnthropicFileService`** — scan the first 1 KB for `%PDF` and stream the upload from that offset, subtracting it from the declared `Content-Length` (the multipart envelope needs a length matching the bytes actually sent). Trimming logs a warning naming the byte count, so it stays visible in Datadog rather than being silently corrected. When no signature is found at all, upload unchanged and warn — Anthropic's rejection is the honest answer for a file that isn't a PDF, and inventing a new failure mode risks rejecting files that would otherwise work.
- **`AzureBlobStorageService`** — added `DownloadBlobRangeFromBlobStorageAsStream`. Azure's streaming download isn't seekable, so the header can't be peeked and rewound; it has to be requested as its own range. Additive — the existing whole-blob method is untouched.
- **Release script 041** — clears cached `AnthropicFileID` / `AnthropicFileUploadedDate`. Idempotent.

## The release script is load-bearing

Normalization runs only on upload, and upload only runs on a cache miss — `AnthropicFileID` short-circuits it entirely. **Without script 041, every document already uploaded with a bad header keeps failing**, and the fix looks like it didn't work. QA and prod each have their own cached ids.

Clearing is safe: the next extraction or chat call re-uploads and re-caches. The only cost is one repeat upload per document.

## Ruled out, with evidence

So nobody re-walks this ground:

| Suspected | Evidence it wasn't the cause |
|---|---|
| Size / 32 MB limit | A 35.2 MB PDF works untouched; this 38.4 MB one works once the header is fixed |
| Encryption / portfolio | `/Encrypt` count 0, `/Collection` count 0 |
| Page count | 92 pages, well under the 600 limit |
| Truncated upload | Blob is byte-exact with `FileResource.ContentLength` (40,280,013) |
| Document-block shape / beta header / SDK | Same block with a *nonexistent* `file_id` returns a clean `404` — and `BetaFileDocumentSource` is unchanged between SDK 12.29.0 and 12.40.0 |
| Anthropic-side change | The 35.2 MB file uploaded Aug 5 still processes today, unchanged |

Two things worth knowing for the next person debugging this:

- **The two Anthropic endpoints disagree.** `GET /v1/files/{id}` reports `mime_type: application/pdf` — the Files API trusts the content-type declared at upload, while the Messages API sniffs the actual bytes. Correct file metadata does *not* mean the document is parseable.
- **Free diagnostic probe.** Send the same document block with a nonexistent `file_id`; a clean `404 not_found` proves shape, beta header, and SDK are fine, and costs nothing — validation failures aren't billed.

## Testing

- Verified end-to-end in the running app: WQMP 3321 extraction now succeeds.
- Full solution builds clean; `Neptune.Tests` at its usual baseline (429 passed, 2 pre-existing local-DB failures).
- Script 041 confirmed picked up by the post-deployment generator (`:r ".\041 - …"`).

## Follow-up (out of scope)

`NeptuneConfiguration.MaxExtractablePdfSizeBytes` defaults to 400 MB, on the assumption that the Files API path lifts the documented 32 MB request limit. It does lift it — 38.4 MB is now proven — but 400 MB is untested and optimistic. Worth establishing a real ceiling separately.
