### PR TITLE
NPT-1121: Reclaim Anthropic uploads when a cached file_id is dropped

### DIFF
--- a/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanController.cs
@@ -41,7 +41,8 @@ namespace Neptune.API.Controllers
         AzureBlobStorageService azureBlobStorageService,
         WqmpExtractionService wqmpExtractionService,
         SitkaSmtpClientService sitkaSmtpClientService,
-        GDALAPIService gdalApiService)
+        GDALAPIService gdalApiService,
+        AnthropicFileService anthropicFileService)
         : SitkaController<WaterQualityManagementPlanController>(dbContext, logger,
             neptuneConfiguration)
     {
@@ -226,6 +227,7 @@ namespace Neptune.API.Controllers
 
             int? newFileResourceID = null;
             int? oldFileResourceID = null;
+            string oldAnthropicFileID = null;
             if (dto.File != null)
             {
                 var errors = FileResources.ValidateFileUpload(dto.File);
@@ -236,6 +238,9 @@ namespace Neptune.API.Controllers
                 }
 
                 oldFileResourceID = existing.FileResourceID;
+                // UpdateMetadataAsync clears the cached id because it belongs to the file
+                // we're replacing; hold onto it so we can delete the upload upstream too.
+                oldAnthropicFileID = existing.AnthropicFileID;
                 var fileResource = await HttpUtilities.MakeFileResourceFromFormFileAsync(DbContext, HttpContext, azureBlobStorageService, dto.File);
                 newFileResourceID = fileResource.FileResourceID;
             }
@@ -255,6 +260,12 @@ namespace Neptune.API.Controllers
                 }
             }
 
+            // Same for the Anthropic upload made from the replaced file — nothing references
+            // it now, and nothing else ever reclaims it. Best-effort; never fails the request.
+            // Deliberately not the request token: the row is already updated, so a client
+            // disconnect here would strand the very file we are trying to reclaim.
+            await anthropicFileService.DeleteRemoteFileAsync(oldAnthropicFileID, CancellationToken.None);
+
             return Ok(updated);
         }
 
@@ -271,11 +282,15 @@ namespace Neptune.API.Controllers
             if (existing.WaterQualityManagementPlanID != waterQualityManagementPlanID) return NotFound();
 
             var fileResource = FileResources.GetByID(DbContext, existing.FileResourceID);
+            // Capture before the row goes away — it is the only record of the upload (NPT-1121).
+            var anthropicFileID = existing.AnthropicFileID;
             await WaterQualityManagementPlanDocuments.DeleteAsync(DbContext, waterQualityManagementPlanDocumentID);
             if (fileResource != null)
             {
                 await azureBlobStorageService.DeleteFileResourceBlob(fileResource.FileResourceGUID);
             }
+            // Best-effort, and deliberately not the request token — see UpdateDocument.
+            await anthropicFileService.DeleteRemoteFileAsync(anthropicFileID, CancellationToken.None);
             return NoContent();
         }
 

--- a/Neptune.API/Controllers/WaterQualityManagementPlanDocumentController.cs
+++ b/Neptune.API/Controllers/WaterQualityManagementPlanDocumentController.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Neptune.API.Services;
+using Neptune.API.Services.AI;
 using Neptune.API.Services.Attributes;
 using Neptune.API.Services.Authorization;
 using Neptune.EFModels.Entities;
@@ -16,7 +18,8 @@ namespace Neptune.API.Controllers
     public class WaterQualityManagementPlanDocumentController(
         NeptuneDbContext dbContext,
         ILogger<WaterQualityManagementPlanDocumentController> logger,
-        IOptions<NeptuneConfiguration> neptuneConfiguration)
+        IOptions<NeptuneConfiguration> neptuneConfiguration,
+        AnthropicFileService anthropicFileService)
         : SitkaController<WaterQualityManagementPlanDocumentController>(dbContext, logger,
             neptuneConfiguration)
     {
@@ -51,8 +54,18 @@ namespace Neptune.API.Controllers
         [EntityNotFoundAttribute(typeof(WaterQualityManagementPlanDocument), "waterQualityManagementPlanDocumentID")]
         public async Task<ActionResult<WaterQualityManagementPlanDocumentDto>> Update([FromRoute] int waterQualityManagementPlanDocumentID, [FromBody] WaterQualityManagementPlanDocumentUpsertDto dto)
         {
+            // Pointing the row at a different FileResource orphans the cached Anthropic
+            // upload (UpdateFromUpsertDto clears the id) — capture it first so we can
+            // reclaim it upstream. NPT-1121.
+            var existing = WaterQualityManagementPlanDocuments.GetByID(DbContext, waterQualityManagementPlanDocumentID);
+            var replacedAnthropicFileID = existing.FileResourceID != dto.FileResourceID
+                ? existing.AnthropicFileID
+                : null;
+
             var updated = await WaterQualityManagementPlanDocuments.UpdateAsync(DbContext, waterQualityManagementPlanDocumentID, dto);
             if (updated == null) return NotFound();
+
+            await anthropicFileService.DeleteRemoteFileAsync(replacedAnthropicFileID, CancellationToken.None);
             return Ok(updated);
         }
 
@@ -61,8 +74,14 @@ namespace Neptune.API.Controllers
         [EntityNotFoundAttribute(typeof(WaterQualityManagementPlanDocument), "waterQualityManagementPlanDocumentID")]
         public async Task<IActionResult> Delete([FromRoute] int waterQualityManagementPlanDocumentID)
         {
+            // Capture before the row goes away — it is the only record of the upload (NPT-1121).
+            var existing = WaterQualityManagementPlanDocuments.GetByID(DbContext, waterQualityManagementPlanDocumentID);
+            var anthropicFileID = existing.AnthropicFileID;
+
             var deleted = await WaterQualityManagementPlanDocuments.DeleteAsync(DbContext, waterQualityManagementPlanDocumentID);
             if (!deleted) return NotFound();
+
+            await anthropicFileService.DeleteRemoteFileAsync(anthropicFileID, CancellationToken.None);
             return NoContent();
         }
     }

--- a/Neptune.API/Services/AI/AnthropicFileService.cs
+++ b/Neptune.API/Services/AI/AnthropicFileService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -352,21 +353,60 @@ public class AnthropicFileService
     }
 
     /// <summary>
-    /// Clear the cached file_id for a document, e.g., after Anthropic returned a 404
-    /// for a stale id. The next <see cref="EnsureUploadedFileIDAsync"/> call will
-    /// re-upload.
+    /// Best-effort delete of a remote Anthropic upload. Call this whenever a cached
+    /// <c>file_id</c> stops being referenced — the document row is deleted, or its
+    /// PDF is replaced — otherwise the upload is orphaned on the account permanently
+    /// and nothing ever reclaims it (NPT-1121).
+    ///
+    /// Never throws. A leftover remote file is not worth failing (or masking) the
+    /// caller's operation over — same posture as
+    /// <c>GDALAPIService.DeleteStagedBlobs</c>. Callers should invoke this *after*
+    /// the database change commits, so a cleanup failure can't leave the row
+    /// pointing at a file we already deleted.
+    ///
+    /// Do not call this on the stale-id 404 path in <see cref="RefreshFileIDAsync"/>:
+    /// upstream has already reported the file missing, so there is nothing to delete
+    /// and the extra round trip only adds latency to an error path.
     /// </summary>
-    public async Task InvalidateFileIDAsync(
-        int waterQualityManagementPlanDocumentID, CancellationToken cancellationToken)
+    public async Task DeleteRemoteFileAsync(string fileID, CancellationToken cancellationToken)
     {
-        var document = await _dbContext.WaterQualityManagementPlanDocuments
-            .SingleAsync(x => x.WaterQualityManagementPlanDocumentID == waterQualityManagementPlanDocumentID, cancellationToken);
+        if (string.IsNullOrEmpty(fileID))
+        {
+            return;
+        }
 
-        document.AnthropicFileID = null;
-        document.AnthropicFileUploadedDate = null;
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        try
+        {
+            // Raw HttpClient rather than the SDK, matching the upload path — see the
+            // NPT-1044 note in UploadAndCacheAsync.
+            using var client = _httpClientFactory.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{AnthropicFilesUrl}/{fileID}");
+            request.Headers.Add("x-api-key", _configuration.AnthropicApiKey);
+            request.Headers.Add("anthropic-version", "2023-06-01");
+            request.Headers.Add("anthropic-beta", "files-api-2025-04-14");
 
-        _logger.LogWarning("Invalidated Anthropic file cache for documentID={DocumentID}",
-            waterQualityManagementPlanDocumentID);
+            using var response = await client.SendAsync(request, cancellationToken);
+
+            // Already gone upstream is the outcome we wanted, not a failure.
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                _logger.LogInformation("Anthropic file {FileID} was already absent upstream; nothing to delete.", fileID);
+                return;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogWarning("Failed to delete Anthropic file {FileID} (status={Status}): {Body}",
+                    fileID, (int)response.StatusCode, body);
+                return;
+            }
+
+            _logger.LogInformation("Deleted Anthropic file {FileID}.", fileID);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to delete Anthropic file {FileID}", fileID);
+        }
     }
 }

--- a/Neptune.API/Services/AI/AnthropicFileService.cs
+++ b/Neptune.API/Services/AI/AnthropicFileService.cs
@@ -32,6 +32,13 @@ public class AnthropicFileService
 {
     private const string AnthropicFilesUrl = "https://api.anthropic.com/v1/files";
 
+    /// <summary>
+    /// Ceiling on the best-effort cleanup DELETE in <see cref="DeleteRemoteFileAsync"/>.
+    /// Short on purpose: it runs inline on user-facing delete and file-swap requests, and
+    /// abandoning an orphaned file is much cheaper than making someone wait on it.
+    /// </summary>
+    private static readonly TimeSpan DeleteTimeout = TimeSpan.FromSeconds(10);
+
     // Serializes upload attempts per documentID so concurrent callers (extract+chat
     // hitting the same doc, or two users on the same doc) don't both upload the same
     // PDF when the cache is empty. Same gate covers the stale-id refresh path so
@@ -370,7 +377,7 @@ public class AnthropicFileService
     /// </summary>
     public async Task DeleteRemoteFileAsync(string fileID, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrEmpty(fileID))
+        if (string.IsNullOrWhiteSpace(fileID))
         {
             return;
         }
@@ -380,7 +387,16 @@ public class AnthropicFileService
             // Raw HttpClient rather than the SDK, matching the upload path — see the
             // NPT-1044 note in UploadAndCacheAsync.
             using var client = _httpClientFactory.CreateClient();
-            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{AnthropicFilesUrl}/{fileID}");
+            // Callers pass CancellationToken.None so a client disconnect can't strand the
+            // file, which means nothing else bounds this wait. Without an explicit timeout
+            // an unreachable Anthropic would hang every document delete and file swap for
+            // HttpClient's 100s default. Cleanup is best-effort, so give up quickly and
+            // leave the orphan behind rather than making the user wait on it.
+            client.Timeout = DeleteTimeout;
+            // fileID is Anthropic-generated and read back from the database; escape it
+            // rather than trusting that round trip to keep it URL-safe.
+            using var request = new HttpRequestMessage(
+                HttpMethod.Delete, $"{AnthropicFilesUrl}/{Uri.EscapeDataString(fileID)}");
             request.Headers.Add("x-api-key", _configuration.AnthropicApiKey);
             request.Headers.Add("anthropic-version", "2023-06-01");
             request.Headers.Add("anthropic-beta", "files-api-2025-04-14");

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlanDocument.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlanDocument.cs
@@ -6,6 +6,13 @@ namespace Neptune.EFModels.Entities
     {
         public async Task DeleteFull(NeptuneDbContext dbContext)
         {
+            // The AI extraction result points at the document it was extracted from, with a
+            // plain FK (no ON DELETE CASCADE), so the document delete fails outright once an
+            // extraction has run against it. Drop the derived result first — it is a cache of
+            // what the AI read out of this PDF, so it cannot outlive its source document.
+            await dbContext.WaterQualityManagementPlanExtractionResults
+                .Where(x => x.WaterQualityManagementPlanDocumentID == WaterQualityManagementPlanDocumentID)
+                .ExecuteDeleteAsync();
             await dbContext.WaterQualityManagementPlanDocuments
                 .Where(x => x.WaterQualityManagementPlanDocumentID == WaterQualityManagementPlanDocumentID)
                 .ExecuteDeleteAsync();

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlanDocumentExtensionMethods.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlanDocumentExtensionMethods.cs
@@ -22,6 +22,15 @@ public static class WaterQualityManagementPlanDocumentExtensionMethods
     public static void UpdateFromUpsertDto(this WaterQualityManagementPlanDocument entity, WaterQualityManagementPlanDocumentUpsertDto dto)
     {
         entity.WaterQualityManagementPlanID = dto.WaterQualityManagementPlanID;
+        // Swapping the underlying file invalidates the cached Anthropic upload — it was
+        // made from the *old* PDF. Leaving the id set makes AI extraction and chat keep
+        // reading the replaced document, silently and indefinitely (NPT-1121). The caller
+        // is responsible for deleting the now-unreferenced remote file.
+        if (entity.FileResourceID != dto.FileResourceID)
+        {
+            entity.AnthropicFileID = null;
+            entity.AnthropicFileUploadedDate = null;
+        }
         entity.FileResourceID = dto.FileResourceID;
         entity.DisplayName = dto.DisplayName;
         entity.Description = dto.Description;

--- a/Neptune.EFModels/Entities/WaterQualityManagementPlanDocuments.cs
+++ b/Neptune.EFModels/Entities/WaterQualityManagementPlanDocuments.cs
@@ -92,6 +92,11 @@ public static class WaterQualityManagementPlanDocuments
         {
             entity.FileResourceID = newFileResourceID.Value;
             entity.UploadDate = DateTime.UtcNow;
+            // The cached Anthropic upload was made from the file we just replaced; keeping
+            // it would leave extraction and chat reading the old PDF (NPT-1121). The caller
+            // deletes the now-unreferenced remote file after this commits.
+            entity.AnthropicFileID = null;
+            entity.AnthropicFileUploadedDate = null;
         }
         await dbContext.SaveChangesAsync();
         return await GetByIDAsDtoAsync(dbContext, entity.WaterQualityManagementPlanDocumentID);


### PR DESCRIPTION
## What

Nothing in the codebase ever deleted an Anthropic Files API upload. Every document delete and every PDF replacement orphaned one permanently — **58 files / 2.19 GB** on the account as of 2026-08-12, growing monotonically with nothing to reclaim it.

While tracing where the leak actually comes from, the card's stated change turned out to be a no-op, and two further bugs surfaced behind it. This PR fixes the real sources.

## Changes

**`AnthropicFileService`** — replaces the dead `InvalidateFileIDAsync` (zero callers) with `DeleteRemoteFileAsync`: a raw `HttpClient` `DELETE /v1/files/{id}` matching the upload path's headers, best-effort in the same posture as `GDALAPIService.DeleteStagedBlobs`, treating a 404 as the outcome we wanted rather than a failure. Bounded by an explicit 10s timeout.

**Silent correctness bug** — reassigning `FileResourceID` left `AnthropicFileID` cached, so replacing a document's PDF left AI extraction and chat reading the **old** file indefinitely, with no visible symptom. Both `UpdateFromUpsertDto` and `UpdateMetadataAsync` now clear the cached id when the underlying file changes.

**All four call sites** that drop or replace a cached id now reclaim the upload — `UpdateDocument` / `DeleteDocument` on `WaterQualityManagementPlanController`, and `Update` / `Delete` on the admin `WaterQualityManagementPlanDocumentController` — after the DB change commits, alongside the existing `DeleteFileResourceBlob` cleanup.

**Pre-existing bug, fixed here (`46b66bbf1`)** — `WaterQualityManagementPlanExtractionResult` carries a plain FK to `WaterQualityManagementPlanDocument` with no `ON DELETE CASCADE`, but `DeleteFull` only deleted the document row. **Deleting any document that AI extraction had run against failed with a `SqlException` and surfaced as a 500** — true since the extraction feature shipped, not a regression from this branch. Found while manually testing this card's delete path, which is untestable without it. Fixed following the `DeleteFull` pattern used by `FieldVisit` and friends: explicit dependent deletes in FK order, no schema change. That FK is the only one referencing the document table, so the delete is now complete.

## Notes for review

- **`CancellationToken.None` on cleanup, not the request token.** The row is already committed at that point, so honoring a client disconnect would strand the exact file being reclaimed. Because that removes the usual bound on the wait, the delete client sets an explicit 10s timeout — otherwise it would inherit `HttpClient`'s 100s default and hang user-facing requests when Anthropic is unreachable. (Thanks Copilot.)
- **`RefreshFileIDAsync`'s 404 path deliberately does not delete.** Upstream already reported the file missing; the extra round trip would only add latency to an error path. This is why the card's requirement 1 and requirement 3 cancelled each other out — that path is `RefreshFileIDAsync`'s only caller.
- The admin controller's `Update` reads the entity first to detect a `FileResourceID` change. It uses `GetByID`, which is `AsNoTracking`, so there's no change-tracker pollution before `UpdateAsync` tracks its own copy.
- No schema change, so no release script. No API surface change, so no codegen.

## Out of scope

The one-off sweep of the existing 58-file backlog (card requirement 4) is **not** included. Local, QA and prod share one Anthropic API key, so a sweep driven from any single environment's database would delete files the other environments are actively referencing. That needs per-environment keys settled first; it stays tracked on NPT-1121.

## Testing

- `dotnet build` clean across Neptune.API, Neptune.ExternalAPI, Neptune.Jobs, Neptune.Tests.
- `dotnet test` — **429 passed / 2 failed**, matching the documented local baseline exactly; both failures are known local-data-state issues unrelated to this change.
- **Manually verified end to end** against a local WQMP with a cached `file_id`: replaced the document's PDF → cached id cleared, remote file deleted; re-ran extraction → fresh upload, results reflected the new PDF; deleted the document → extraction result cascaded and the remote file was reclaimed.
